### PR TITLE
fix: real hardware tests with rust

### DIFF
--- a/apps/web/src-tauri/Cargo.lock
+++ b/apps/web/src-tauri/Cargo.lock
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "microflow"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "criterion",
  "firmata-rs",

--- a/apps/web/src-tauri/src/runtime/input/button.rs
+++ b/apps/web/src-tauri/src/runtime/input/button.rs
@@ -43,6 +43,8 @@ pub struct Button {
     hold_emitted: bool,
     polling_active: Arc<AtomicBool>,
     poll_handle: Option<tokio::task::JoinHandle<()>>,
+    /// Timestamp of the last state change, used for debouncing
+    last_change: Option<Instant>,
 }
 
 impl Button {
@@ -52,11 +54,21 @@ impl Button {
             base: ComponentBase::new(id, ComponentValue::Bool(false)),
             config, board: None, is_pressed: false, press_start: None,
             hold_emitted: false, polling_active: Arc::new(AtomicBool::new(false)), poll_handle: None,
+            last_change: None,
         }
     }
 
     fn process_state(&mut self, pressed: bool) {
         if pressed != self.is_pressed {
+            // Debounce: ignore state changes that arrive within XXXms of the last one.
+            // Most mechanical switches settle within 5ms;
+            // keeping latency imperceptible for real-time flows.
+            if let Some(last) = self.last_change {
+                if last.elapsed() < Duration::from_millis(20) {
+                    return;
+                }
+            }
+            self.last_change = Some(Instant::now());
             self.is_pressed = pressed;
             self.base.set_value(ComponentValue::Bool(pressed));
             if pressed {

--- a/apps/web/src-tauri/src/runtime/input/mod.rs
+++ b/apps/web/src-tauri/src/runtime/input/mod.rs
@@ -6,8 +6,10 @@ mod button;
 mod motion;
 mod proximity;
 mod sensor;
+mod switch;
 
 pub use button::{Button, ButtonConfig};
 pub use motion::{Motion, MotionConfig};
 pub use proximity::{Proximity, ProximityConfig};
 pub use sensor::{Sensor, SensorConfig};
+pub use switch::{Switch, SwitchConfig};

--- a/apps/web/src-tauri/src/runtime/input/switch.rs
+++ b/apps/web/src-tauri/src/runtime/input/switch.rs
@@ -2,7 +2,7 @@
 //!
 //! A latching on/off toggle switch (as opposed to a momentary Button).
 //! Supports Normally-Open (NO) and Normally-Closed (NC) wiring.
-//! Reference: https://johnny-five.io/examples/switch/
+//! Reference: <https://johnny-five.io/examples/switch/>
 
 use crate::runtime::base::{
     pin_mode, serde_utils, BoardCommand, BoardHandle, Component, ComponentBase, ComponentEvent,
@@ -13,18 +13,13 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub enum SwitchType {
     /// Normally Open — circuit is open when not actuated
+    #[default]
     NO,
     /// Normally Closed — circuit is closed when not actuated
     NC,
-}
-
-impl Default for SwitchType {
-    fn default() -> Self {
-        SwitchType::NO
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/apps/web/src-tauri/src/runtime/input/switch.rs
+++ b/apps/web/src-tauri/src/runtime/input/switch.rs
@@ -1,0 +1,148 @@
+//! Switch Component - Input
+//!
+//! A latching on/off toggle switch (as opposed to a momentary Button).
+//! Supports Normally-Open (NO) and Normally-Closed (NC) wiring.
+//! Reference: https://johnny-five.io/examples/switch/
+
+use crate::runtime::base::{
+    pin_mode, serde_utils, BoardCommand, BoardHandle, Component, ComponentBase, ComponentEvent,
+    ComponentValue,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum SwitchType {
+    /// Normally Open — circuit is open when not actuated
+    NO,
+    /// Normally Closed — circuit is closed when not actuated
+    NC,
+}
+
+impl Default for SwitchType {
+    fn default() -> Self {
+        SwitchType::NO
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SwitchConfig {
+    #[serde(default = "default_pin", deserialize_with = "serde_utils::deserialize_pin_u8")]
+    pub pin: u8,
+    #[serde(default, rename = "type")]
+    pub switch_type: SwitchType,
+}
+
+fn default_pin() -> u8 { 2 }
+
+impl Default for SwitchConfig {
+    fn default() -> Self {
+        Self { pin: default_pin(), switch_type: SwitchType::default() }
+    }
+}
+
+pub struct Switch {
+    base: ComponentBase,
+    config: SwitchConfig,
+    board: Option<Arc<BoardHandle>>,
+    is_closed: bool,
+    /// Timestamp of the last state change, used for debouncing
+    last_change: Option<Instant>,
+}
+
+impl Switch {
+    #[must_use]
+    pub fn new(id: String, config: SwitchConfig) -> Self {
+        Self {
+            base: ComponentBase::new(id, ComponentValue::Bool(false)),
+            config,
+            board: None,
+            is_closed: false,
+            last_change: None,
+        }
+    }
+
+    /// Translate raw pin reading to logical closed/open based on wiring type.
+    /// - NO (normally open): pin HIGH (pulled up) = open, pin LOW = closed
+    /// - NC (normally closed): pin HIGH (pulled up) = closed, pin LOW = open
+    fn is_logically_closed(&self, pin_high: bool) -> bool {
+        match self.config.switch_type {
+            SwitchType::NO => !pin_high,
+            SwitchType::NC => pin_high,
+        }
+    }
+
+    fn process_state(&mut self, pin_high: bool) {
+        let closed = self.is_logically_closed(pin_high);
+        log::info!("Switch {} process_state: pin_high={}, closed={}, was_closed={}, type={:?}",
+            self.base.id, pin_high, closed, self.is_closed, self.config.switch_type);
+
+        if closed != self.is_closed {
+            // Debounce: ignore changes within 20ms of the last one
+            if let Some(last) = self.last_change {
+                if last.elapsed() < Duration::from_millis(20) {
+                    return;
+                }
+            }
+            self.last_change = Some(Instant::now());
+            self.is_closed = closed;
+            self.base.set_value(ComponentValue::Bool(closed));
+
+            // Emit on every state change
+            self.base.emit("event");
+
+            if closed {
+                self.base.emit("true");
+            } else {
+                self.base.emit("false");
+            }
+        }
+    }
+}
+
+impl Component for Switch {
+    fn id(&self) -> &str { &self.base.id }
+    fn value(&self) -> ComponentValue { self.base.value.clone() }
+    fn set_value(&mut self, value: ComponentValue) { self.base.value = value; }
+    fn component_type(&self) -> &'static str { "Switch" }
+    fn requires_hardware(&self) -> bool { true }
+
+    fn initialize(&mut self, board: Arc<BoardHandle>) -> Result<(), String> {
+        log::info!("Switch {} initialize: pin={}, type={:?}", self.base.id, self.config.pin, self.config.switch_type);
+        // With external 5V wiring (GND-SIG-5V), use plain INPUT mode
+        board.send_command(BoardCommand::SetPinMode { pin: self.config.pin, mode: pin_mode::INPUT })?;
+        board.send_command(BoardCommand::EnableDigitalReporting { pin: self.config.pin })?;
+        self.board = Some(board);
+        Ok(())
+    }
+
+    fn call_method(&mut self, method: &str, args: ComponentValue) -> Result<(), String> {
+        match method {
+            "read" => Ok(()),
+            "pin_change" => {
+                log::info!("Switch {} pin_change called with args: {:?}", self.base.id, args);
+                if let Some(pin_high) = args.as_bool() {
+                    self.process_state(pin_high);
+                } else {
+                    log::warn!("Switch {} pin_change: could not extract bool from {:?}", self.base.id, args);
+                }
+                Ok(())
+            }
+            _ => Err(format!("Unknown method: {method}")),
+        }
+    }
+
+    fn destroy(&mut self) {
+        if let Some(board) = &self.board {
+            log::info!("Switch {} destroy: disabling digital reporting for pin {}", self.base.id, self.config.pin);
+            let _ = board.send_command(BoardCommand::DisableDigitalReporting { pin: self.config.pin });
+        }
+        self.board = None;
+    }
+
+    fn event_sender(&self) -> Option<mpsc::UnboundedSender<ComponentEvent>> { self.base.event_sender.clone() }
+    fn set_event_sender(&mut self, sender: mpsc::UnboundedSender<ComponentEvent>) { self.base.event_sender = Some(sender); }
+}

--- a/apps/web/src-tauri/src/runtime/mod.rs
+++ b/apps/web/src-tauri/src/runtime/mod.rs
@@ -289,7 +289,7 @@ impl FlowRuntime {
     /// Register pin listener for an input component based on its type and config
     fn register_component_pin_listener(&self, component_id: &str, instance: &str, data: &serde_json::Value) {
         match instance {
-            "Button" | "Motion" => {
+            "Button" | "Motion" | "Switch" => {
                 // Digital input components - handle both string and number pin formats
                 let pin: Option<u8> = if let Some(pin_num) = data.get("pin").and_then(serde_json::Value::as_u64) {
                     Some(pin_num as u8)

--- a/apps/web/src-tauri/src/runtime/registry.rs
+++ b/apps/web/src-tauri/src/runtime/registry.rs
@@ -7,7 +7,7 @@ use super::base::{BoardHandle, Component, ComponentEvent};
 use super::control::{Counter, CounterConfig, Delay, DelayConfig, Trigger, TriggerConfig};
 use super::external::{Figma, FigmaConfig, Llm, LlmConfig, Mqtt, MqttConfig};
 use super::generator::{Constant, ConstantConfig, Interval, IntervalConfig, Oscillator, OscillatorConfig};
-use super::input::{Button, ButtonConfig, Motion, MotionConfig, Proximity, ProximityConfig, Sensor, SensorConfig};
+use super::input::{Button, ButtonConfig, Motion, MotionConfig, Proximity, ProximityConfig, Sensor, SensorConfig, Switch, SwitchConfig};
 use super::output::{Led, LedConfig, Monitor, MonitorConfig, Piezo, PiezoConfig, Relay, RelayConfig, Rgb, RgbConfig, Servo, ServoConfig};
 use super::transformation::{Calculate, CalculateConfig, Compare, CompareConfig, Gate, GateConfig, RangeMap, RangeMapConfig, Smooth, SmoothConfig};
 use std::sync::Arc;
@@ -124,6 +124,10 @@ impl ComponentRegistry {
         self.register_hardware("Proximity", |id, data| {
             let config: ProximityConfig = serde_json::from_value(data.clone()).unwrap_or_default();
             Box::new(Proximity::new(id, config))
+        });
+        self.register_hardware("Switch", |id, data| {
+            let config: SwitchConfig = serde_json::from_value(data.clone()).unwrap_or_default();
+            Box::new(Switch::new(id, config))
         });
 
         // Control components (software only)


### PR DESCRIPTION
This pull request adds support for a new `Switch` input component to the runtime, representing a latching on/off toggle switch (as opposed to a momentary button). It also introduces debouncing logic to both the new `Switch` and the existing `Button` components to improve input reliability. The changes ensure that the new component is fully integrated into the runtime's registration and pin-listener logic.

**New Input Component: Switch**

* Added a new `Switch` component (`switch.rs`) supporting both Normally-Open (NO) and Normally-Closed (NC) wiring, with configuration, state processing, and event emission. Includes debouncing logic to ignore rapid state changes.
* Registered the `Switch` component in the component registry to enable its use in flows and hardware initialization.
* Updated the pin listener logic to recognize and handle the `Switch` component alongside existing digital input types.

**Debouncing Improvements**

* Added a `last_change` timestamp and 20ms debounce logic to the `Button` component to prevent false triggering from switch bounce. [[1]](diffhunk://#diff-b0c6e41e0350977eb2aee32a59263e0720240f2a8b83e39508968148bfdbe219R46-R47) [[2]](diffhunk://#diff-b0c6e41e0350977eb2aee32a59263e0720240f2a8b83e39508968148bfdbe219R57-R71)

**Module and Import Updates**

* Exposed the new `Switch` and `SwitchConfig` types in the input module and updated imports throughout the codebase to support the new component. [[1]](diffhunk://#diff-fd66d019e07a108a9abb150e55c26494495bf3d150804148d530eee8522998f6R9-R15) [[2]](diffhunk://#diff-54a8ad7cafcdb62ce86f4b6bb4855c9f7258cada15e98faa2e4c474fdacdb0c7L10-R10)