### PR TITLE
fix(figma): some figma variables stability improvements

### DIFF
--- a/apps/figma-plugin/src/ui/components/MqttVariableMessenger.ts
+++ b/apps/figma-plugin/src/ui/components/MqttVariableMessenger.ts
@@ -13,18 +13,29 @@ import { useMessageListener } from "../hooks/use-message-listener";
 /**
  * Headless component that bridges MQTT messages ↔ Figma variables.
  *
- * Improvements over prototype:
- * - Poll interval raised from 100ms → 250ms (less CPU, still responsive)
- * - Ref-based dedup to avoid redundant publishes
- * - Cleaner subscription lifecycle
+ * - Polls Figma sandbox for variable changes every 250ms
+ * - Publishes variable list (retained) and individual values via MQTT
+ * - Responds to variable requests from other clients
+ * - Handles inbound set commands
+ * - Resets dedup caches on reconnect so state is always re-published
  */
 export function MqttVariableMessenger() {
   const { status, publish, subscribe, uniqueId } = useMqttStore();
   const publishedValues = useRef<Map<string, string>>(new Map());
   const knownVariables = useRef<Record<string, PickedVariable>>({});
+  const prevStatus = useRef(status);
+
+  // Reset dedup caches when MQTT reconnects so everything gets re-published
+  useEffect(() => {
+    if (status === "connected" && prevStatus.current !== "connected") {
+      knownVariables.current = {};
+      publishedValues.current.clear();
+    }
+    prevStatus.current = status;
+  }, [status]);
 
   function publishVariables(variables?: FullVariable[]) {
-    if (!variables) return;
+    if (!variables || status !== "connected") return;
 
     const newVars: Record<string, PickedVariable> = {};
     for (const v of variables) {
@@ -33,7 +44,8 @@ export function MqttVariableMessenger() {
 
     const newJson = JSON.stringify(newVars);
     if (newJson !== JSON.stringify(knownVariables.current)) {
-      publish(`microflow/${uniqueId}/figma/variables`, newJson);
+      // Retain the variables list so late-joining subscribers get it immediately
+      publish(`microflow/${uniqueId}/figma/variables`, newJson, { retain: true });
     }
     knownVariables.current = newVars;
 

--- a/apps/penpot-plugin/src/ui/components/MqttVariableMessenger.ts
+++ b/apps/penpot-plugin/src/ui/components/MqttVariableMessenger.ts
@@ -16,17 +16,28 @@ import { useMessageListener } from "../hooks/use-message-listener";
  * Penpot's design token terminology and path-based IDs.
  *
  * - Polls sandbox for token changes at 250ms interval
- * - Publishes token list and individual values to MQTT
+ * - Publishes token list (retained) and individual values to MQTT
  * - Subscribes to inbound set commands and variable requests
  * - Deduplicates publishes using a ref-based value cache
+ * - Resets dedup caches on reconnect so state is always re-published
  */
 export function MqttVariableMessenger() {
   const { status, publish, subscribe, uniqueId } = useMqttStore();
   const publishedValues = useRef<Map<string, string>>(new Map());
   const knownTokens = useRef<Record<string, { path: string; name: string; type: string }>>({});
+  const prevStatus = useRef(status);
+
+  // Reset dedup caches when MQTT reconnects so everything gets re-published
+  useEffect(() => {
+    if (status === "connected" && prevStatus.current !== "connected") {
+      knownTokens.current = {};
+      publishedValues.current.clear();
+    }
+    prevStatus.current = status;
+  }, [status]);
 
   function publishTokens(tokens?: DesignToken[]) {
-    if (!tokens) return;
+    if (!tokens || status !== "connected") return;
 
     const newMap: Record<string, { path: string; name: string; type: string }> = {};
     for (const t of tokens) {
@@ -35,7 +46,8 @@ export function MqttVariableMessenger() {
 
     const newJson = JSON.stringify(newMap);
     if (newJson !== JSON.stringify(knownTokens.current)) {
-      publish(`microflow/${uniqueId}/penpot/variables`, newJson);
+      // Retain the token list so late-joining subscribers get it immediately
+      publish(`microflow/${uniqueId}/penpot/variables`, newJson, { retain: true });
     }
     knownTokens.current = newMap;
 

--- a/apps/web/src/stores/figma.ts
+++ b/apps/web/src/stores/figma.ts
@@ -72,6 +72,8 @@ export function useFigmaSync() {
   useEffect(() => {
     if (!isDesktop() || !brokerId) return;
 
+    let cancelled = false;
+
     // Only the topics the frontend needs: variables list + connection status
     const topics = [
       `microflow/${uniqueId}/figma/variables`,
@@ -79,13 +81,18 @@ export function useFigmaSync() {
       `microflow/${uniqueId}/app/variables/response`,
     ];
 
-    Promise.all(topics.map((t) => subscribeToTopic(brokerId, t))).then(() => {
+    function requestVariables() {
+      if (cancelled) return;
       invokeCommand({
         type: "mqtt_publish",
-        brokerId,
+        brokerId: brokerId!,
         topic: `microflow/${uniqueId}/app/variables/request`,
         payload: "",
       });
+    }
+
+    Promise.all(topics.map((t) => subscribeToTopic(brokerId, t))).then(() => {
+      requestVariables();
     });
 
     invokeCommand({
@@ -96,7 +103,19 @@ export function useFigmaSync() {
       retain: true,
     });
 
+    // Re-request variables periodically until we have them.
+    // The plugin may not be connected yet when we first subscribe,
+    // and retained messages may not be available. Once we have
+    // variables the interval is cheap (plugin deduplicates responses).
+    const retryId = setInterval(() => {
+      const { variables, pluginConnected } = useFigmaStore.getState();
+      if (pluginConnected && Object.keys(variables).length > 0) return;
+      requestVariables();
+    }, 3000);
+
     return () => {
+      cancelled = true;
+      clearInterval(retryId);
       topics.forEach((t) => unsubscribeFromTopic(brokerId, t));
       invokeCommand({
         type: "mqtt_publish",
@@ -111,11 +130,12 @@ export function useFigmaSync() {
   const handleMessage = useCallback(
     (event: { payload: MqttMessagePayload }) => {
       const { topic, payload } = event.payload;
+      const { uniqueId: currentId } = useFigmaStore.getState();
       const { setVariables, setPluginConnected } = useFigmaStore.getState();
 
       if (
-        topic === `microflow/${uniqueId}/figma/variables` ||
-        topic === `microflow/${uniqueId}/app/variables/response`
+        topic === `microflow/${currentId}/figma/variables` ||
+        topic === `microflow/${currentId}/app/variables/response`
       ) {
         try {
           setVariables(JSON.parse(payload) as Record<string, PickedVariable>);
@@ -123,11 +143,11 @@ export function useFigmaSync() {
         return;
       }
 
-      if (topic === `microflow/${uniqueId}/figma/status`) {
+      if (topic === `microflow/${currentId}/figma/status`) {
         setPluginConnected(payload === "connected");
       }
     },
-    [uniqueId],
+    [],
   );
 
   useEffect(() => {


### PR DESCRIPTION
This pull request improves the reliability and robustness of MQTT-based variable/token synchronization between the Figma/Penpot plugins and the web app. The main changes ensure that state is always up-to-date after reconnects, late subscribers receive the latest data, and the web app persistently requests variables until they are available.

**Plugin-side improvements (Figma & Penpot):**

- **Deduplication and state reset on reconnect:**  
  The plugins now reset their deduplication caches (`knownVariables`/`knownTokens` and `publishedValues`) whenever MQTT reconnects, ensuring that all state is re-published and up-to-date after a connection drop. [[1]](diffhunk://#diff-09810657d84f2c6ada787f3b8ef1272e9868a9d3e46ce56a3b728b14ec2af9dcL16-R38) [[2]](diffhunk://#diff-0d1f19a2894f9e02d315115b4d1f6f4a19fb455fb9c8e42225863e7e892f9e9eL19-R40)
- **Retained variable/token list publishing:**  
  The plugins publish the variable/token list with the MQTT "retain" flag, so late-joining subscribers immediately receive the current state. [[1]](diffhunk://#diff-09810657d84f2c6ada787f3b8ef1272e9868a9d3e46ce56a3b728b14ec2af9dcL36-R48) [[2]](diffhunk://#diff-0d1f19a2894f9e02d315115b4d1f6f4a19fb455fb9c8e42225863e7e892f9e9eL38-R50)

**Web app improvements (Figma sync):**

- **Persistent variable requests:**  
  The web app now periodically re-requests variables from the plugin every 3 seconds until it receives them, handling cases where the plugin isn't connected or retained messages aren't available yet.
- **Topic subscription and message handling fixes:**  
  - Ensures topic subscriptions and requests are only made when appropriate, and cleans up properly on unmount. [[1]](diffhunk://#diff-13ab15647b51e950f386275547ee854abad2cc906d847922b4b96bbbbb14f071R75-R95) [[2]](diffhunk://#diff-13ab15647b51e950f386275547ee854abad2cc906d847922b4b96bbbbb14f071R106-R118)
  - Handles messages using the current `uniqueId` from store state, preventing issues if the value changes during the session.

These changes make the synchronization between plugins and the web app more robust, especially in the face of reconnects, late joins, and variable network conditions.