### PR TITLE
feat(codegen): emit core hardware-IO Nodes to C++ (#41)

### DIFF
--- a/apps/web/src-tauri/src/codegen/emit.rs
+++ b/apps/web/src-tauri/src/codegen/emit.rs
@@ -1,0 +1,143 @@
+//! Shared emitter contract for per-Node C++ emission.
+//!
+//! Each supported core hardware-IO Node contributes C++ fragments into the
+//! sketch regions produced by the skeleton (Task 1): the include block, the
+//! global declarations region, `setup()`, and `loop()`. An emitter is a pure
+//! function of a single [`FlowNode`] — it reads the Node's `data` field (the
+//! same `data` the live runtime deserializes into its `*Config`) and returns a
+//! [`NodeEmission`]. No clock, no hashmap iteration, no board IO: identical
+//! input always yields identical output.
+
+use crate::runtime::types::FlowNode;
+
+/// C++ fragments a single Node contributes to the assembled sketch.
+///
+/// Every field is optional in spirit — an emitter only fills the regions it
+/// needs. `mod.rs` concatenates these across all Nodes in deterministic
+/// traversal order.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct NodeEmission {
+    /// Lines for the top-of-file include block (e.g. `#include <Servo.h>`).
+    /// De-duplicated by the assembler so repeated Node types include once.
+    pub includes: Vec<String>,
+    /// Global declaration lines (e.g. `const uint8_t led_13_pin = 13;`).
+    pub declarations: Vec<String>,
+    /// Statements emitted inside `setup()` (e.g. `pinMode(...)`).
+    pub setup: Vec<String>,
+    /// Statements emitted inside `loop()` (read/write logic).
+    pub loop_body: Vec<String>,
+}
+
+impl NodeEmission {
+    /// True when the Node produced no C++ at all (unsupported / skipped).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.includes.is_empty()
+            && self.declarations.is_empty()
+            && self.setup.is_empty()
+            && self.loop_body.is_empty()
+    }
+}
+
+/// Extension methods for turning Flow read-model types into C++-safe tokens.
+pub trait NodeToken {
+    /// A C++-identifier-safe token derived from the Node `id`. Flow ids may
+    /// contain hyphens or other punctuation (e.g. `led-1`); every non
+    /// alphanumeric character is replaced with `_` so the token can be used in
+    /// variable names. Deterministic for a given id.
+    fn id_token(&self) -> String;
+}
+
+impl NodeToken for FlowNode {
+    fn id_token(&self) -> String {
+        self.id
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+            .collect()
+    }
+}
+
+/// Read a pin from a Node's `data`, accepting either a JSON number (`13`) or a
+/// numeric/`"A0"`-style string, mirroring the live runtime's lenient pin
+/// deserialization. Returns `default` when the field is missing or unparseable
+/// so emission never produces uncompilable code for a malformed Node.
+#[must_use]
+pub fn pin_or_default(node: &FlowNode, default: u8) -> u8 {
+    let Some(value) = node.data.get("pin") else {
+        return default;
+    };
+    if let Some(n) = value.as_u64() {
+        return u8::try_from(n).unwrap_or(default);
+    }
+    if let Some(s) = value.as_str() {
+        let digits = s.strip_prefix(['A', 'a']).unwrap_or(s);
+        return digits.parse().unwrap_or(default);
+    }
+    default
+}
+
+/// Read a boolean flag from a Node's `data`, defaulting to `false`.
+#[must_use]
+pub fn bool_flag(node: &FlowNode, key: &str) -> bool {
+    node.data.get(key).and_then(serde_json::Value::as_bool).unwrap_or(false)
+}
+
+/// Read a `u16` from a Node's `data`, falling back to `default`.
+#[must_use]
+pub fn u16_or_default(node: &FlowNode, key: &str, default: u16) -> u16 {
+    node.data
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|n| u16::try_from(n).ok())
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn node_with(data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: "n".to_string(),
+            node_type: Some("Led".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn pin_reads_numeric_value() {
+        assert_eq!(pin_or_default(&node_with(json!({ "pin": 9 })), 13), 9);
+    }
+
+    #[test]
+    fn pin_reads_string_value() {
+        assert_eq!(pin_or_default(&node_with(json!({ "pin": "14" })), 0), 14);
+    }
+
+    #[test]
+    fn pin_reads_legacy_analog_string() {
+        assert_eq!(pin_or_default(&node_with(json!({ "pin": "A0" })), 99), 0);
+    }
+
+    #[test]
+    fn pin_falls_back_when_missing_or_invalid() {
+        assert_eq!(pin_or_default(&node_with(json!({})), 13), 13);
+        assert_eq!(pin_or_default(&node_with(json!({ "pin": "xyz" })), 7), 7);
+    }
+
+    #[test]
+    fn id_token_sanitizes_punctuation() {
+        let n = node_with(json!({}));
+        let mut hyphenated = n.clone();
+        hyphenated.id = "led-1".to_string();
+        assert_eq!(hyphenated.id_token(), "led_1");
+    }
+
+    #[test]
+    fn empty_emission_is_empty() {
+        assert!(NodeEmission::default().is_empty());
+    }
+}

--- a/apps/web/src-tauri/src/codegen/input/button.rs
+++ b/apps/web/src-tauri/src/codegen/input/button.rs
@@ -1,0 +1,91 @@
+//! Button emitter — mirrors `runtime/input/button.rs`.
+//!
+//! The live Button sets `pinMode(pin, PULLUP)` when `isPullup` is set, else
+//! `pinMode(pin, INPUT)`, and reports digital reads. The generated sketch emits
+//! the matching pin mode and a `digitalRead` in `loop()` stored into a `bool`
+//! state variable that downstream Nodes (e.g. a wired Led) read. With
+//! `INPUT_PULLUP` the raw read is active-low; the runtime treats a press as a
+//! logical true, so the emitted state inverts the pull-up read to match.
+
+use crate::codegen::emit::{bool_flag, pin_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default pin matches `runtime/input/button.rs::default_pin` (6).
+const DEFAULT_PIN: u8 = 6;
+
+/// The C++ `bool` variable name holding this Button's current pressed state.
+/// Downstream emitters reference it as their driver expression.
+#[must_use]
+pub fn state_var(node: &FlowNode) -> String {
+    format!("button_{}_state", node.id_token())
+}
+
+/// Emit C++ for a Button Node.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let pin = pin_or_default(node, DEFAULT_PIN);
+    let pin_var = format!("button_{}_pin", node.id_token());
+    let state = state_var(node);
+    let pullup = bool_flag(node, "isPullup");
+
+    let mode = if pullup { "INPUT_PULLUP" } else { "INPUT" };
+    // With INPUT_PULLUP a pressed button reads LOW, so invert to a logical
+    // "pressed = true" to match the runtime's semantics.
+    let read_expr = if pullup {
+        format!("(digitalRead({pin_var}) == LOW)")
+    } else {
+        format!("(digitalRead({pin_var}) == HIGH)")
+    };
+
+    NodeEmission {
+        declarations: vec![
+            format!("const uint8_t {pin_var} = {pin};"),
+            format!("bool {state} = false;"),
+        ],
+        setup: vec![format!("pinMode({pin_var}, {mode});")],
+        loop_body: vec![format!("{state} = {read_expr};")],
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn button(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Button".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn button_input_mode_and_reads() {
+        let e = emit(&button("btn-1", json!({ "pin": 6 })));
+        assert!(e.setup.iter().any(|s| s.contains("pinMode") && s.contains("INPUT") && !s.contains("PULLUP")));
+        assert!(e.loop_body.iter().any(|l| l.contains("digitalRead")));
+    }
+
+    #[test]
+    fn button_pullup_mode_inverts_read() {
+        let e = emit(&button("btn-1", json!({ "pin": 6, "isPullup": true })));
+        assert!(e.setup.iter().any(|s| s.contains("INPUT_PULLUP")));
+        assert!(e.loop_body.iter().any(|l| l.contains("LOW")));
+    }
+
+    #[test]
+    fn button_uses_default_pin() {
+        let e = emit(&button("btn-1", json!({})));
+        assert!(e.declarations.iter().any(|d| d.contains("= 6;")));
+    }
+
+    #[test]
+    fn button_emits_deterministically() {
+        let n = button("btn-1", json!({ "pin": 6 }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/input/mod.rs
+++ b/apps/web/src-tauri/src/codegen/input/mod.rs
@@ -1,0 +1,5 @@
+//! Input-Node C++ emitters (Button, Sensor) — the codegen mirror of
+//! `runtime/input`.
+
+pub mod button;
+pub mod sensor;

--- a/apps/web/src-tauri/src/codegen/input/sensor.rs
+++ b/apps/web/src-tauri/src/codegen/input/sensor.rs
@@ -1,0 +1,72 @@
+//! Sensor emitter — mirrors `runtime/input/sensor.rs`.
+//!
+//! The live Sensor sets the ANALOG pin mode and reports `analogRead` values.
+//! Its pin is stored as a string (`"A0"` or a numeric pin) and resolved to a
+//! numeric pin via `analog_pin()`. The generated sketch declares the analog pin
+//! and stores `analogRead(pin)` into an `int` state variable each loop, which
+//! downstream Nodes read.
+
+use crate::codegen::emit::{pin_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default analog pin matches `runtime/input/sensor.rs` (`"A0"` => 0).
+const DEFAULT_PIN: u8 = 0;
+
+/// The C++ `int` variable name holding this Sensor's latest reading.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("sensor_{}_value", node.id_token())
+}
+
+/// Emit C++ for a Sensor Node.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let pin = pin_or_default(node, DEFAULT_PIN);
+    let pin_var = format!("sensor_{}_pin", node.id_token());
+    let value = value_var(node);
+
+    NodeEmission {
+        declarations: vec![
+            format!("const uint8_t {pin_var} = A{pin};"),
+            format!("int {value} = 0;"),
+        ],
+        setup: vec![format!("pinMode({pin_var}, INPUT);")],
+        loop_body: vec![format!("{value} = analogRead({pin_var});")],
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn sensor(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Sensor".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn sensor_reads_analog_pin() {
+        let e = emit(&sensor("s-1", json!({ "pin": "A0" })));
+        assert!(e.loop_body.iter().any(|l| l.contains("analogRead")));
+        assert!(e.declarations.iter().any(|d| d.contains("A0")));
+    }
+
+    #[test]
+    fn sensor_resolves_numeric_pin() {
+        let e = emit(&sensor("s-1", json!({ "pin": "2" })));
+        assert!(e.declarations.iter().any(|d| d.contains("A2")));
+    }
+
+    #[test]
+    fn sensor_emits_deterministically() {
+        let n = sensor("s-1", json!({ "pin": "A0" }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/mod.rs
+++ b/apps/web/src-tauri/src/codegen/mod.rs
@@ -21,7 +21,12 @@
 //! - **Validity:** the output is always syntactically valid Arduino C++ and
 //!   compiles even when the Flow is empty.
 
+pub mod emit;
+pub mod input;
+pub mod output;
+
 use crate::runtime::types::{FlowNode, FlowUpdate};
+use emit::NodeEmission;
 use std::collections::{BTreeMap, BTreeSet};
 
 /// Assemble the Arduino sketch skeleton for the given Flow.
@@ -37,12 +42,24 @@ use std::collections::{BTreeMap, BTreeSet};
 /// the frontend without changing the contract.
 pub fn generate(flow: &FlowUpdate) -> Result<String, String> {
     let order = traversal_order(flow);
+    let drivers = driver_expressions(flow);
+
+    // Emit each Node in deterministic traversal order, collecting fragments.
+    let emissions: Vec<NodeEmission> =
+        order.iter().map(|node| emit_node(node, &drivers)).collect();
+
+    let emitted_count = emissions.iter().filter(|e| !e.is_empty()).count();
+    log::debug!(
+        "codegen: emitted {emitted_count} of {} node(s)",
+        order.len()
+    );
 
     let mut sketch = String::new();
     sketch.push_str(&header(&order));
-    sketch.push_str(&declarations(&order));
-    sketch.push_str(SETUP);
-    sketch.push_str(LOOP);
+    sketch.push_str(&includes_region(&emissions));
+    sketch.push_str(&declarations(&order, &emissions));
+    sketch.push_str(&setup_region(&emissions));
+    sketch.push_str(&loop_region(&emissions));
 
     Ok(sketch)
 }
@@ -109,32 +126,136 @@ fn header(order: &[&FlowNode]) -> String {
     )
 }
 
-/// Declarations region. For the skeleton each Node contributes a stable comment
-/// slot (in traversal order) that later emitters replace with real declarations.
-fn declarations(order: &[&FlowNode]) -> String {
-    let mut out = String::from("// --- Declarations ---\n");
-    for node in order {
-        let kind = node.node_type.as_deref().unwrap_or("unknown");
-        out.push_str(&format!("// node {} ({})\n", node.id, kind));
+/// Dispatch a single Node to its per-type C++ emitter, mirroring the live
+/// `ComponentRegistry`. Node types outside the supported core hardware-IO set
+/// emit nothing here — graceful placeholders for them are Task 5's concern.
+/// `drivers` maps a target Node id to the C++ expression that drives it (from
+/// its wired source), so output Nodes write what their input reads.
+fn emit_node(node: &FlowNode, drivers: &BTreeMap<&str, String>) -> NodeEmission {
+    let driver = drivers.get(node.id.as_str()).map(String::as_str);
+    match node.node_type.as_deref() {
+        Some("Led") => output::led::emit(node, driver),
+        Some("Relay") => output::relay::emit(node, driver),
+        Some("Servo") => output::servo::emit(node, driver),
+        Some("Button") => input::button::emit(node),
+        Some("Sensor") => input::sensor::emit(node),
+        _ => NodeEmission::default(),
+    }
+}
+
+/// Build the map from a target Node id to the C++ expression that drives it.
+///
+/// An output Node (Led/Relay/Servo) wired from an input Node (Button/Sensor)
+/// reads that input's state/value variable. When a target has multiple incoming
+/// edges, the source with the smallest id wins, keeping the result
+/// deterministic. Edges from sources that expose no readable expression are
+/// ignored.
+fn driver_expressions(flow: &FlowUpdate) -> BTreeMap<&str, String> {
+    let by_id: BTreeMap<&str, &FlowNode> =
+        flow.nodes.iter().map(|n| (n.id.as_str(), n)).collect();
+
+    // For determinism, choose the smallest source id per target.
+    let mut chosen: BTreeMap<&str, &str> = BTreeMap::new();
+    for edge in &flow.edges {
+        let target = edge.target.as_str();
+        let source = edge.source.as_str();
+        chosen
+            .entry(target)
+            .and_modify(|s| {
+                if source < *s {
+                    *s = source;
+                }
+            })
+            .or_insert(source);
+    }
+
+    chosen
+        .into_iter()
+        .filter_map(|(target, source)| {
+            let src_node = by_id.get(source)?;
+            source_expression(src_node).map(|expr| (target, expr))
+        })
+        .collect()
+}
+
+/// The C++ expression a source Node exposes for downstream Nodes to read, or
+/// `None` if the Node type produces no readable value.
+fn source_expression(node: &FlowNode) -> Option<String> {
+    match node.node_type.as_deref() {
+        Some("Button") => Some(input::button::state_var(node)),
+        Some("Sensor") => Some(input::sensor::value_var(node)),
+        _ => None,
+    }
+}
+
+/// Deduplicated `#include` block, sorted for determinism.
+fn includes_region(emissions: &[NodeEmission]) -> String {
+    let includes: BTreeSet<&str> = emissions
+        .iter()
+        .flat_map(|e| e.includes.iter().map(String::as_str))
+        .collect();
+    if includes.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("// --- Includes ---\n");
+    for inc in includes {
+        out.push_str(inc);
+        out.push('\n');
     }
     out.push('\n');
     out
 }
 
-/// Empty-but-valid `setup()`. Per-Node init is hung off this in a later task.
-const SETUP: &str = "void setup() {\n  // --- Setup ---\n}\n\n";
+/// Declarations region. Each Node gets a labelled comment slot followed by its
+/// real declarations (in traversal order) so output is stable and readable.
+fn declarations(order: &[&FlowNode], emissions: &[NodeEmission]) -> String {
+    let mut out = String::from("// --- Declarations ---\n");
+    for (node, emission) in order.iter().zip(emissions) {
+        let kind = node.node_type.as_deref().unwrap_or("unknown");
+        out.push_str(&format!("// node {} ({})\n", node.id, kind));
+        for line in &emission.declarations {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out.push('\n');
+    out
+}
+
+/// `setup()` with each Node's init statements stitched in (traversal order).
+fn setup_region(emissions: &[NodeEmission]) -> String {
+    let mut out = String::from("void setup() {\n  // --- Setup ---\n");
+    for line in emissions.iter().flat_map(|e| &e.setup) {
+        out.push_str("  ");
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push_str("}\n\n");
+    out
+}
 
 /// Non-blocking, `millis()`-based scheduler `loop()`. It compares `millis()`
-/// against a per-tick deadline instead of calling blocking `delay()`, giving
-/// timing Nodes added later a deterministic, host-free model.
-const LOOP: &str = "void loop() {\n  \
+/// against a per-tick deadline instead of calling blocking `delay()`, giving a
+/// deterministic, host-free model. Per-Node read/write logic runs inside the
+/// scheduled-task block in traversal order.
+fn loop_region(emissions: &[NodeEmission]) -> String {
+    let mut out = String::from(
+        "void loop() {\n  \
 static unsigned long previousMillis = 0;\n  \
 const unsigned long interval = 1; // ms; non-blocking scheduler tick\n  \
 unsigned long currentMillis = millis();\n  \
 if (currentMillis - previousMillis >= interval) {\n    \
 previousMillis = currentMillis;\n    \
-// --- Scheduled tasks ---\n  \
-}\n}\n";
+// --- Scheduled tasks ---\n",
+    );
+    for line in emissions.iter().flat_map(|e| &e.loop_body) {
+        out.push_str("    ");
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push_str("  }\n}\n");
+    out
+}
 
 #[cfg(test)]
 mod tests {
@@ -147,6 +268,15 @@ mod tests {
             id: id.to_string(),
             node_type: Some(kind.to_string()),
             data: json!({}),
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    fn node_data(id: &str, kind: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some(kind.to_string()),
+            data,
             position: Position { x: 0.0, y: 0.0 },
         }
     }
@@ -246,5 +376,103 @@ mod tests {
         // the id-ordered seed loop).
         assert!(sketch.contains("// node lonely (Sensor)"), "disconnected node missing");
         assert_eq!(sketch.matches("// node ").count(), 3, "all nodes emitted once");
+    }
+
+    /// Scenario: A core hardware-IO Flow produces a compilable sketch.
+    ///
+    /// A Flow using all five supported Node types must emit pin setup and
+    /// read/write logic for each, inside a structurally valid sketch.
+    #[test]
+    fn core_hardware_io_flow_emits_setup_and_io_for_each_node() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+                node_data("btn-1", "Button", json!({ "pin": 6 })),
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data("servo-1", "Servo", json!({ "pin": 9 })),
+                node_data("relay-1", "Relay", json!({ "pin": 10 })),
+            ],
+            edges: vec![edge("btn-1", "led-1"), edge("sensor-1", "servo-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Structurally valid sketch.
+        assert!(sketch.contains("void setup()"));
+        assert!(sketch.contains("void loop()"));
+        assert!(!sketch.contains("delay("), "must stay non-blocking");
+
+        // Pin setup for each Node.
+        assert!(sketch.contains("pinMode") && sketch.contains("OUTPUT"), "led/relay OUTPUT setup");
+        assert!(sketch.contains("INPUT"), "button INPUT setup");
+        // Read/write logic present.
+        assert!(sketch.contains("digitalWrite"), "led/relay write");
+        assert!(sketch.contains("digitalRead"), "button read");
+        assert!(sketch.contains("analogRead"), "sensor read");
+        assert!(sketch.contains(".attach("), "servo attach");
+        assert!(sketch.contains("#include <Servo.h>"), "servo include");
+    }
+
+    /// Scenario: A Button drives a Led through an edge.
+    #[test]
+    fn button_drives_led_through_an_edge() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+                node_data("btn-1", "Button", json!({ "pin": 6 })),
+            ],
+            edges: vec![edge("btn-1", "led-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // The Button reads its input into a state var.
+        assert!(sketch.contains("button_btn_1_state = "), "button read into state var");
+        assert!(sketch.contains("digitalRead"), "button digitalRead");
+        // The Led writes that state.
+        assert!(
+            sketch.contains("digitalWrite(led_led_1_pin, (button_btn_1_state)"),
+            "led must be driven by the button state, got:\n{sketch}"
+        );
+    }
+
+    /// Scenario: A Servo Node pulls in its supporting library.
+    #[test]
+    fn servo_node_pulls_in_its_library() {
+        let flow = FlowUpdate {
+            nodes: vec![node_data("servo-1", "Servo", json!({ "pin": 9 }))],
+            edges: vec![],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        assert!(sketch.contains("#include <Servo.h>"), "missing Servo include");
+        assert!(sketch.contains("Servo servo_servo_1"), "missing Servo object decl");
+        assert!(sketch.contains(".attach(servo_servo_1_pin)"), "missing attach to pin");
+    }
+
+    /// The Servo include appears only when a Servo Node is present.
+    #[test]
+    fn no_servo_include_without_a_servo_node() {
+        let flow = FlowUpdate {
+            nodes: vec![node_data("led-1", "Led", json!({ "pin": 13 }))],
+            edges: vec![],
+        };
+        let sketch = generate(&flow).expect("generation should succeed");
+        assert!(!sketch.contains("Servo.h"), "no servo include without a servo node");
+    }
+
+    /// Scenario: Each supported Node type emits deterministic code — full Flow.
+    #[test]
+    fn full_flow_emits_deterministically() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+                node_data("btn-1", "Button", json!({ "pin": 6, "isPullup": true })),
+                node_data("servo-1", "Servo", json!({ "pin": 9 })),
+            ],
+            edges: vec![edge("btn-1", "led-1")],
+        };
+        assert_eq!(generate(&flow).unwrap(), generate(&flow).unwrap());
     }
 }

--- a/apps/web/src-tauri/src/codegen/output/led.rs
+++ b/apps/web/src-tauri/src/codegen/output/led.rs
@@ -1,0 +1,83 @@
+//! Led emitter — mirrors `runtime/output/led.rs`.
+//!
+//! The live Led sets `pinMode(pin, OUTPUT)` then `digitalWrite(pin, LOW)` on
+//! initialize (off by default). On/off drive `digitalWrite`; brightness drives
+//! `analogWrite` (PWM). The generated sketch emits the OUTPUT pin setup and a
+//! `digitalWrite` in `loop()` that reflects the wired source's state, matching
+//! the runtime's default-off behavior.
+
+use crate::codegen::emit::{pin_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default pin matches `runtime/output/led.rs::default_pin` (13).
+const DEFAULT_PIN: u8 = 13;
+
+/// Emit C++ for a Led Node. `driver` is the C++ boolean expression that drives
+/// the Led's state (from a wired input), or `None` for an unconnected Led which
+/// stays in its initialized-off state.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let pin = pin_or_default(node, DEFAULT_PIN);
+    let var = format!("led_{}_pin", node.id_token());
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("const uint8_t {var} = {pin};")],
+        setup: vec![
+            format!("pinMode({var}, OUTPUT);"),
+            // Mirror runtime initialize: start off.
+            format!("digitalWrite({var}, LOW);"),
+        ],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        e.loop_body
+            .push(format!("digitalWrite({var}, ({expr}) ? HIGH : LOW);"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn led(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Led".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    /// Scenario: Each supported Node type emits deterministic code.
+    #[test]
+    fn led_emits_deterministically() {
+        let n = led("led-1", json!({ "pin": 13 }));
+        let first = emit(&n, None);
+        let second = emit(&n, None);
+        assert_eq!(first, second, "same Led must emit identical C++ each time");
+    }
+
+    #[test]
+    fn led_sets_output_pin_mode_and_starts_off() {
+        let e = emit(&led("led-1", json!({ "pin": 8 })), None);
+        assert!(e.declarations.iter().any(|d| d.contains("= 8;")));
+        assert!(e.setup.iter().any(|s| s.contains("pinMode") && s.contains("OUTPUT")));
+        assert!(e.setup.iter().any(|s| s.contains("digitalWrite") && s.contains("LOW")));
+    }
+
+    #[test]
+    fn led_uses_default_pin_when_missing() {
+        let e = emit(&led("led-1", json!({})), None);
+        assert!(e.declarations.iter().any(|d| d.contains("= 13;")));
+    }
+
+    #[test]
+    fn led_writes_driver_expression_in_loop() {
+        let e = emit(&led("led-1", json!({ "pin": 5 })), Some("btn_6_state"));
+        assert!(e.loop_body.iter().any(|l| l.contains("digitalWrite") && l.contains("btn_6_state")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/output/mod.rs
+++ b/apps/web/src-tauri/src/codegen/output/mod.rs
@@ -1,0 +1,6 @@
+//! Output-Node C++ emitters (Led, Servo, Relay) — the codegen mirror of
+//! `runtime/output`.
+
+pub mod led;
+pub mod relay;
+pub mod servo;

--- a/apps/web/src-tauri/src/codegen/output/relay.rs
+++ b/apps/web/src-tauri/src/codegen/output/relay.rs
@@ -1,0 +1,96 @@
+//! Relay emitter — mirrors `runtime/output/relay.rs`.
+//!
+//! The live Relay sets `pinMode(pin, OUTPUT)` and starts closed. For a
+//! Normally-Open (NO) relay, "open" writes HIGH and "close" writes LOW; for a
+//! Normally-Closed (NC) relay the signal is inverted. The generated sketch
+//! emits the OUTPUT setup and, when driven, a `digitalWrite` that honours the
+//! relay type so emitted behavior matches the runtime.
+
+use crate::codegen::emit::{pin_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default pin matches `runtime/output/relay.rs::default_pin` (10).
+const DEFAULT_PIN: u8 = 10;
+
+/// True when the Node's `data.type` selects a Normally-Closed relay.
+fn is_normally_closed(node: &FlowNode) -> bool {
+    node.data
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|t| t.eq_ignore_ascii_case("NC"))
+}
+
+/// Emit C++ for a Relay Node. `driver` is the C++ boolean expression for the
+/// desired open/closed state (true = open), or `None` for an unconnected relay
+/// which stays in its initialized-closed state.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let pin = pin_or_default(node, DEFAULT_PIN);
+    let var = format!("relay_{}_pin", node.id_token());
+    // NO: open => HIGH; NC: open => LOW. Closing is the inverse.
+    let nc = is_normally_closed(node);
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("const uint8_t {var} = {pin};")],
+        setup: vec![
+            format!("pinMode({var}, OUTPUT);"),
+            // Mirror runtime initialize: start closed.
+            format!("digitalWrite({var}, {});", closed_level(nc)),
+        ],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        let open_level = if nc { "LOW" } else { "HIGH" };
+        let closed = closed_level(nc);
+        e.loop_body
+            .push(format!("digitalWrite({var}, ({expr}) ? {open_level} : {closed});"));
+    }
+    e
+}
+
+/// The digital level written when the relay is closed, per relay type.
+fn closed_level(normally_closed: bool) -> &'static str {
+    if normally_closed {
+        "HIGH"
+    } else {
+        "LOW"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn relay(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Relay".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn relay_sets_output_and_starts_closed_no() {
+        let e = emit(&relay("r-1", json!({ "pin": 10 })), None);
+        assert!(e.setup.iter().any(|s| s.contains("OUTPUT")));
+        // NO relay closed => LOW.
+        assert!(e.setup.iter().any(|s| s.contains("digitalWrite") && s.contains("LOW")));
+    }
+
+    #[test]
+    fn relay_nc_inverts_closed_level() {
+        let e = emit(&relay("r-1", json!({ "pin": 10, "type": "NC" })), None);
+        // NC relay closed => HIGH.
+        assert!(e.setup.iter().any(|s| s.contains("digitalWrite") && s.contains("HIGH")));
+    }
+
+    #[test]
+    fn relay_emits_deterministically() {
+        let n = relay("r-1", json!({ "pin": 10, "type": "NC" }));
+        assert_eq!(emit(&n, Some("x")), emit(&n, Some("x")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/output/servo.rs
+++ b/apps/web/src-tauri/src/codegen/output/servo.rs
@@ -1,0 +1,110 @@
+//! Servo emitter — mirrors `runtime/output/servo.rs`.
+//!
+//! The live Servo uses the Firmata SERVO pin mode and centers itself to the
+//! midpoint of its `[min, max]` range on initialize. The generated sketch uses
+//! the Arduino `Servo` library: it `#include <Servo.h>`, declares a `Servo`
+//! object, `attach`es it to the pin in `setup()`, and `write`s the center
+//! position — matching the runtime's centering behavior. The `#include` and
+//! object are only present because a Servo Node exists (the assembler
+//! de-duplicates the include).
+
+use crate::codegen::emit::{pin_or_default, u16_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default pin matches `runtime/output/servo.rs::default_pin` (3).
+const DEFAULT_PIN: u8 = 3;
+/// Range defaults match `runtime/output/servo.rs` (0..=180).
+const DEFAULT_MIN: u16 = 0;
+const DEFAULT_MAX: u16 = 180;
+
+/// Read the servo's `[min, max]` range from `data.range`, with runtime defaults.
+fn range(node: &FlowNode) -> (u16, u16) {
+    let range = node.data.get("range");
+    let read = |key: &str, default: u16| {
+        range
+            .and_then(|r| r.get(key))
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| u16::try_from(n).ok())
+            .unwrap_or(default)
+    };
+    // Fall back to top-level keys too, then defaults.
+    let min = read("min", u16_or_default(node, "min", DEFAULT_MIN));
+    let max = read("max", u16_or_default(node, "max", DEFAULT_MAX));
+    (min, max)
+}
+
+/// Emit C++ for a Servo Node. `driver` is the C++ integer angle expression to
+/// write each loop, or `None` for an unconnected Servo which holds its center.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let pin = pin_or_default(node, DEFAULT_PIN);
+    let token = node.id_token();
+    let obj = format!("servo_{token}");
+    let pin_var = format!("servo_{token}_pin");
+    let (min, max) = range(node);
+    let center = (min + max) / 2;
+
+    let mut e = NodeEmission {
+        includes: vec!["#include <Servo.h>".to_string()],
+        declarations: vec![
+            format!("const uint8_t {pin_var} = {pin};"),
+            format!("Servo {obj};"),
+        ],
+        setup: vec![
+            format!("{obj}.attach({pin_var});"),
+            // Mirror runtime initialize: center the servo.
+            format!("{obj}.write({center});"),
+        ],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        e.loop_body
+            .push(format!("{obj}.write(constrain((int)({expr}), {min}, {max}));"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn servo(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Servo".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    /// Scenario: A Servo Node pulls in its supporting library.
+    #[test]
+    fn servo_includes_library_and_declares_object() {
+        let e = emit(&servo("srv-1", json!({ "pin": 9 })), None);
+        assert!(e.includes.iter().any(|i| i.contains("Servo.h")), "missing Servo.h include");
+        assert!(e.declarations.iter().any(|d| d.contains("Servo servo_srv_1")), "missing Servo object");
+    }
+
+    /// Scenario: A Servo Node pulls in its supporting library — attaches to pin.
+    #[test]
+    fn servo_attaches_to_its_pin() {
+        let e = emit(&servo("srv-1", json!({ "pin": 9 })), None);
+        assert!(e.declarations.iter().any(|d| d.contains("= 9;")));
+        assert!(e.setup.iter().any(|s| s.contains(".attach(")), "missing attach call");
+    }
+
+    #[test]
+    fn servo_centers_within_range() {
+        let e = emit(&servo("srv-1", json!({ "pin": 9, "range": { "min": 0, "max": 180 } })), None);
+        assert!(e.setup.iter().any(|s| s.contains(".write(90)")), "should center to 90");
+    }
+
+    #[test]
+    fn servo_emits_deterministically() {
+        let n = servo("srv-1", json!({ "pin": 9 }));
+        assert_eq!(emit(&n, None), emit(&n, None));
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Task #41** — emit core hardware-IO Nodes to C++ — under Feature #23 / Epic #22. Builds on the sketch skeleton from #39 without changing its public contract.

Adds per-Node C++ emitters that mirror the live runtime impls (`runtime/output/{led,servo,relay}.rs`, `runtime/input/{button,sensor}.rs`) so generated code matches live behavior:

- **Led** — `pinMode OUTPUT`, starts LOW, `digitalWrite` driven by its wired source.
- **Button** — `INPUT`/`INPUT_PULLUP`, `digitalRead` into a `bool` state var (pull-up read inverted to logical pressed=true).
- **Sensor** — analog pin, `analogRead` into an `int` value var.
- **Servo** — `#include <Servo.h>` (only when a Servo Node exists), `Servo` object, `attach`, centers to range midpoint, `write(constrain(...))`.
- **Relay** — `pinMode OUTPUT`, starts closed, `digitalWrite` honoring NO/NC type.

`codegen::generate` now dispatches each Node to its emitter (mirroring `ComponentRegistry`), resolves output-Node drivers from incoming Flow edges (smallest source id wins, for determinism), dedupes includes, and stitches fragments into the skeleton's include/declarations/`setup()`/`loop()` regions. Output stays deterministic and non-blocking. Unsupported Node types emit nothing (Task 5 adds placeholders).

## Testing

- 34 codegen unit tests + 4 Gherkin scenario tests, all passing.
- `cargo test --lib --tests` green; `cargo clippy --all-targets -- -D warnings -W clippy::pedantic` clean.
- Backend-only; no TS touched.

## Scenarios

All four Task #41 Gherkin scenarios are covered by passing tests (see Test Mapping on the issue).

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)
