### PR TITLE
feat(RGB): added support for RBG LEDs

### DIFF
--- a/apps/web/src-tauri/src/runtime/executor.rs
+++ b/apps/web/src-tauri/src/runtime/executor.rs
@@ -199,6 +199,14 @@ impl FlowExecutor {
             return false;
         }
 
+        // Keep the source component's stored value in sync with what it emitted.
+        // Components that emit from background threads (Interval, Oscillator, Delay, LLM)
+        // cannot call set_value() themselves because they lack &mut self. By updating here
+        // we guarantee collect_input_values() always sees the latest emitted value.
+        if let Some(component) = self.components.get_mut(event.source.as_ref()) {
+            component.set_value(event.value.clone());
+        }
+
         // Handle internal events (prefixed with _) by routing back to source component
         if event.source_handle.starts_with('_') {
             log::info!("Processing internal event: {} ({}) -> {:?}", 
@@ -255,7 +263,7 @@ impl FlowExecutor {
         true
     }
     
-    /// Collect current values from all components connected to a target's specific handle
+    /// Collect current values from all components connected to a target's specific handle.
     fn collect_input_values(&self, target_id: &str, target_handle: &str) -> Vec<ComponentValue> {
         self.edges
             .iter()

--- a/apps/web/src-tauri/src/runtime/mod.rs
+++ b/apps/web/src-tauri/src/runtime/mod.rs
@@ -56,7 +56,7 @@ pub use control::{Counter, CounterConfig, Delay, DelayConfig, Trigger, TriggerCo
 #[allow(unused_imports)]
 pub use generator::{Constant, ConstantConfig, Interval, IntervalConfig, Oscillator, OscillatorConfig};
 #[allow(unused_imports)]
-pub use transformation::{Calculate, CalculateConfig, Compare, CompareConfig, Gate, GateConfig, RangeMap, RangeMapConfig, Smooth, SmoothConfig};
+pub use transformation::{Calculate, CalculateConfig, CalculateFunction, Compare, CompareConfig, CompareValidator, Gate, GateConfig, RangeMap, RangeMapConfig, Smooth, SmoothConfig};
 
 use crate::hardware::board::BoardManager;
 use registry::ComponentRegistry;

--- a/apps/web/src-tauri/src/runtime/transformation/calculate.rs
+++ b/apps/web/src-tauri/src/runtime/transformation/calculate.rs
@@ -62,6 +62,7 @@ impl Calculate {
         };
 
         self.base.set_value(ComponentValue::Number(result));
+        self.base.emit("value");
     }
 }
 

--- a/apps/web/src-tauri/src/runtime/transformation/mod.rs
+++ b/apps/web/src-tauri/src/runtime/transformation/mod.rs
@@ -8,8 +8,8 @@ mod gate;
 mod range_map;
 mod smooth;
 
-pub use calculate::{Calculate, CalculateConfig};
-pub use compare::{Compare, CompareConfig};
+pub use calculate::{Calculate, CalculateConfig, CalculateFunction};
+pub use compare::{Compare, CompareConfig, CompareValidator};
 pub use gate::{Gate, GateConfig};
 pub use range_map::{RangeMap, RangeMapConfig};
 pub use smooth::{Smooth, SmoothConfig};

--- a/apps/web/src-tauri/tests/value_sync.rs
+++ b/apps/web/src-tauri/tests/value_sync.rs
@@ -70,7 +70,7 @@ impl Component for ThreadEmitter {
     }
 }
 
-/// A simple sink that stores whatever it receives via call_method.
+/// A simple sink that stores whatever it receives via `call_method`.
 struct Sink {
     base: ComponentBase,
 }
@@ -138,7 +138,7 @@ fn test_executor_syncs_stored_value_across_multiple_events() {
     executor.set_edges(vec![edge("emitter", "value", "sink", "value")]);
 
     for i in 1..=5 {
-        let val = i as f64 * 100.0;
+        let val = f64::from(i) * 100.0;
         executor.process_event(event("emitter", "value", ComponentValue::Number(val)));
         assert_eq!(
             executor.get_component("emitter").unwrap().value(),
@@ -238,7 +238,7 @@ fn test_calculate_add_with_thread_emitter() {
 // ---------------------------------------------------------------------------
 
 /// Calculate must emit its result downstream after processing.
-/// Before the fix, Calculate called set_value but never emitted, so
+/// Before the fix, Calculate called `set_value` but never emitted, so
 /// downstream nodes were never reached.
 #[test]
 fn test_calculate_emits_downstream() {
@@ -273,7 +273,7 @@ fn test_calculate_emits_downstream() {
 // Smooth transformation: set_value auto-emits, verify propagation
 // ---------------------------------------------------------------------------
 
-/// Smooth calls set_value which auto-emits "value". Verify the stored value
+/// Smooth calls `set_value` which auto-emits "value". Verify the stored value
 /// is correct after processing.
 #[test]
 fn test_smooth_updates_stored_value() {

--- a/apps/web/src-tauri/tests/value_sync.rs
+++ b/apps/web/src-tauri/tests/value_sync.rs
@@ -1,0 +1,431 @@
+//! Tests for the stored-value-sync invariant.
+//!
+//! Every component's stored `value()` must stay in sync with the values it
+//! emits. The executor's `process_event` is responsible for updating the
+//! source component's stored value before routing to downstream targets.
+//! This ensures `collect_input_values` (used by aggregating nodes like
+//! Calculate and Gate) always sees the latest emitted value.
+
+use app_lib::runtime::base::{BoardHandle, Component, ComponentBase, ComponentEvent, ComponentValue};
+use app_lib::runtime::{
+    Calculate, CalculateConfig, CalculateFunction, Constant, ConstantConfig, FlowEdge, FlowExecutor,
+    Gate, GateConfig, RangeMap, RangeMapConfig, Smooth, SmoothConfig, Compare, CompareConfig,
+    CompareValidator,
+};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn edge(source: &str, source_handle: &str, target: &str, target_handle: &str) -> FlowEdge {
+    FlowEdge {
+        id: None,
+        source: source.to_string(),
+        source_handle: source_handle.to_string(),
+        target: target.to_string(),
+        target_handle: target_handle.to_string(),
+    }
+}
+
+fn event(source: &str, handle: &str, value: ComponentValue) -> ComponentEvent {
+    ComponentEvent {
+        source: Arc::from(source),
+        source_handle: Arc::from(handle),
+        value,
+        edge_id: None,
+        sequence: 0,
+    }
+}
+
+/// A minimal "generator" mock that emits from outside (simulating a background
+/// thread) without updating its own stored value — exactly like Interval and
+/// Oscillator do.
+struct ThreadEmitter {
+    base: ComponentBase,
+}
+
+impl ThreadEmitter {
+    fn new(id: &str) -> Self {
+        Self {
+            base: ComponentBase::new(id.to_string(), ComponentValue::Number(0.0)),
+        }
+    }
+}
+
+impl Component for ThreadEmitter {
+    fn id(&self) -> &str { &self.base.id }
+    fn value(&self) -> ComponentValue { self.base.value.clone() }
+    fn set_value(&mut self, v: ComponentValue) { self.base.value = v; }
+    fn component_type(&self) -> &'static str { "ThreadEmitter" }
+    fn initialize(&mut self, _board: Arc<BoardHandle>) -> Result<(), String> { Ok(()) }
+    fn call_method(&mut self, _method: &str, _args: ComponentValue) -> Result<(), String> { Ok(()) }
+    fn destroy(&mut self) {}
+    fn event_sender(&self) -> Option<mpsc::UnboundedSender<ComponentEvent>> {
+        self.base.event_sender.clone()
+    }
+    fn set_event_sender(&mut self, sender: mpsc::UnboundedSender<ComponentEvent>) {
+        self.base.event_sender = Some(sender);
+    }
+}
+
+/// A simple sink that stores whatever it receives via call_method.
+struct Sink {
+    base: ComponentBase,
+}
+
+impl Sink {
+    fn new(id: &str) -> Self {
+        Self { base: ComponentBase::new(id.to_string(), ComponentValue::Number(0.0)) }
+    }
+}
+
+impl Component for Sink {
+    fn id(&self) -> &str { &self.base.id }
+    fn value(&self) -> ComponentValue { self.base.value.clone() }
+    fn set_value(&mut self, v: ComponentValue) { self.base.value = v; }
+    fn component_type(&self) -> &'static str { "Sink" }
+    fn initialize(&mut self, _board: Arc<BoardHandle>) -> Result<(), String> { Ok(()) }
+    fn call_method(&mut self, _method: &str, args: ComponentValue) -> Result<(), String> {
+        self.base.value = args;
+        Ok(())
+    }
+    fn destroy(&mut self) {}
+    fn event_sender(&self) -> Option<mpsc::UnboundedSender<ComponentEvent>> {
+        self.base.event_sender.clone()
+    }
+    fn set_event_sender(&mut self, sender: mpsc::UnboundedSender<ComponentEvent>) {
+        self.base.event_sender = Some(sender);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Executor stored-value-sync tests
+// ---------------------------------------------------------------------------
+
+/// The executor must update the source component's stored value when
+/// processing an event, so that `collect_input_values` sees the latest value.
+#[test]
+fn test_executor_syncs_source_stored_value_on_event() {
+    let mut executor = FlowExecutor::new();
+
+    executor.add_component("emitter", Box::new(ThreadEmitter::new("emitter")));
+    executor.add_component("sink", Box::new(Sink::new("sink")));
+    executor.set_edges(vec![edge("emitter", "value", "sink", "value")]);
+
+    // Emitter's stored value starts at 0
+    assert_eq!(executor.get_component("emitter").unwrap().value(), ComponentValue::Number(0.0));
+
+    // Simulate the emitter firing an event with value 42 (like Interval does from a thread)
+    executor.process_event(event("emitter", "value", ComponentValue::Number(42.0)));
+
+    // The executor should have updated the emitter's stored value
+    assert_eq!(
+        executor.get_component("emitter").unwrap().value(),
+        ComponentValue::Number(42.0),
+        "Executor must sync source component's stored value with emitted event value"
+    );
+}
+
+/// Repeated events from the same source must keep the stored value up to date.
+#[test]
+fn test_executor_syncs_stored_value_across_multiple_events() {
+    let mut executor = FlowExecutor::new();
+
+    executor.add_component("emitter", Box::new(ThreadEmitter::new("emitter")));
+    executor.add_component("sink", Box::new(Sink::new("sink")));
+    executor.set_edges(vec![edge("emitter", "value", "sink", "value")]);
+
+    for i in 1..=5 {
+        let val = i as f64 * 100.0;
+        executor.process_event(event("emitter", "value", ComponentValue::Number(val)));
+        assert_eq!(
+            executor.get_component("emitter").unwrap().value(),
+            ComponentValue::Number(val),
+        );
+    }
+}
+
+/// Stale events must NOT update the stored value.
+#[test]
+fn test_stale_event_does_not_update_stored_value() {
+    let mut executor = FlowExecutor::new();
+    executor.set_current_sequence(10);
+
+    executor.add_component("emitter", Box::new(ThreadEmitter::new("emitter")));
+    executor.add_component("sink", Box::new(Sink::new("sink")));
+    executor.set_edges(vec![edge("emitter", "value", "sink", "value")]);
+
+    let stale = ComponentEvent {
+        source: Arc::from("emitter"),
+        source_handle: Arc::from("value"),
+        value: ComponentValue::Number(999.0),
+        edge_id: None,
+        sequence: 3, // older than current_sequence=10
+    };
+    executor.process_event(stale);
+
+    assert_eq!(
+        executor.get_component("emitter").unwrap().value(),
+        ComponentValue::Number(0.0),
+        "Stale events must not update stored value"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Aggregating node tests (collect_input_values correctness)
+// ---------------------------------------------------------------------------
+
+/// Interval -> Calculate (min) with Constant should use the actual interval
+/// value, not the stale stored default.
+/// This is the exact scenario from the original bug report.
+#[test]
+fn test_calculate_min_with_thread_emitter_and_constant() {
+    let mut executor = FlowExecutor::new();
+
+    // Constant(255) and a thread emitter (simulating Interval) both feed into Calculate(min)
+    executor.add_component("constant", Box::new(Constant::new("constant".into(), ConstantConfig { value: 255.0 })));
+    executor.add_component("interval", Box::new(ThreadEmitter::new("interval")));
+    executor.add_component("calc", Box::new(Calculate::new("calc".into(), CalculateConfig { function: CalculateFunction::Min })));
+    executor.add_component("sink", Box::new(Sink::new("sink")));
+
+    executor.set_edges(vec![
+        edge("constant", "value", "calc", "value"),
+        edge("interval", "event", "calc", "value"),
+        edge("calc", "value", "sink", "value"),
+    ]);
+
+    // Simulate interval tick with elapsed=5005ms
+    executor.process_event(event("interval", "event", ComponentValue::Number(5005.0)));
+
+    // Calculate(min) should compute min(255, 5005) = 255, not min(255, 0)
+    assert_eq!(
+        executor.get_component("calc").unwrap().value(),
+        ComponentValue::Number(255.0),
+        "Calculate(min) must use the actual event value (5005), not the stale default (0)"
+    );
+}
+
+/// Calculate(add) should sum all input values correctly when one source is a
+/// thread emitter.
+#[test]
+fn test_calculate_add_with_thread_emitter() {
+    let mut executor = FlowExecutor::new();
+
+    executor.add_component("constant", Box::new(Constant::new("constant".into(), ConstantConfig { value: 10.0 })));
+    executor.add_component("emitter", Box::new(ThreadEmitter::new("emitter")));
+    executor.add_component("calc", Box::new(Calculate::new("calc".into(), CalculateConfig::default()))); // default = Add
+    executor.add_component("sink", Box::new(Sink::new("sink")));
+
+    executor.set_edges(vec![
+        edge("constant", "value", "calc", "value"),
+        edge("emitter", "event", "calc", "value"),
+        edge("calc", "value", "sink", "value"),
+    ]);
+
+    executor.process_event(event("emitter", "event", ComponentValue::Number(20.0)));
+
+    // add(10, 20) = 30
+    assert_eq!(
+        executor.get_component("calc").unwrap().value(),
+        ComponentValue::Number(30.0),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Calculate emit test (the original bug: Calculate didn't emit downstream)
+// ---------------------------------------------------------------------------
+
+/// Calculate must emit its result downstream after processing.
+/// Before the fix, Calculate called set_value but never emitted, so
+/// downstream nodes were never reached.
+#[test]
+fn test_calculate_emits_downstream() {
+    let mut executor = FlowExecutor::new();
+    let (tx, mut rx) = mpsc::unbounded_channel::<ComponentEvent>();
+
+    let mut calc = Calculate::new("calc".into(), CalculateConfig::default());
+    calc.set_event_sender(tx);
+    executor.add_component("calc", Box::new(calc));
+    executor.add_component("sink", Box::new(Sink::new("sink")));
+
+    executor.set_edges(vec![
+        edge("calc", "value", "sink", "value"),
+    ]);
+
+    // Directly call the calculate component's method
+    if let Some(c) = executor.get_component_mut("calc") {
+        c.call_method("value", ComponentValue::Array(vec![
+            ComponentValue::Number(3.0),
+            ComponentValue::Number(7.0),
+        ])).unwrap();
+    }
+
+    // Calculate should have emitted a "value" event
+    let emitted = rx.try_recv();
+    assert!(emitted.is_ok(), "Calculate must emit an event after processing");
+    let evt = emitted.unwrap();
+    assert_eq!(evt.value, ComponentValue::Number(10.0)); // 3 + 7
+}
+
+// ---------------------------------------------------------------------------
+// Smooth transformation: set_value auto-emits, verify propagation
+// ---------------------------------------------------------------------------
+
+/// Smooth calls set_value which auto-emits "value". Verify the stored value
+/// is correct after processing.
+#[test]
+fn test_smooth_updates_stored_value() {
+    let mut executor = FlowExecutor::new();
+    let (tx, _rx) = mpsc::unbounded_channel::<ComponentEvent>();
+
+    let mut smooth = Smooth::new("smooth".into(), SmoothConfig::default());
+    smooth.set_event_sender(tx);
+    executor.add_component("smooth", Box::new(smooth));
+
+    if let Some(c) = executor.get_component_mut("smooth") {
+        c.call_method("value", ComponentValue::Number(100.0)).unwrap();
+    }
+
+    let val = executor.get_component("smooth").unwrap().value();
+    match val {
+        ComponentValue::Number(n) => assert!(n > 0.0, "Smooth should have updated its value from 0"),
+        _ => panic!("Expected Number value from Smooth"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Gate transformation: emits on named handles after set_value
+// ---------------------------------------------------------------------------
+
+/// Gate must update stored value AND emit after processing.
+#[test]
+fn test_gate_emits_and_updates_value() {
+    let mut executor = FlowExecutor::new();
+    let (tx, mut rx) = mpsc::unbounded_channel::<ComponentEvent>();
+
+    let mut gate = Gate::new("gate".into(), GateConfig::default()); // default = And
+    gate.set_event_sender(tx);
+    executor.add_component("gate", Box::new(gate));
+
+    if let Some(c) = executor.get_component_mut("gate") {
+        c.call_method("value", ComponentValue::Array(vec![
+            ComponentValue::Bool(true),
+            ComponentValue::Bool(true),
+        ])).unwrap();
+    }
+
+    // Gate(And) with [true, true] -> true
+    assert_eq!(
+        executor.get_component("gate").unwrap().value(),
+        ComponentValue::Bool(true),
+    );
+
+    // Should have emitted on "true" handle
+    let emitted = rx.try_recv();
+    assert!(emitted.is_ok(), "Gate must emit after processing");
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: thread emitter -> aggregating node -> sink
+// ---------------------------------------------------------------------------
+
+/// Full pipeline: two thread emitters feed into Calculate(add), result goes to sink.
+/// Both emitters fire at different times. Stored values must stay in sync.
+#[test]
+fn test_full_pipeline_two_emitters_to_calculate_to_sink() {
+    let mut executor = FlowExecutor::new();
+    let (tx, _rx) = mpsc::unbounded_channel::<ComponentEvent>();
+
+    let mut calc = Calculate::new("calc".into(), CalculateConfig::default());
+    calc.set_event_sender(tx);
+
+    executor.add_component("em1", Box::new(ThreadEmitter::new("em1")));
+    executor.add_component("em2", Box::new(ThreadEmitter::new("em2")));
+    executor.add_component("calc", Box::new(calc));
+    executor.add_component("sink", Box::new(Sink::new("sink")));
+
+    executor.set_edges(vec![
+        edge("em1", "value", "calc", "value"),
+        edge("em2", "value", "calc", "value"),
+        edge("calc", "value", "sink", "value"),
+    ]);
+
+    // em1 fires with 100
+    executor.process_event(event("em1", "value", ComponentValue::Number(100.0)));
+    // At this point: em1 stored=100, em2 stored=0 (default), calc = add(100, 0) = 100
+    assert_eq!(executor.get_component("em1").unwrap().value(), ComponentValue::Number(100.0));
+    assert_eq!(executor.get_component("calc").unwrap().value(), ComponentValue::Number(100.0));
+
+    // em2 fires with 50
+    executor.process_event(event("em2", "value", ComponentValue::Number(50.0)));
+    // Now: em1 stored=100, em2 stored=50, calc = add(100, 50) = 150
+    assert_eq!(executor.get_component("em2").unwrap().value(), ComponentValue::Number(50.0));
+    assert_eq!(executor.get_component("calc").unwrap().value(), ComponentValue::Number(150.0));
+
+    // em1 fires again with 200
+    executor.process_event(event("em1", "value", ComponentValue::Number(200.0)));
+    // Now: em1 stored=200, em2 stored=50, calc = add(200, 50) = 250
+    assert_eq!(executor.get_component("em1").unwrap().value(), ComponentValue::Number(200.0));
+    assert_eq!(executor.get_component("calc").unwrap().value(), ComponentValue::Number(250.0));
+}
+
+// ---------------------------------------------------------------------------
+// Compare transformation: emits on named handles
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_compare_emits_and_updates_value() {
+    let mut executor = FlowExecutor::new();
+    let (tx, mut rx) = mpsc::unbounded_channel::<ComponentEvent>();
+
+    let mut compare = Compare::new("cmp".into(), CompareConfig {
+        validator: CompareValidator::Number,
+        sub_validator: "greater than".to_string(),
+        number: 50.0,
+        ..CompareConfig::default()
+    });
+    compare.set_event_sender(tx);
+    executor.add_component("cmp", Box::new(compare));
+
+    if let Some(c) = executor.get_component_mut("cmp") {
+        c.call_method("value", ComponentValue::Number(100.0)).unwrap();
+    }
+
+    // 100 > 50 = true
+    assert_eq!(
+        executor.get_component("cmp").unwrap().value(),
+        ComponentValue::Bool(true),
+    );
+
+    let emitted = rx.try_recv();
+    assert!(emitted.is_ok(), "Compare must emit after processing");
+}
+
+// ---------------------------------------------------------------------------
+// RangeMap transformation: emits with custom value on "to" handle
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_range_map_emits_mapped_value() {
+    let mut executor = FlowExecutor::new();
+    let (tx, mut rx) = mpsc::unbounded_channel::<ComponentEvent>();
+
+    let mut range_map = RangeMap::new("rm".into(), RangeMapConfig::default());
+    range_map.set_event_sender(tx);
+    executor.add_component("rm", Box::new(range_map));
+
+    if let Some(c) = executor.get_component_mut("rm") {
+        c.call_method("value", ComponentValue::Number(512.0)).unwrap();
+    }
+
+    // RangeMap's set_value auto-emits "value" first, then explicitly emits on "to"
+    let first = rx.try_recv();
+    assert!(first.is_ok(), "RangeMap must emit after processing");
+
+    // The "to" handle event comes second
+    let second = rx.try_recv();
+    assert!(second.is_ok(), "RangeMap must emit on 'to' handle");
+    assert_eq!(second.unwrap().source_handle.as_ref(), "to");
+}

--- a/apps/web/src/components/flow/nodes/_base/_base.tsx
+++ b/apps/web/src/components/flow/nodes/_base/_base.tsx
@@ -22,7 +22,7 @@ import { cva } from "class-variance-authority";
 import { OctagonAlertIcon, CableIcon } from "lucide-react";
 import { useFlowStore } from "@/stores/flow-store";
 import { usePins } from "@/stores/board";
-import { Pin } from "@/components/hardware/pin";
+import { Pin, pinDisplayValue } from "@/components/hardware/pin";
 import { Icon, type IconName } from "@/components/ui/icon";
 
 function NodeHeader(props: { error?: string }) {
@@ -86,7 +86,7 @@ function NodeDescription() {
           <div key={key} className="flex items-center gap-1">
             <CableIcon size={12} />
             <span className="font-extralight">
-              {key}: {String(value)}
+              {key}: {pinDisplayValue(value, pins)}
             </span>
           </div>
         ))}

--- a/apps/web/src/components/flow/nodes/rgb/rgb.tsx
+++ b/apps/web/src/components/flow/nodes/rgb/rgb.tsx
@@ -9,7 +9,7 @@ import { folder } from "leva";
 
 export function Rgb(props: Props) {
   return (
-    <NodeContainer {...props}>
+    <NodeContainer {...props} className="min-w-sm">
       <Value />
       <Settings />
       <Handle type="target" position="left" id="red" handleType="value" hint="0-255" offset={-1.5} />


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the runtime and UI layers, focusing on component value synchronization, event emission, and UI display enhancements. The most significant changes ensure that component values remain consistent, especially for components emitting values from background threads, and improve the clarity of pin value displays in the UI.

**Runtime logic and synchronization:**

* Ensured that whenever a component emits a value (even from background threads), its stored value is updated in `FlowExecutor`, guaranteeing that `collect_input_values()` always retrieves the latest value. This fixes potential inconsistencies for components like Interval, Oscillator, Delay, and LLM.
* In the `Calculate` transformation, added an explicit emit call after setting the value, ensuring downstream components are notified immediately of value changes.

**API and type exports:**

* Exposed additional types (`CalculateFunction`, `CompareValidator`) from the transformation module, making them available for use elsewhere in the codebase. [[1]](diffhunk://#diff-5a931572bf34994c8a12cf65fb78cf14b99f6c54eef2e85bbedd1cb084d5dea1L59-R59) [[2]](diffhunk://#diff-2b7fb8696abcf5a1d6ef65ba54cefbbf7e9522f5b60974b7506a161b1d713b93L11-R12)

**UI and display improvements:**

* Updated the node description UI to use the new `pinDisplayValue` function for rendering pin values, providing more user-friendly and context-aware formatting. [[1]](diffhunk://#diff-ef56a42a62c9e1f31462ced9d05817b5fa329ad7210ea46c1feaec0cf348f67bL25-R25) [[2]](diffhunk://#diff-ef56a42a62c9e1f31462ced9d05817b5fa329ad7210ea46c1feaec0cf348f67bL89-R89)
* Adjusted the minimum width of the RGB node container for improved layout consistency.