### PR TITLE
feat: martix display

### DIFF
--- a/apps/web/src-tauri/src/runtime/base.rs
+++ b/apps/web/src-tauri/src/runtime/base.rs
@@ -421,7 +421,7 @@ pub enum BoardCommand {
     ClearPinCache,
     /// Register a pin as active so `detect_and_emit_changes` checks it.
     RegisterActivePin { pin: u8 },
-    /// Shift out a byte MSB-first on data_pin, clocking clock_pin.
+    /// Shift out a byte MSB-first on `data_pin`, clocking `clock_pin`.
     /// Equivalent to Arduino's shiftOut(dataPin, clockPin, MSBFIRST, value).
     /// Performed atomically on the reader thread for correct timing.
     ShiftOut { data_pin: u8, clock_pin: u8, value: u8 },
@@ -485,7 +485,7 @@ impl BoardConnection {
             .map_err(|e| format!("Failed to analog write: {e}"))
     }
 
-    /// Shift out a byte MSB-first, toggling data_pin and clock_pin.
+    /// Shift out a byte MSB-first, toggling `data_pin` and `clock_pin`.
     /// This performs all the digital writes atomically on the reader thread,
     /// matching Arduino's shiftOut(dataPin, clockPin, MSBFIRST, value).
     pub fn shift_out(&mut self, data_pin: u8, clock_pin: u8, value: u8) -> Result<(), String> {

--- a/apps/web/src-tauri/src/runtime/base.rs
+++ b/apps/web/src-tauri/src/runtime/base.rs
@@ -279,6 +279,9 @@ impl BoardHandle {
                         Ok(BoardCommand::RegisterActivePin { pin }) => {
                             conn.active_pins.insert(pin);
                         }
+                        Ok(BoardCommand::ShiftOut { data_pin, clock_pin, value }) => {
+                            let _ = conn.shift_out(data_pin, clock_pin, value);
+                        }
                         Err(std::sync::mpsc::TryRecvError::Empty) => break,
                         Err(std::sync::mpsc::TryRecvError::Disconnected) => {
                             log::info!("Firmata reader: command channel closed, stopping");
@@ -418,6 +421,10 @@ pub enum BoardCommand {
     ClearPinCache,
     /// Register a pin as active so `detect_and_emit_changes` checks it.
     RegisterActivePin { pin: u8 },
+    /// Shift out a byte MSB-first on data_pin, clocking clock_pin.
+    /// Equivalent to Arduino's shiftOut(dataPin, clockPin, MSBFIRST, value).
+    /// Performed atomically on the reader thread for correct timing.
+    ShiftOut { data_pin: u8, clock_pin: u8, value: u8 },
     Stop,
 }
 
@@ -476,6 +483,26 @@ impl BoardConnection {
         self.board
             .analog_write(i32::from(pin), i32::from(value))
             .map_err(|e| format!("Failed to analog write: {e}"))
+    }
+
+    /// Shift out a byte MSB-first, toggling data_pin and clock_pin.
+    /// This performs all the digital writes atomically on the reader thread,
+    /// matching Arduino's shiftOut(dataPin, clockPin, MSBFIRST, value).
+    pub fn shift_out(&mut self, data_pin: u8, clock_pin: u8, value: u8) -> Result<(), String> {
+        for i in 0..8 {
+            // Match J5 board.shiftOut exactly: CLK low → set data → CLK high
+            self.board
+                .digital_write(i32::from(clock_pin), 0)
+                .map_err(|e| format!("Failed to clock low: {e}"))?;
+            let bit = i32::from((value >> (7 - i)) & 1);
+            self.board
+                .digital_write(i32::from(data_pin), bit)
+                .map_err(|e| format!("Failed to shift data: {e}"))?;
+            self.board
+                .digital_write(i32::from(clock_pin), 1)
+                .map_err(|e| format!("Failed to clock high: {e}"))?;
+        }
+        Ok(())
     }
 
     pub fn digital_read(&mut self, pin: u8) -> Result<bool, String> {

--- a/apps/web/src-tauri/src/runtime/output/matrix.rs
+++ b/apps/web/src-tauri/src/runtime/output/matrix.rs
@@ -1,8 +1,8 @@
 //! LED Matrix Component - Output (MAX7219)
 //!
 //! Drives a MAX7219-based LED matrix via bit-banged SPI.
-//! Uses ShiftOut board command for atomic byte transfers matching
-//! Johnny-Five's LedControl.send() approach.
+//! Uses `ShiftOut` board command for atomic byte transfers matching
+//! Johnny-Five's `LedControl.send()` approach.
 
 use crate::runtime::base::{
     pin_mode, serde_utils, BoardCommand, BoardHandle, Component, ComponentBase, ComponentEvent,
@@ -78,7 +78,7 @@ impl Matrix {
     }
 
     /// Send a register+data command to a specific device in the chain.
-    /// Mirrors Johnny-Five's LedControl.send() approach:
+    /// Mirrors Johnny-Five's `LedControl.send()` approach:
     /// - Build a buffer of (devices * 2) bytes, all zeros (NOOPs)
     /// - Place opcode and data for the target device
     /// - Pull CS low, shift out all bytes in reverse order, pull CS high

--- a/apps/web/src-tauri/src/runtime/output/matrix.rs
+++ b/apps/web/src-tauri/src/runtime/output/matrix.rs
@@ -1,7 +1,8 @@
 //! LED Matrix Component - Output (MAX7219)
 //!
-//! Drives a MAX7219-based LED matrix via bit-banged SPI using digital writes.
-//! Receives a shape index number and displays the corresponding pattern.
+//! Drives a MAX7219-based LED matrix via bit-banged SPI.
+//! Uses ShiftOut board command for atomic byte transfers matching
+//! Johnny-Five's LedControl.send() approach.
 
 use crate::runtime::base::{
     pin_mode, serde_utils, BoardCommand, BoardHandle, Component, ComponentBase, ComponentEvent,
@@ -12,7 +13,6 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 
 // MAX7219 registers
-const REG_NOOP: u8 = 0x00;
 const REG_DECODE_MODE: u8 = 0x09;
 const REG_INTENSITY: u8 = 0x0A;
 const REG_SCAN_LIMIT: u8 = 0x0B;
@@ -64,6 +64,11 @@ pub struct Matrix {
 impl Matrix {
     #[must_use]
     pub fn new(id: String, config: MatrixConfig) -> Self {
+        log::info!(
+            "Matrix::new id={id} pins=(data={}, clock={}, cs={}) devices={} shapes={}",
+            config.pins.data, config.pins.clock, config.pins.cs,
+            config.devices, config.shapes.len()
+        );
         Self {
             base: ComponentBase::new(id, ComponentValue::Number(0.0)),
             config,
@@ -72,95 +77,105 @@ impl Matrix {
         }
     }
 
-    /// Bit-bang a single byte out the data pin, MSB first.
-    fn shift_out(&self, board: &Arc<BoardHandle>, byte: u8) -> Result<(), String> {
-        for i in (0..8).rev() {
-            let bit = (byte >> i) & 1 == 1;
-            board.send_command(BoardCommand::DigitalWrite { pin: self.config.pins.data, value: bit })?;
-            board.send_command(BoardCommand::DigitalWrite { pin: self.config.pins.clock, value: true })?;
-            board.send_command(BoardCommand::DigitalWrite { pin: self.config.pins.clock, value: false })?;
-        }
-        Ok(())
-    }
+    /// Send a register+data command to a specific device in the chain.
+    /// Mirrors Johnny-Five's LedControl.send() approach:
+    /// - Build a buffer of (devices * 2) bytes, all zeros (NOOPs)
+    /// - Place opcode and data for the target device
+    /// - Pull CS low, shift out all bytes in reverse order, pull CS high
+    fn send(&self, board: &Arc<BoardHandle>, addr: u8, opcode: u8, data: u8) -> Result<(), String> {
+        let offset = (addr as usize) * 2;
+        let max_bytes = (self.config.devices as usize) * 2;
+        let mut spi_data = vec![0u8; max_bytes];
 
-    /// Send a register+data pair to all chained devices.
-    fn send_command_to_all(&self, board: &Arc<BoardHandle>, register: u8, data: u8) -> Result<(), String> {
-        board.send_command(BoardCommand::DigitalWrite { pin: self.config.pins.cs, value: false })?;
-        for _ in 0..self.config.devices {
-            self.shift_out(board, register)?;
-            self.shift_out(board, data)?;
-        }
-        board.send_command(BoardCommand::DigitalWrite { pin: self.config.pins.cs, value: true })?;
-        Ok(())
-    }
+        if (addr as usize) < self.config.devices as usize {
+            spi_data[offset + 1] = opcode;
+            spi_data[offset] = data;
 
-    /// Send a register+data pair to a specific device in the chain.
-    fn send_to_device(&self, board: &Arc<BoardHandle>, device: u8, register: u8, data: u8) -> Result<(), String> {
-        board.send_command(BoardCommand::DigitalWrite { pin: self.config.pins.cs, value: false })?;
-        // Devices are daisy-chained: last shifted data goes to first device.
-        // Send NOOPs to devices after the target, then the real command, then NOOPs before.
-        for d in (0..self.config.devices).rev() {
-            if d == device {
-                self.shift_out(board, register)?;
-                self.shift_out(board, data)?;
-            } else {
-                self.shift_out(board, REG_NOOP)?;
-                self.shift_out(board, 0)?;
+            board.send_command(BoardCommand::DigitalWrite {
+                pin: self.config.pins.cs,
+                value: false,
+            })?;
+
+            for j in (0..max_bytes).rev() {
+                board.send_command(BoardCommand::ShiftOut {
+                    data_pin: self.config.pins.data,
+                    clock_pin: self.config.pins.clock,
+                    value: spi_data[j],
+                })?;
             }
+
+            board.send_command(BoardCommand::DigitalWrite {
+                pin: self.config.pins.cs,
+                value: true,
+            })?;
         }
-        board.send_command(BoardCommand::DigitalWrite { pin: self.config.pins.cs, value: true })?;
+        Ok(())
+    }
+
+    /// Send a command to all devices.
+    fn send_to_all(&self, board: &Arc<BoardHandle>, opcode: u8, data: u8) -> Result<(), String> {
+        for device in 0..self.config.devices {
+            self.send(board, device, opcode, data)?;
+        }
         Ok(())
     }
 
     /// Initialize the MAX7219 chip(s).
     fn init_max7219(&self, board: &Arc<BoardHandle>) -> Result<(), String> {
-        self.send_command_to_all(board, REG_DISPLAY_TEST, 0)?;
-        self.send_command_to_all(board, REG_SCAN_LIMIT, 7)?;
-        self.send_command_to_all(board, REG_DECODE_MODE, 0)?;
-        self.send_command_to_all(board, REG_INTENSITY, 4)?;
-        self.send_command_to_all(board, REG_SHUTDOWN, 1)?;
-        // Clear all rows
-        for row in 1..=8 {
-            self.send_command_to_all(board, row, 0)?;
+        log::info!("Matrix {}: initializing MAX7219 (pins: data={}, clock={}, cs={})",
+            self.base.id, self.config.pins.data, self.config.pins.clock, self.config.pins.cs);
+        for device in 0..self.config.devices {
+            // Match J5 LedControl init order exactly — wrong order causes all LEDs to stay lit
+            self.send(board, device, REG_DECODE_MODE, 0)?;
+            self.send(board, device, REG_INTENSITY, 3)?;
+            self.send(board, device, REG_SCAN_LIMIT, 7)?;
+            self.send(board, device, REG_SHUTDOWN, 1)?;
+            self.send(board, device, REG_DISPLAY_TEST, 0)?;
+            for row in 1..=8 {
+                self.send(board, device, row, 0)?;
+            }
+            // J5 calls on() after clear, re-asserting normal operation
+            self.send(board, device, REG_SHUTDOWN, 1)?;
         }
+        log::info!("Matrix {}: MAX7219 initialized", self.base.id);
         Ok(())
     }
 
-    /// Display a shape (array of binary strings) on the matrix.
+    /// Display a shape on the matrix.
     fn display_shape(&self, board: &Arc<BoardHandle>, shape: &[String]) -> Result<(), String> {
-        let cols_per_device = 8u8;
         for device in 0..self.config.devices {
             for row in 0..8u8 {
                 let row_idx = row as usize;
                 let byte = if row_idx < shape.len() {
                     let row_str = &shape[row_idx];
-                    let start = (device as usize) * (cols_per_device as usize);
-                    let end = start + (cols_per_device as usize);
-                    // Parse the relevant 8-bit slice of this row
+                    let start = (device as usize) * 8;
+                    let end = start + 8;
                     if start < row_str.len() {
                         let slice_end = end.min(row_str.len());
-                        let slice = &row_str[start..slice_end];
-                        u8::from_str_radix(slice, 2).unwrap_or(0)
+                        u8::from_str_radix(&row_str[start..slice_end], 2).unwrap_or(0)
                     } else {
                         0
                     }
                 } else {
                     0
                 };
-                // MAX7219 rows are registers 1-8
-                self.send_to_device(board, device, row + 1, byte)?;
+                log::debug!("Matrix {}: row {} device {} = 0x{:02X} (0b{:08b})",
+                    self.base.id, row, device, byte, byte);
+                self.send(board, device, row + 1, byte)?;
             }
         }
         Ok(())
     }
 
-    /// Set shape by index, clamping to available shapes.
     fn set_shape(&mut self, index: usize) -> Result<(), String> {
         if self.config.shapes.is_empty() {
+            log::warn!("Matrix {}: no shapes configured", self.base.id);
             return Ok(());
         }
         let clamped = index.min(self.config.shapes.len() - 1);
         self.current_shape_index = clamped;
+        log::info!("Matrix {}: set_shape index={index} clamped={clamped} board={}",
+            self.base.id, self.board.is_some());
 
         if let Some(board) = &self.board {
             let board = Arc::clone(board);
@@ -168,7 +183,6 @@ impl Matrix {
             self.display_shape(&board, &shape)?;
         }
 
-        // Emit the current shape as the value (array of strings)
         let shape = &self.config.shapes[clamped];
         let val = ComponentValue::Array(
             shape.iter().map(|s| ComponentValue::String(s.clone())).collect()
@@ -177,11 +191,10 @@ impl Matrix {
         Ok(())
     }
 
-    /// Clear the display.
     fn clear(&mut self) -> Result<(), String> {
         if let Some(board) = &self.board {
             for row in 1..=8 {
-                self.send_command_to_all(board, row, 0)?;
+                self.send_to_all(board, row, 0)?;
             }
         }
         self.base.set_value(ComponentValue::Number(0.0));
@@ -197,19 +210,36 @@ impl Component for Matrix {
     fn requires_hardware(&self) -> bool { true }
 
     fn initialize(&mut self, board: Arc<BoardHandle>) -> Result<(), String> {
-        board.send_command(BoardCommand::SetPinMode { pin: self.config.pins.data, mode: pin_mode::OUTPUT })?;
-        board.send_command(BoardCommand::SetPinMode { pin: self.config.pins.clock, mode: pin_mode::OUTPUT })?;
-        board.send_command(BoardCommand::SetPinMode { pin: self.config.pins.cs, mode: pin_mode::OUTPUT })?;
+        log::info!(
+            "Matrix {}: initialize called, board connected={}",
+            self.base.id, board.is_connected()
+        );
+        board.send_command(BoardCommand::SetPinMode {
+            pin: self.config.pins.data, mode: pin_mode::OUTPUT,
+        })?;
+        board.send_command(BoardCommand::SetPinMode {
+            pin: self.config.pins.clock, mode: pin_mode::OUTPUT,
+        })?;
+        board.send_command(BoardCommand::SetPinMode {
+            pin: self.config.pins.cs, mode: pin_mode::OUTPUT,
+        })?;
+        // MAX7219 LOAD idles HIGH — set before first transaction
+        board.send_command(BoardCommand::DigitalWrite {
+            pin: self.config.pins.cs,
+            value: true,
+        })?;
         self.board = Some(Arc::clone(&board));
         self.init_max7219(&board)?;
-        // Display first shape if available
         if !self.config.shapes.is_empty() {
+            log::info!("Matrix {}: displaying initial shape", self.base.id);
             self.set_shape(0)?;
         }
         Ok(())
     }
 
     fn call_method(&mut self, method: &str, args: ComponentValue) -> Result<(), String> {
+        log::info!("Matrix {}: call_method '{}' board={}",
+            self.base.id, method, self.board.is_some());
         match method {
             "value" => {
                 let index = args.as_number().unwrap_or(0.0).round() as usize;
@@ -224,14 +254,18 @@ impl Component for Matrix {
     }
 
     fn destroy(&mut self) {
+        log::info!("Matrix {}: destroy", self.base.id);
         let _ = self.clear();
-        // Shutdown the MAX7219
         if let Some(board) = &self.board {
-            let _ = self.send_command_to_all(board, REG_SHUTDOWN, 0);
+            let _ = self.send_to_all(board, REG_SHUTDOWN, 0);
         }
         self.board = None;
     }
 
-    fn event_sender(&self) -> Option<mpsc::UnboundedSender<ComponentEvent>> { self.base.event_sender.clone() }
-    fn set_event_sender(&mut self, sender: mpsc::UnboundedSender<ComponentEvent>) { self.base.event_sender = Some(sender); }
+    fn event_sender(&self) -> Option<mpsc::UnboundedSender<ComponentEvent>> {
+        self.base.event_sender.clone()
+    }
+    fn set_event_sender(&mut self, sender: mpsc::UnboundedSender<ComponentEvent>) {
+        self.base.event_sender = Some(sender);
+    }
 }


### PR DESCRIPTION
This pull request significantly refactors the MAX7219-based LED matrix output component to use a new atomic `ShiftOut` board command for SPI communication, closely matching the Johnny-Five LedControl behavior. The changes improve the reliability and timing of byte transfers to the LED matrix and simplify the code for sending commands to devices. Additional logging has been added for easier debugging and traceability.

Key changes include:

### Board communication enhancements

* Added a new `BoardCommand::ShiftOut` command and its handler, enabling atomic MSB-first byte transfers on specified data and clock pins, performed on the reader thread for correct timing. (`apps/web/src-tauri/src/runtime/base.rs`) [[1]](diffhunk://#diff-3487ab5b81c000e350db0de770cca966fea6f4d0573a4f6628079e14ba151093R282-R284) [[2]](diffhunk://#diff-3487ab5b81c000e350db0de770cca966fea6f4d0573a4f6628079e14ba151093R424-R427) [[3]](diffhunk://#diff-3487ab5b81c000e350db0de770cca966fea6f4d0573a4f6628079e14ba151093R488-R507)

### LED Matrix (MAX7219) refactor

* Refactored the `Matrix` component to use the new `ShiftOut` command for SPI communication, replacing manual bit-banging with atomic byte transfers. The `send`, `send_to_all`, and related methods now mirror Johnny-Five's LedControl logic, ensuring correct operation with daisy-chained devices. (`apps/web/src-tauri/src/runtime/output/matrix.rs`) [[1]](diffhunk://#diff-8857710e2fe59859f2f49a3ff6cc66d416824e40cf8292e4c44d97d8b91d5ad1L3-R5) [[2]](diffhunk://#diff-8857710e2fe59859f2f49a3ff6cc66d416824e40cf8292e4c44d97d8b91d5ad1L75-L171) [[3]](diffhunk://#diff-8857710e2fe59859f2f49a3ff6cc66d416824e40cf8292e4c44d97d8b91d5ad1L180-R197)
* Simplified and clarified initialization, display, and shutdown procedures for the matrix, including correct order of MAX7219 register setup and improved clearing/shutdown logic. (`apps/web/src-tauri/src/runtime/output/matrix.rs`) [[1]](diffhunk://#diff-8857710e2fe59859f2f49a3ff6cc66d416824e40cf8292e4c44d97d8b91d5ad1L75-L171) [[2]](diffhunk://#diff-8857710e2fe59859f2f49a3ff6cc66d416824e40cf8292e4c44d97d8b91d5ad1L180-R197) [[3]](diffhunk://#diff-8857710e2fe59859f2f49a3ff6cc66d416824e40cf8292e4c44d97d8b91d5ad1R257-R270)

### Logging and diagnostics

* Added detailed logging throughout the `Matrix` component lifecycle, including initialization, shape setting, display updates, and destruction, to aid in debugging and monitoring hardware interactions. (`apps/web/src-tauri/src/runtime/output/matrix.rs`) [[1]](diffhunk://#diff-8857710e2fe59859f2f49a3ff6cc66d416824e40cf8292e4c44d97d8b91d5ad1R67-R71) [[2]](diffhunk://#diff-8857710e2fe59859f2f49a3ff6cc66d416824e40cf8292e4c44d97d8b91d5ad1L75-L171) [[3]](diffhunk://#diff-8857710e2fe59859f2f49a3ff6cc66d416824e40cf8292e4c44d97d8b91d5ad1L200-R242) [[4]](diffhunk://#diff-8857710e2fe59859f2f49a3ff6cc66d416824e40cf8292e4c44d97d8b91d5ad1R257-R270)

These changes improve the reliability, maintainability, and observability of the LED matrix output functionality.