### PR TITLE
fix(piezo): play songs on different tones and lengths

### DIFF
--- a/apps/web/src-tauri/src/runtime/base.rs
+++ b/apps/web/src-tauri/src/runtime/base.rs
@@ -210,6 +210,9 @@ pub struct BoardHandle {
     reader_running: std::sync::atomic::AtomicBool,
     /// Handle to the reader thread for joining on stop
     reader_handle: std::sync::Mutex<Option<std::thread::JoinHandle<()>>>,
+    /// Flag to cancel an in-progress tone on the reader thread.
+    /// Checked inside the `tone()` spin-loop so `NoTone` can interrupt it.
+    tone_cancel: std::sync::atomic::AtomicBool,
 }
 
 impl BoardHandle {
@@ -220,6 +223,7 @@ impl BoardHandle {
             connected: std::sync::atomic::AtomicBool::new(false),
             reader_running: std::sync::atomic::AtomicBool::new(false),
             reader_handle: std::sync::Mutex::new(None),
+            tone_cancel: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -281,6 +285,14 @@ impl BoardHandle {
                         }
                         Ok(BoardCommand::ShiftOut { data_pin, clock_pin, value }) => {
                             let _ = conn.shift_out(data_pin, clock_pin, value);
+                        }
+                        Ok(BoardCommand::Tone { pin, half_period_us, duration_ms }) => {
+                            handle_clone.tone_cancel.store(false, std::sync::atomic::Ordering::Release);
+                            let _ = conn.tone(pin, half_period_us, duration_ms, &handle_clone.tone_cancel);
+                        }
+                        Ok(BoardCommand::NoTone { pin }) => {
+                            handle_clone.tone_cancel.store(true, std::sync::atomic::Ordering::Release);
+                            let _ = conn.no_tone(pin);
                         }
                         Err(std::sync::mpsc::TryRecvError::Empty) => break,
                         Err(std::sync::mpsc::TryRecvError::Disconnected) => {
@@ -425,6 +437,11 @@ pub enum BoardCommand {
     /// Equivalent to Arduino's shiftOut(dataPin, clockPin, MSBFIRST, value).
     /// Performed atomically on the reader thread for correct timing.
     ShiftOut { data_pin: u8, clock_pin: u8, value: u8 },
+    /// Play a tone by toggling a pin at the given half-period (µs) for duration (ms).
+    /// Executed directly on the reader thread for tight timing (no channel overhead).
+    Tone { pin: u8, half_period_us: u32, duration_ms: u32 },
+    /// Stop tone and drive pin low.
+    NoTone { pin: u8 },
     Stop,
 }
 
@@ -503,6 +520,46 @@ impl BoardConnection {
                 .map_err(|e| format!("Failed to clock high: {e}"))?;
         }
         Ok(())
+
+    }
+
+    /// Play a tone by toggling a digital pin at the given half-period.
+    /// Runs directly on the reader thread for tight timing — mirrors J5's
+    /// DEFAULT controller approach (OUTPUT mode + digitalWrite toggling).
+    pub fn tone(&mut self, pin: u8, half_period_us: u32, duration_ms: u32, cancel: &std::sync::atomic::AtomicBool) -> Result<(), String> {
+        let half_period = std::time::Duration::from_micros(u64::from(half_period_us));
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(u64::from(duration_ms));
+        let mut value = 1;
+
+        while std::time::Instant::now() < deadline {
+            if cancel.load(std::sync::atomic::Ordering::Acquire) {
+                break;
+            }
+            let _ = self.board.digital_write(i32::from(pin), value);
+            value = if value == 1 { 0 } else { 1 };
+            // Spin-sleep for accurate sub-millisecond timing
+            let target = std::time::Instant::now() + half_period;
+            if half_period > std::time::Duration::from_millis(1) {
+                std::thread::sleep(half_period - std::time::Duration::from_micros(500));
+            }
+            while std::time::Instant::now() < target {
+                if cancel.load(std::sync::atomic::Ordering::Acquire) {
+                    break;
+                }
+                std::hint::spin_loop();
+            }
+        }
+
+        // Ensure pin is low when done
+        let _ = self.board.digital_write(i32::from(pin), 0);
+        Ok(())
+    }
+
+    /// Stop tone — drive pin low.
+    pub fn no_tone(&mut self, pin: u8) -> Result<(), String> {
+        self.board
+            .digital_write(i32::from(pin), 0)
+            .map_err(|e| format!("Failed to stop tone: {e}"))
     }
 
     pub fn digital_read(&mut self, pin: u8) -> Result<bool, String> {

--- a/apps/web/src-tauri/src/runtime/base.rs
+++ b/apps/web/src-tauri/src/runtime/base.rs
@@ -536,11 +536,11 @@ impl BoardConnection {
                 break;
             }
             let _ = self.board.digital_write(i32::from(pin), value);
-            value = if value == 1 { 0 } else { 1 };
+            value = i32::from(value != 1);
             // Spin-sleep for accurate sub-millisecond timing
             let target = std::time::Instant::now() + half_period;
             if half_period > std::time::Duration::from_millis(1) {
-                std::thread::sleep(half_period - std::time::Duration::from_micros(500));
+                std::thread::sleep(half_period.checked_sub(std::time::Duration::from_micros(500)).unwrap());
             }
             while std::time::Instant::now() < target {
                 if cancel.load(std::sync::atomic::Ordering::Acquire) {

--- a/apps/web/src-tauri/src/runtime/executor.rs
+++ b/apps/web/src-tauri/src/runtime/executor.rs
@@ -199,14 +199,6 @@ impl FlowExecutor {
             return false;
         }
 
-        // Keep the source component's stored value in sync with what it emitted.
-        // Components that emit from background threads (Interval, Oscillator, Delay, LLM)
-        // cannot call set_value() themselves because they lack &mut self. By updating here
-        // we guarantee collect_input_values() always sees the latest emitted value.
-        if let Some(component) = self.components.get_mut(event.source.as_ref()) {
-            component.set_value(event.value.clone());
-        }
-
         // Handle internal events (prefixed with _) by routing back to source component
         if event.source_handle.starts_with('_') {
             log::info!("Processing internal event: {} ({}) -> {:?}", 
@@ -220,6 +212,18 @@ impl FlowExecutor {
                 }
             }
             return true;
+        }
+
+        // Keep the source component's stored value in sync with what it emitted.
+        // Components that emit from background threads (Interval, Oscillator, Delay, LLM)
+        // cannot call set_value() themselves because they lack &mut self. By updating here
+        // we guarantee collect_input_values() always sees the latest emitted value.
+        // NOTE: This must happen AFTER the internal-event early return above, because
+        // internal handlers (e.g. auto_stop) call set_value() themselves and rely on
+        // change detection to emit a "value" event to the frontend. Pre-setting the value
+        // here would suppress that emission.
+        if let Some(component) = self.components.get_mut(event.source.as_ref()) {
+            component.set_value(event.value.clone());
         }
 
         log::info!("Processing event: {} ({}) -> looking for edges (total edges: {})", 

--- a/apps/web/src-tauri/src/runtime/output/piezo.rs
+++ b/apps/web/src-tauri/src/runtime/output/piezo.rs
@@ -1,4 +1,9 @@
 //! Piezo Buzzer Component - Output
+//!
+//! Tone generation uses the Johnny-Five approach: OUTPUT mode + DigitalWrite
+//! toggling at the note's half-period to produce a square wave at the desired
+//! frequency. The toggling runs on the Firmata reader thread (via BoardCommand::Tone)
+//! for tight timing with direct serial access — no channel overhead per toggle.
 
 use crate::runtime::base::{
     pin_mode, serde_utils, BoardCommand, BoardHandle, Component, ComponentBase, ComponentEvent,
@@ -7,6 +12,8 @@ use crate::runtime::base::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 use tokio::sync::mpsc;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -38,7 +45,7 @@ pub struct PiezoConfig {
 fn default_pin() -> u8 { 11 }
 fn default_duration() -> u32 { 500 }
 fn default_frequency() -> u32 { 440 }
-fn default_tempo() -> u32 { 120 }
+fn default_tempo() -> u32 { 113 }
 
 impl Default for PiezoConfig {
     fn default() -> Self {
@@ -46,42 +53,40 @@ impl Default for PiezoConfig {
     }
 }
 
-/// Get note frequencies (standard piano frequencies)
+/// Get note frequencies (standard piano frequencies in Hz)
 fn note_frequencies() -> HashMap<&'static str, u16> {
     let mut m = HashMap::new();
-    // Octave 0
     m.insert("b0", 31);
-    // Octave 1
     m.insert("c1", 33); m.insert("c#1", 35); m.insert("d1", 37); m.insert("d#1", 39);
     m.insert("e1", 41); m.insert("f1", 44); m.insert("f#1", 46); m.insert("g1", 49);
     m.insert("g#1", 52); m.insert("a1", 55); m.insert("a#1", 58); m.insert("b1", 62);
-    // Octave 2
     m.insert("c2", 65); m.insert("c#2", 69); m.insert("d2", 73); m.insert("d#2", 78);
     m.insert("e2", 82); m.insert("f2", 87); m.insert("f#2", 93); m.insert("g2", 98);
     m.insert("g#2", 104); m.insert("a2", 110); m.insert("a#2", 117); m.insert("b2", 123);
-    // Octave 3
     m.insert("c3", 131); m.insert("c#3", 139); m.insert("d3", 147); m.insert("d#3", 156);
     m.insert("e3", 165); m.insert("f3", 175); m.insert("f#3", 185); m.insert("g3", 196);
     m.insert("g#3", 208); m.insert("a3", 220); m.insert("a#3", 233); m.insert("b3", 247);
-    // Octave 4 (middle)
     m.insert("c4", 262); m.insert("c#4", 277); m.insert("d4", 294); m.insert("d#4", 311);
     m.insert("e4", 330); m.insert("f4", 349); m.insert("f#4", 370); m.insert("g4", 392);
     m.insert("g#4", 415); m.insert("a4", 440); m.insert("a#4", 466); m.insert("b4", 494);
-    // Octave 5
     m.insert("c5", 523); m.insert("c#5", 554); m.insert("d5", 587); m.insert("d#5", 622);
     m.insert("e5", 659); m.insert("f5", 698); m.insert("f#5", 740); m.insert("g5", 784);
     m.insert("g#5", 831); m.insert("a5", 880); m.insert("a#5", 932); m.insert("b5", 988);
-    // Octave 6
     m.insert("c6", 1047); m.insert("c#6", 1109); m.insert("d6", 1175); m.insert("d#6", 1245);
     m.insert("e6", 1319); m.insert("f6", 1397); m.insert("f#6", 1480); m.insert("g6", 1568);
     m.insert("g#6", 1661); m.insert("a6", 1760); m.insert("a#6", 1865); m.insert("b6", 1976);
-    // Octave 7
     m.insert("c7", 2093); m.insert("c#7", 2217); m.insert("d7", 2349); m.insert("d#7", 2489);
     m.insert("e7", 2637); m.insert("f7", 2794); m.insert("f#7", 2960); m.insert("g7", 3136);
     m.insert("g#7", 3322); m.insert("a7", 3520); m.insert("a#7", 3729); m.insert("b7", 3951);
-    // Octave 8
     m.insert("c8", 4186); m.insert("c#8", 4435); m.insert("d8", 4699); m.insert("d#8", 4978);
     m
+}
+
+/// Convert frequency (Hz) to half-period (microseconds).
+/// J5 approach: tone = round((1/freq) / 2 * 1_000_000)
+fn hz_to_half_period_us(freq: u16) -> u32 {
+    if freq == 0 { return 0; }
+    500_000 / u32::from(freq)
 }
 
 pub struct Piezo {
@@ -89,46 +94,67 @@ pub struct Piezo {
     config: PiezoConfig,
     board: Option<Arc<BoardHandle>>,
     is_playing: bool,
+    /// Shared cancellation flag for the background song/buzz thread.
+    /// Set to `true` by `stop()` so the thread exits early.
+    cancel_token: Arc<AtomicBool>,
 }
 
 impl Piezo {
-    #[must_use] 
+    #[must_use]
     pub fn new(id: String, config: PiezoConfig) -> Self {
-        Self { base: ComponentBase::new(id, ComponentValue::Bool(false)), config, board: None, is_playing: false }
+        Self {
+            base: ComponentBase::new(id, ComponentValue::Bool(false)),
+            config,
+            board: None,
+            is_playing: false,
+            cancel_token: Arc::new(AtomicBool::new(false)),
+        }
     }
 
     pub fn buzz(&mut self) -> Result<(), String> {
         self.stop()?;
         if self.config.r#type != PiezoType::Buzz { return Ok(()); }
-        if let Some(board) = &self.board {
-            board.send_command(BoardCommand::AnalogWrite { pin: self.config.pin, value: 128 })?;
-            
-            // Schedule automatic stop after duration using std::thread
-            let duration_ms = self.config.duration;
-            let sender = self.base.event_sender.clone();
-            let source = self.base.id.clone();
-            
-            std::thread::spawn(move || {
-                std::thread::sleep(std::time::Duration::from_millis(u64::from(duration_ms)));
+        // Fresh token for this buzz
+        self.cancel_token = Arc::new(AtomicBool::new(false));
+        self.buzz_once(self.config.frequency as u16, self.config.duration)
+    }
+
+    fn buzz_once(&mut self, freq: u16, duration_ms: u32) -> Result<(), String> {
+        let board = match &self.board {
+            Some(b) => Arc::clone(b),
+            None => return Err("No board connected".to_string()),
+        };
+
+        let pin = self.config.pin;
+        let half_period_us = hz_to_half_period_us(freq);
+        let sender = self.base.event_sender.clone();
+        let source = self.base.id.clone();
+        let cancel = Arc::clone(&self.cancel_token);
+
+        std::thread::spawn(move || {
+            let _ = board.send_command(BoardCommand::Tone { pin, half_period_us, duration_ms });
+            // Only emit auto_stop if we weren't cancelled (avoids stale event after re-trigger)
+            if !cancel.load(Ordering::Acquire) {
                 if let Some(tx) = sender {
                     let _ = tx.send(ComponentEvent {
                         source,
                         source_handle: Arc::from("_auto_stop"),
                         value: ComponentValue::Bool(false),
                         edge_id: None,
-                        sequence: 0,  // Will be set by FlowRuntime when sequence tracking is enabled
+                        sequence: 0,
                     });
                 }
-            });
-        }
+            }
+        });
+
         self.is_playing = true;
         self.base.set_value(ComponentValue::Bool(true));
         Ok(())
     }
-    
+
     fn handle_auto_stop(&mut self) -> Result<(), String> {
         if let Some(board) = &self.board {
-            board.send_command(BoardCommand::AnalogWrite { pin: self.config.pin, value: 0 })?;
+            let _ = board.send_command(BoardCommand::NoTone { pin: self.config.pin });
         }
         self.is_playing = false;
         self.base.set_value(ComponentValue::Bool(false));
@@ -136,82 +162,115 @@ impl Piezo {
     }
 
     pub fn stop(&mut self) -> Result<(), String> {
+        // Signal any background thread (buzz or song) to exit early
+        self.cancel_token.store(true, Ordering::Release);
         self.handle_auto_stop()
     }
 
     pub fn play(&mut self) -> Result<(), String> {
         self.stop()?;
-        
+
         log::info!("Piezo play() called - type: {:?}, song length: {}", self.config.r#type, self.config.song.len());
-        
-        if self.config.r#type != PiezoType::Song { 
+
+        if self.config.r#type != PiezoType::Song {
             log::info!("Piezo type is not Song, skipping");
-            return Ok(()); 
+            return Ok(());
         }
-        if self.config.song.is_empty() { 
-            log::info!("Song is empty, skipping");
-            return Ok(()); 
+        if self.config.song.is_empty() {
+            log::info!("Song is empty, falling back to single buzz");
+            // Fresh token for this buzz
+            self.cancel_token = Arc::new(AtomicBool::new(false));
+            return self.buzz_once(self.config.frequency as u16, self.config.duration);
         }
-        
+
         let board = match &self.board {
             Some(b) => Arc::clone(b),
             None => return Err("No board connected".to_string()),
         };
-        
+
         let song = self.config.song.clone();
         let tempo = self.config.tempo;
         let pin = self.config.pin;
         let sender = self.base.event_sender.clone();
         let source = self.base.id.clone();
-        
+
+        // Fresh token for this playback
+        self.cancel_token = Arc::new(AtomicBool::new(false));
+        let cancel = Arc::clone(&self.cancel_token);
+
         log::info!("Playing song with {} notes at tempo {}", song.len(), tempo);
-        
+
         self.is_playing = true;
         self.base.set_value(ComponentValue::Bool(true));
-        
-        // Play song in background thread
+
+        // Play song in background thread.
+        // Each note sends a Tone command to the reader thread, then sleeps
+        // for the note's duration. The reader thread does the tight
+        // DigitalWrite toggling. A small silence gap between notes provides
+        // articulation so consecutive notes are distinguishable.
         std::thread::spawn(move || {
             let frequencies = note_frequencies();
-            // Beat duration in ms (tempo is BPM, so 60000/tempo = ms per beat)
             let beat_ms = 60000.0 / f64::from(tempo);
-            
+
             for (note, beats) in song {
+                // Check cancellation before each note
+                if cancel.load(Ordering::Acquire) {
+                    log::info!("Song cancelled, stopping playback");
+                    break;
+                }
+
                 let duration_ms = (beat_ms * beats) as u64;
-                
+
                 if let Some(note_name) = note {
-                    // Play the note
-                    let _freq = frequencies.get(note_name.to_lowercase().as_str()).copied().unwrap_or(440);
-                    log::info!("Playing note {note_name} for {duration_ms}ms");
-                    // For PWM-based tone, we write a mid-value to create sound
-                    let _ = board.send_command(BoardCommand::AnalogWrite { pin, value: 128 });
-                    // Play for most of the duration, tiny gap for articulation
-                    let gap = 5.min(duration_ms / 10); // 5ms or 10% of note, whichever is smaller
-                    std::thread::sleep(std::time::Duration::from_millis(duration_ms.saturating_sub(gap)));
-                    let _ = board.send_command(BoardCommand::AnalogWrite { pin, value: 0 });
-                    if gap > 0 {
-                        std::thread::sleep(std::time::Duration::from_millis(gap));
+                    let freq = frequencies.get(note_name.to_lowercase().as_str()).copied().unwrap_or(440);
+                    let half_period_us = hz_to_half_period_us(freq);
+                    log::info!("Playing note {note_name} ({freq}Hz, half={half_period_us}µs) for {duration_ms}ms");
+
+                    // Small fixed articulation gap to distinguish consecutive notes.
+                    let gap: u64 = 20;
+                    let tone_duration = duration_ms.saturating_sub(gap) as u32;
+
+                    let _ = board.send_command(BoardCommand::Tone { pin, half_period_us, duration_ms: tone_duration });
+
+                    // Sleep in small increments so we can check cancellation
+                    let sleep_end = std::time::Instant::now() + Duration::from_millis(duration_ms);
+                    while std::time::Instant::now() < sleep_end {
+                        if cancel.load(Ordering::Acquire) {
+                            break;
+                        }
+                        std::thread::sleep(Duration::from_millis(10));
                     }
                 } else {
-                    // Rest - silence
                     log::info!("Rest for {duration_ms}ms");
-                    let _ = board.send_command(BoardCommand::AnalogWrite { pin, value: 0 });
-                    std::thread::sleep(std::time::Duration::from_millis(duration_ms));
+                    let _ = board.send_command(BoardCommand::NoTone { pin });
+
+                    let sleep_end = std::time::Instant::now() + Duration::from_millis(duration_ms);
+                    while std::time::Instant::now() < sleep_end {
+                        if cancel.load(Ordering::Acquire) {
+                            break;
+                        }
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
                 }
             }
-            
-            log::info!("Song finished, emitting auto_stop");
-            // Song finished - emit auto_stop event
-            if let Some(tx) = sender {
-                let _ = tx.send(ComponentEvent {
-                    source,
-                    source_handle: Arc::from("_auto_stop"),
-                    value: ComponentValue::Bool(false),
-                    edge_id: None,
-                    sequence: 0,  // Will be set by FlowRuntime when sequence tracking is enabled
-                });
+
+            // Only emit auto_stop if we weren't cancelled
+            if !cancel.load(Ordering::Acquire) {
+                let _ = board.send_command(BoardCommand::NoTone { pin });
+
+                log::info!("Song finished, emitting auto_stop");
+                if let Some(tx) = sender {
+                    let _ = tx.send(ComponentEvent {
+                        source,
+                        source_handle: Arc::from("_auto_stop"),
+                        value: ComponentValue::Bool(false),
+                        edge_id: None,
+                        sequence: 0,
+                    });
+                }
             }
         });
-        
+
         Ok(())
     }
 }
@@ -224,8 +283,9 @@ impl Component for Piezo {
     fn requires_hardware(&self) -> bool { true }
 
     fn initialize(&mut self, board: Arc<BoardHandle>) -> Result<(), String> {
-        board.send_command(BoardCommand::SetPinMode { pin: self.config.pin, mode: pin_mode::PWM })?;
-        board.send_command(BoardCommand::AnalogWrite { pin: self.config.pin, value: 0 })?;
+        // Use OUTPUT mode like J5 — we generate frequency via DigitalWrite toggling
+        board.send_command(BoardCommand::SetPinMode { pin: self.config.pin, mode: pin_mode::OUTPUT })?;
+        board.send_command(BoardCommand::DigitalWrite { pin: self.config.pin, value: false })?;
         self.board = Some(board);
         Ok(())
     }
@@ -233,7 +293,6 @@ impl Component for Piezo {
     fn call_method(&mut self, method: &str, _args: ComponentValue) -> Result<(), String> {
         match method {
             "trigger" => {
-                // Trigger plays buzz or song depending on type
                 match self.config.r#type {
                     PiezoType::Buzz => self.buzz(),
                     PiezoType::Song => self.play(),

--- a/apps/web/src-tauri/src/runtime/output/piezo.rs
+++ b/apps/web/src-tauri/src/runtime/output/piezo.rs
@@ -1,8 +1,8 @@
 //! Piezo Buzzer Component - Output
 //!
-//! Tone generation uses the Johnny-Five approach: OUTPUT mode + DigitalWrite
+//! Tone generation uses the Johnny-Five approach: OUTPUT mode + `DigitalWrite`
 //! toggling at the note's half-period to produce a square wave at the desired
-//! frequency. The toggling runs on the Firmata reader thread (via BoardCommand::Tone)
+//! frequency. The toggling runs on the Firmata reader thread (via `BoardCommand::Tone`)
 //! for tight timing with direct serial access — no channel overhead per toggle.
 
 use crate::runtime::base::{
@@ -83,7 +83,7 @@ fn note_frequencies() -> HashMap<&'static str, u16> {
 }
 
 /// Convert frequency (Hz) to half-period (microseconds).
-/// J5 approach: tone = round((1/freq) / 2 * 1_000_000)
+/// J5 approach: tone = round((1/freq) / 2 * `1_000_000`)
 fn hz_to_half_period_us(freq: u16) -> u32 {
     if freq == 0 { return 0; }
     500_000 / u32::from(freq)

--- a/apps/web/src/components/flow/nodes/_base/_base.tsx
+++ b/apps/web/src/components/flow/nodes/_base/_base.tsx
@@ -145,8 +145,15 @@ export const useNodeControls = <
     [id, getNode, onNodesChange, updateNodeInternals],
   );
 
+  // Defer the Leva → node sync so that any setNodeData() calls made from
+  // onChange callbacks (which fire synchronously before this effect) have
+  // time to commit through the Yjs → ReactFlow cycle first.  Without the
+  // deferral, getNode(id) inside updateNodeData reads stale data and the
+  // merge silently drops fields that were just set by onChange/setNodeData.
   useEffect(() => {
-    updateNodeData(controlsData as Data);
+    requestAnimationFrame(() => {
+      updateNodeData(controlsData as Data);
+    });
   }, [controlsData]);
 
   /**

--- a/apps/web/src/components/flow/nodes/piezo/piezo.constants.ts
+++ b/apps/web/src/components/flow/nodes/piezo/piezo.constants.ts
@@ -110,23 +110,40 @@ export const NOTE_DURATION = {
 export const DEFAULT_NOTE = "C4";
 export const DEFAULT_NOTE_DURATION = NOTE_DURATION.Quarter;
 
+// "Never Gonna Give You Up" - Rick Astley (chorus melody, 113 BPM)
 export const DEFAULT_SONG: [string | null, number][] = [
-  ["C4", NOTE_DURATION.Quarter],
-  ["D4", NOTE_DURATION.Quarter],
-  ["F4", NOTE_DURATION.Quarter],
-  ["D4", NOTE_DURATION.Quarter],
+  // "Never gonna"
   ["A4", NOTE_DURATION.Quarter],
-  [null, NOTE_DURATION.Quarter],
-  ["A4", NOTE_DURATION.Whole],
-  ["G4", NOTE_DURATION.Whole],
-  [null, NOTE_DURATION.Half],
-  ["C4", NOTE_DURATION.Quarter],
-  ["D4", NOTE_DURATION.Quarter],
-  ["F4", NOTE_DURATION.Quarter],
-  ["D4", NOTE_DURATION.Quarter],
-  ["G4", NOTE_DURATION.Quarter],
-  [null, NOTE_DURATION.Quarter],
-  ["G4", NOTE_DURATION.Whole],
-  ["F4", NOTE_DURATION.Whole],
-  [null, NOTE_DURATION.Half],
+  ["B4", NOTE_DURATION.Quarter],
+  ["D5", NOTE_DURATION.Quarter],
+  ["B4", NOTE_DURATION.Quarter],
+  // "give you up"
+  ["F#5", NOTE_DURATION.Half],
+  ["F#5", NOTE_DURATION.Half],
+  ["E5", NOTE_DURATION.Whole],
+  // "Never gonna"
+  ["A4", NOTE_DURATION.Quarter],
+  ["B4", NOTE_DURATION.Quarter],
+  ["D5", NOTE_DURATION.Quarter],
+  ["B4", NOTE_DURATION.Quarter],
+  // "let you down"
+  ["E5", NOTE_DURATION.Half],
+  ["E5", NOTE_DURATION.Half],
+  ["D5", NOTE_DURATION.Half],
+  ["C#5", NOTE_DURATION.Quarter],
+  ["B4", NOTE_DURATION.Quarter],
+  // "Never gonna"
+  ["A4", NOTE_DURATION.Quarter],
+  ["B4", NOTE_DURATION.Quarter],
+  ["D5", NOTE_DURATION.Quarter],
+  ["B4", NOTE_DURATION.Quarter],
+  // "run around and"
+  ["D5", NOTE_DURATION.Half],
+  ["E5", NOTE_DURATION.Half],
+  ["C#5", NOTE_DURATION.Half],
+  ["A4", NOTE_DURATION.Quarter],
+  // "desert you"
+  ["A4", NOTE_DURATION.Quarter],
+  ["E5", NOTE_DURATION.Half],
+  ["D5", NOTE_DURATION.Whole],
 ];

--- a/apps/web/src/components/flow/nodes/piezo/piezo.schema.ts
+++ b/apps/web/src/components/flow/nodes/piezo/piezo.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { baseDataSchema } from "../_base/_base.schema";
+import { DEFAULT_SONG } from "./piezo.constants";
 
 export const valueSchema = z.boolean();
 export type Value = z.infer<typeof valueSchema>;
@@ -17,8 +18,8 @@ const noteSchema = z.tuple([z.string().nullable(), z.number()]);
 const songDataSchema = baseDataSchema.extend({
   instance: z.literal("Piezo").default("Piezo"),
   type: z.literal("song").default("song"),
-  song: z.array(noteSchema).default([]),
-  tempo: z.number().default(120),
+  song: z.array(noteSchema).default(DEFAULT_SONG),
+  tempo: z.number().default(113),
   pin: z.number().default(11),
 });
 

--- a/apps/web/src/components/flow/nodes/piezo/piezo.tsx
+++ b/apps/web/src/components/flow/nodes/piezo/piezo.tsx
@@ -2,7 +2,6 @@ import { button, folder } from "leva";
 import { Handle } from "../../handle";
 import {
   NodeContainer,
-  useDeleteHandles,
   useNodeControls,
   useNodeData,
   type BaseNode,
@@ -62,8 +61,6 @@ function Settings() {
   const data = useNodeData<Data>();
   const pins = usePins([MODES.INPUT, MODES.PWM]);
   const [editorOpened, setEditorOpened] = useState(false);
-  const deleteHandles = useDeleteHandles();
-
   const { render, setNodeData } = useNodeControls<Data>(
     {
       pin: { options: pins.reduce(reducePinsToOptions, {}), value: data.pin },
@@ -72,11 +69,11 @@ function Settings() {
         value: data.type,
         transient: false,
         onChange: (event) => {
-          deleteHandles(event === "song" ? ["trigger"] : ["trigger"]);
           setNodeData({
             ...data,
             type: event,
-            tempo: event === "song" ? 120 : undefined,
+            tempo: event === "song" ? 113 : undefined,
+            song: event === "song" ? ((data as SongData).song?.length ? (data as SongData).song : DEFAULT_SONG) : undefined,
             duration: event === "buzz" ? 500 : undefined,
           });
         },
@@ -100,13 +97,13 @@ function Settings() {
           render: (get) => get("type") === "buzz",
         }
       ),
-      song: folder(
+      songSettings: folder(
         {
           tempo: {
             min: 40,
             max: 240,
-            step: 10,
-            value: (data as SongData).tempo ?? 120,
+            step: 1,
+            value: (data as SongData).tempo ?? 113,
           },
           "edit song": button(() => setEditorOpened(true)),
         },


### PR DESCRIPTION
This pull request introduces a major refactor to the piezo buzzer (tone generation) system, moving from PWM-based analog writes to precise digital pin toggling for tone generation, and adds robust cancellation support for both single buzzes and song playback. The changes ensure more accurate and responsive tone output, tighter timing, and better handling of user-initiated stops. Additionally, there are minor improvements to event handling and node control synchronization.

**Key changes:**

### Tone Generation & Cancellation (Piezo, Board, and Runtime)
- Switched the piezo output from using `AnalogWrite` (PWM) to toggling the pin in `OUTPUT` mode at the desired frequency, following the Johnny-Five (J5) approach. Tone generation is now performed on the Firmata reader thread for precise timing, with new `BoardCommand::Tone` and `BoardCommand::NoTone` commands. (`apps/web/src-tauri/src/runtime/base.rs`, `apps/web/src-tauri/src/runtime/output/piezo.rs`) [[1]](diffhunk://#diff-3487ab5b81c000e350db0de770cca966fea6f4d0573a4f6628079e14ba151093R440-R444) [[2]](diffhunk://#diff-e8d85035099b5c4004d4e48b34049a8d4f33faf1914e78537533c0f3945cf6a3R2-R6) [[3]](diffhunk://#diff-e8d85035099b5c4004d4e48b34049a8d4f33faf1914e78537533c0f3945cf6a3L41-R166) [[4]](diffhunk://#diff-e8d85035099b5c4004d4e48b34049a8d4f33faf1914e78537533c0f3945cf6a3L227-L236)
- Added a cancellation flag (`tone_cancel` in `BoardHandle` and `cancel_token` in `Piezo`) to allow in-progress tones and song playback to be interrupted cleanly, preventing stale events and ensuring responsive stop behavior. (`apps/web/src-tauri/src/runtime/base.rs`, `apps/web/src-tauri/src/runtime/output/piezo.rs`) [[1]](diffhunk://#diff-3487ab5b81c000e350db0de770cca966fea6f4d0573a4f6628079e14ba151093R213-R215) [[2]](diffhunk://#diff-3487ab5b81c000e350db0de770cca966fea6f4d0573a4f6628079e14ba151093R226) [[3]](diffhunk://#diff-e8d85035099b5c4004d4e48b34049a8d4f33faf1914e78537533c0f3945cf6a3L41-R166) [[4]](diffhunk://#diff-e8d85035099b5c4004d4e48b34049a8d4f33faf1914e78537533c0f3945cf6a3L152-R183) [[5]](diffhunk://#diff-e8d85035099b5c4004d4e48b34049a8d4f33faf1914e78537533c0f3945cf6a3R197-R271)
- Refactored song playback to issue a `Tone` command for each note and check for cancellation between notes and during note playback, allowing for immediate interruption. (`apps/web/src-tauri/src/runtime/output/piezo.rs`)

### Board Command and Connection Enhancements
- Added `Tone` and `NoTone` variants to `BoardCommand`, and corresponding methods to `BoardConnection` for direct digital toggling with cancellation support. (`apps/web/src-tauri/src/runtime/base.rs`) [[1]](diffhunk://#diff-3487ab5b81c000e350db0de770cca966fea6f4d0573a4f6628079e14ba151093R440-R444) [[2]](diffhunk://#diff-3487ab5b81c000e350db0de770cca966fea6f4d0573a4f6628079e14ba151093R523-R562) [[3]](diffhunk://#diff-3487ab5b81c000e350db0de770cca966fea6f4d0573a4f6628079e14ba151093R289-R296)

### Event Handling Improvements
- Adjusted the order of event value synchronization in `FlowExecutor` to occur after handling internal events, ensuring that auto-stop events and change detection work correctly for components emitting from background threads. (`apps/web/src-tauri/src/runtime/executor.rs`) [[1]](diffhunk://#diff-afc78649da768e3fe64901906bd881bc0bdc7314bb8088e8554427af7ae60a0bL202-L209) [[2]](diffhunk://#diff-afc78649da768e3fe64901906bd881bc0bdc7314bb8088e8554427af7ae60a0bR217-R228)

### User Interface Synchronization
- Improved node control synchronization in the React frontend by deferring updates to ensure that data set by onChange callbacks is not overwritten by stale values, fixing a race condition in node data updates. (`apps/web/src/components/flow/nodes/_base/_base.tsx`)