### PR TITLE
fix(auto-updater): call the updater on tauri

### DIFF
--- a/apps/web/src/hooks/use-updater.ts
+++ b/apps/web/src/hooks/use-updater.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { check, type Update } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
+import { isDesktop } from '@/lib/platform';
 
 type UpdateStatus = 'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'error';
 
@@ -45,14 +46,17 @@ export function useUpdater() {
     setState(s => ({ ...s, status: 'downloading', progress: 0 }));
 
     try {
+      let contentLength = 0;
+      let downloaded = 0;
+
       await state.update.downloadAndInstall((event) => {
-        if (event.event === 'Started' && event.data.contentLength) {
+        if (event.event === 'Started') {
+          contentLength = event.data.contentLength ?? 0;
           setState(s => ({ ...s, progress: 0 }));
         } else if (event.event === 'Progress') {
-          setState(s => ({
-            ...s,
-            progress: Math.round((event.data.chunkLength / (event.data.contentLength || 1)) * 100),
-          }));
+          downloaded += event.data.chunkLength;
+          const percent = contentLength > 0 ? Math.round((downloaded / contentLength) * 100) : 0;
+          setState(s => ({ ...s, progress: percent }));
         } else if (event.event === 'Finished') {
           setState(s => ({ ...s, status: 'ready', progress: 100 }));
         }
@@ -69,9 +73,9 @@ export function useUpdater() {
     await relaunch();
   }, []);
 
-  // Check for updates on mount (only in production)
+  // Check for updates on mount (only in Tauri desktop + production)
   useEffect(() => {
-    if (import.meta.env.PROD) {
+    if (isDesktop() && import.meta.env.PROD) {
       checkForUpdates();
     }
   }, [checkForUpdates]);

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -21,6 +21,7 @@ import { useBoardEvents } from "@/stores/board";
 import { useComponentEvents } from "@/hooks/use-component-events";
 import { useMqttSync } from "@/hooks/use-mqtt-sync";
 import { useLlmSync } from "@/hooks/use-llm-sync";
+import { useUpdater } from "@/hooks/use-updater";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
@@ -87,5 +88,6 @@ function Board() {
   useComponentEvents();
   useMqttSync();
   useLlmSync();
+  useUpdater();
   return null;
 }


### PR DESCRIPTION
This pull request enhances the update handling logic for the Tauri desktop app and integrates the updater hook into the main application. The most significant changes are improvements to progress tracking during updates and ensuring the updater only runs in the appropriate environment.

**Updater logic improvements:**

* Improved progress calculation in the `useUpdater` hook by accurately tracking the total content length and downloaded bytes, resulting in more precise progress reporting during updates.
* The updater now only checks for updates when running in the Tauri desktop environment and in production, preventing unnecessary update checks in other environments. [[1]](diffhunk://#diff-665a315f9c324affaf6162c4e06487c603dc837961234fb00d9fa810acbc3440R4) [[2]](diffhunk://#diff-665a315f9c324affaf6162c4e06487c603dc837961234fb00d9fa810acbc3440L72-R78)

**Integration:**

* Registered the `useUpdater` hook in the main `Board` component, ensuring the update logic is initialized when the app loads. [[1]](diffhunk://#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100R24) [[2]](diffhunk://#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100R91)