### PR TITLE
fix: rangemap and servo

### DIFF
--- a/apps/web/src-tauri/src/runtime/output/servo.rs
+++ b/apps/web/src-tauri/src/runtime/output/servo.rs
@@ -106,7 +106,10 @@ impl Component for Servo {
         match method {
             "min" => self.min(),
             "max" => self.max(),
-            "value" => self.to(args.as_number().unwrap_or(90.0)),
+            "value" => match self.config.r#type {
+                ServoType::Standard => self.to(args.as_number().unwrap_or(90.0)),
+                ServoType::Continuous => self.rotate(args.as_number().unwrap_or(0.0)),
+            },
             "rotate" => self.rotate(args.as_number().unwrap_or(0.0)),
             "stop" => self.stop(),
             _ => Err(format!("Unknown method: {method}")),

--- a/apps/web/src/components/flow/nodes/range-map/range-map.tsx
+++ b/apps/web/src/components/flow/nodes/range-map/range-map.tsx
@@ -14,7 +14,7 @@ export function RangeMap(props: Props) {
       <Value />
       <Settings />
       <Handle type="target" position="left" id="value" handleType="value" />
-      <Handle type="source" position="right" id="value" handleType="value" />
+      <Handle type="source" position="right" id="to" handleType="value" />
     </NodeContainer>
   );
 }

--- a/apps/web/src/lib/templates/index.ts
+++ b/apps/web/src/lib/templates/index.ts
@@ -157,7 +157,7 @@ const knobServo: Template = {
   ],
   edges: [
     { id: "e1", source: "pot-1", target: "rangemap-1", sourceHandle: "value", targetHandle: "value" },
-    { id: "e2", source: "rangemap-1", target: "servo-1", sourceHandle: "value", targetHandle: "value" },
+    { id: "e2", source: "rangemap-1", target: "servo-1", sourceHandle: "to", targetHandle: "value" },
   ],
 };
 
@@ -191,7 +191,7 @@ const servoSweep: Template = {
   ],
   edges: [
     { id: "e1", source: "oscillator-1", target: "rangemap-1", sourceHandle: "value", targetHandle: "value" },
-    { id: "e2", source: "rangemap-1", target: "servo-1", sourceHandle: "value", targetHandle: "value" },
+    { id: "e2", source: "rangemap-1", target: "servo-1", sourceHandle: "to", targetHandle: "value" },
   ],
 };
 


### PR DESCRIPTION
This pull request updates how the output of the `RangeMap` node is handled and improves support for different servo types in the backend. The main changes ensure that the output handle from `RangeMap` is consistently named `to`, and that the servo logic distinguishes between standard and continuous servos when processing the `value` method.

**Frontend consistency and template updates:**

* Changed the output handle of the `RangeMap` node from `value` to `to` for clarity and consistency in the flow editor (`range-map.tsx`).
* Updated template edge definitions in `index.ts` so that connections from `RangeMap` nodes use the new `to` handle instead of `value` (`knobServo`, `servoSweep`). [[1]](diffhunk://#diff-75edacef8e28161f9bbf2972f727391772c5b6fbbff6294182debfb24ebfcd06L160-R160) [[2]](diffhunk://#diff-75edacef8e28161f9bbf2972f727391772c5b6fbbff6294182debfb24ebfcd06L194-R194)

**Backend servo logic improvement:**

* Modified the `Servo` component to differentiate between `Standard` and `Continuous` servo types when handling the `value` method: standard servos use `to`, while continuous servos use `rotate`.