### PR TITLE
feat(codegen): emit graceful placeholders for unsupported/Cloud Nodes

### DIFF
--- a/apps/web/src-tauri/src/codegen/mod.rs
+++ b/apps/web/src-tauri/src/codegen/mod.rs
@@ -24,6 +24,7 @@
 pub mod emit;
 pub mod input;
 pub mod output;
+pub mod placeholder;
 
 use crate::runtime::types::{FlowNode, FlowUpdate};
 use emit::NodeEmission;
@@ -128,7 +129,9 @@ fn header(order: &[&FlowNode]) -> String {
 
 /// Dispatch a single Node to its per-type C++ emitter, mirroring the live
 /// `ComponentRegistry`. Node types outside the supported core hardware-IO set
-/// emit nothing here — graceful placeholders for them are Task 5's concern.
+/// (Cloud Nodes like Mqtt/Figma/Llm/Monitor, unknown types, and typeless
+/// Nodes) fall through to [`placeholder::emit`], which returns a graceful
+/// comment fragment so generation never crashes or blanks the sketch.
 /// `drivers` maps a target Node id to the C++ expression that drives it (from
 /// its wired source), so output Nodes write what their input reads.
 fn emit_node(node: &FlowNode, drivers: &BTreeMap<&str, String>) -> NodeEmission {
@@ -139,7 +142,7 @@ fn emit_node(node: &FlowNode, drivers: &BTreeMap<&str, String>) -> NodeEmission 
         Some("Servo") => output::servo::emit(node, driver),
         Some("Button") => input::button::emit(node),
         Some("Sensor") => input::sensor::emit(node),
-        _ => NodeEmission::default(),
+        _ => placeholder::emit(node),
     }
 }
 
@@ -474,5 +477,100 @@ mod tests {
             edges: vec![edge("btn-1", "led-1")],
         };
         assert_eq!(generate(&flow).unwrap(), generate(&flow).unwrap());
+    }
+
+    /// Scenario: An unsupported Node becomes a placeholder comment.
+    ///
+    /// A Cloud Node (Mqtt) alongside a core Led: the Cloud Node gets a clear
+    /// placeholder comment, the Led still emits real code, and generation does
+    /// not crash or blank the sketch.
+    #[test]
+    fn cloud_node_becomes_placeholder_while_core_node_still_emits() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node("mqtt-1", "Mqtt"),
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+            ],
+            edges: vec![],
+        };
+
+        let sketch = generate(&flow).expect("cloud node must not crash generation");
+
+        // Placeholder for the Cloud Node, identifying it and the networked need.
+        assert!(
+            sketch.contains("// unsupported Node mqtt_1 (Mqtt)"),
+            "missing Mqtt placeholder, got:\n{sketch}"
+        );
+        assert!(sketch.contains("networked target"), "Cloud message missing");
+        // The Led still produces real code.
+        assert!(sketch.contains("pinMode"), "led pin setup missing");
+        assert!(sketch.contains("digitalWrite"), "led write missing");
+        // Sketch is not blanked.
+        assert!(sketch.contains("void setup()") && sketch.contains("void loop()"));
+    }
+
+    /// Scenario: An unknown Node type does not break generation.
+    #[test]
+    fn unknown_node_type_does_not_break_generation() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node("gizmo-1", "Gizmo"),
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+            ],
+            edges: vec![],
+        };
+
+        let sketch = generate(&flow).expect("unknown node must not crash generation");
+
+        assert!(
+            sketch.contains("// unsupported Node gizmo_1 (Gizmo)"),
+            "missing unknown-type placeholder, got:\n{sketch}"
+        );
+        // The rest of the sketch is still produced.
+        assert!(sketch.contains("digitalWrite"), "led code still produced");
+        assert!(sketch.contains("void loop()"));
+    }
+
+    /// Scenario: A Flow of only unsupported Nodes still yields a valid sketch.
+    #[test]
+    fn all_unsupported_flow_yields_valid_sketch() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node("mqtt-1", "Mqtt"),
+                node("figma-1", "Figma"),
+                node("llm-1", "Llm"),
+                node("monitor-1", "Monitor"),
+            ],
+            edges: vec![],
+        };
+
+        let sketch = generate(&flow).expect("all-unsupported flow must not raise an error");
+
+        // A structurally valid sketch is still produced.
+        assert!(sketch.contains("void setup()"), "missing setup section");
+        assert!(sketch.contains("void loop()"), "missing loop section");
+        // A placeholder for every unsupported Node.
+        assert_eq!(
+            sketch.matches("// unsupported Node ").count(),
+            4,
+            "expected one placeholder per unsupported node, got:\n{sketch}"
+        );
+    }
+
+    /// Scenario: Placeholder comments are deterministic.
+    #[test]
+    fn placeholder_comments_are_deterministic_at_sketch_level() {
+        let flow = FlowUpdate {
+            nodes: vec![node("mqtt-1", "Mqtt"), node("gizmo-1", "Gizmo")],
+            edges: vec![],
+        };
+
+        let first = generate(&flow).expect("generation should succeed");
+        let second = generate(&flow).expect("generation should succeed");
+
+        assert_eq!(
+            first, second,
+            "repeated generation must yield identical placeholder comments"
+        );
     }
 }

--- a/apps/web/src-tauri/src/codegen/placeholder.rs
+++ b/apps/web/src-tauri/src/codegen/placeholder.rs
@@ -1,0 +1,145 @@
+//! Placeholder emitter — the graceful fallback for Node types without a
+//! registered C++ emitter.
+//!
+//! The codegen Node-type dispatch ([`crate::codegen::emit_node`]) routes every
+//! supported core hardware-IO Node (Led, Relay, Servo, Button, Sensor) to its
+//! emitter. Anything else — Cloud Nodes that cross the hardware boundary
+//! (`Mqtt`, `Figma`, `Llm`, `Monitor`), Nodes with no `node_type` at all, and
+//! any future/unknown type — falls through to this module instead of silently
+//! emitting nothing or panicking.
+//!
+//! The result is a single declaration-region comment line identifying the Node
+//! by id and type, with a message tailored to *why* it cannot run on the board:
+//!
+//! - **Cloud Nodes** need a networked target and cannot execute on a bare
+//!   board, so their comment says exactly that (Epic sub-seam).
+//! - **Unknown / typeless Nodes** simply have no emitter; their comment says so.
+//!
+//! Like every other emitter this is a pure function of the [`FlowNode`]: no
+//! clock, no IO, no hashmap iteration. Identical input always yields identical
+//! output, preserving the determinism invariant — the placeholder text never
+//! contains timestamps or other non-deterministic data.
+
+use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The Cloud Node types — those in the `external` category of
+/// `apps/web/node-components.json`. They communicate with networked services
+/// and cannot run on a standalone board, so they get a clearer message.
+const CLOUD_NODE_TYPES: [&str; 4] = ["Mqtt", "Figma", "Llm", "Monitor"];
+
+/// True when `node_type` names a Cloud (networked) Node.
+fn is_cloud_node(node_type: &str) -> bool {
+    CLOUD_NODE_TYPES.contains(&node_type)
+}
+
+/// Emit a deterministic placeholder comment for a Node that has no registered
+/// emitter. Returns a [`NodeEmission`] carrying a single declaration-region
+/// comment line so the Node is still visible in the sketch while contributing
+/// no runnable code. Never panics, even for a `None` `node_type`.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let token = node.id_token();
+    let comment = match node.node_type.as_deref() {
+        Some(kind) if is_cloud_node(kind) => format!(
+            "// unsupported Node {token} ({kind}): Cloud Node requires a networked target — no on-board code generated"
+        ),
+        Some(kind) => format!(
+            "// unsupported Node {token} ({kind}): no emitter for this Node type — no code generated"
+        ),
+        None => format!(
+            "// unsupported Node {token} (unknown): Node has no type — no code generated"
+        ),
+    };
+
+    NodeEmission {
+        declarations: vec![comment],
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn node(id: &str, kind: Option<&str>) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: kind.map(str::to_string),
+            data: json!({}),
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    /// Scenario: An unsupported Node becomes a placeholder comment.
+    /// A Cloud Node yields a placeholder identifying it and explaining it needs
+    /// a networked target.
+    #[test]
+    fn cloud_node_emits_networked_target_placeholder() {
+        let e = emit(&node("mqtt-1", Some("Mqtt")));
+        assert_eq!(e.declarations.len(), 1, "exactly one comment line");
+        let comment = &e.declarations[0];
+        assert!(comment.starts_with("//"), "must be a comment");
+        assert!(comment.contains("mqtt_1"), "identifies the Node id");
+        assert!(comment.contains("Mqtt"), "identifies the Node type");
+        assert!(
+            comment.contains("networked target"),
+            "explains it needs a networked target, got: {comment}"
+        );
+        // No runnable code is contributed.
+        assert!(e.includes.is_empty());
+        assert!(e.setup.is_empty());
+        assert!(e.loop_body.is_empty());
+    }
+
+    /// All four Cloud Node types get the networked-target message.
+    #[test]
+    fn all_cloud_node_types_get_networked_message() {
+        for kind in ["Mqtt", "Figma", "Llm", "Monitor"] {
+            let e = emit(&node("c-1", Some(kind)));
+            assert!(
+                e.declarations[0].contains("networked target"),
+                "{kind} should be treated as a Cloud Node"
+            );
+            assert!(e.declarations[0].contains(kind), "{kind} named in comment");
+        }
+    }
+
+    /// Scenario: An unknown Node type does not break generation.
+    /// A type with no emitter (and not a Cloud type) gets a generic placeholder
+    /// identifying it.
+    #[test]
+    fn unknown_node_type_emits_generic_placeholder() {
+        let e = emit(&node("widget-1", Some("Gizmo")));
+        assert_eq!(e.declarations.len(), 1);
+        let comment = &e.declarations[0];
+        assert!(comment.contains("widget_1"), "identifies the Node id");
+        assert!(comment.contains("Gizmo"), "identifies the Node type");
+        assert!(comment.contains("no emitter"), "generic unsupported message");
+        // Not described as a Cloud Node.
+        assert!(!comment.contains("networked target"));
+    }
+
+    /// Edge case: a Node with no `node_type` must not panic and must still be
+    /// identified.
+    #[test]
+    fn typeless_node_does_not_panic_and_is_identified() {
+        let e = emit(&node("mystery-1", None));
+        assert_eq!(e.declarations.len(), 1);
+        let comment = &e.declarations[0];
+        assert!(comment.contains("mystery_1"), "identifies the Node id");
+        assert!(comment.contains("unknown"), "marked as unknown type");
+    }
+
+    /// Scenario: Placeholder comments are deterministic.
+    /// The same unsupported Node yields a byte-identical placeholder every time.
+    #[test]
+    fn placeholder_is_deterministic() {
+        let n = node("mqtt-1", Some("Mqtt"));
+        let first = emit(&n);
+        let second = emit(&n);
+        assert_eq!(first, second, "same Node must emit identical placeholder");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a graceful placeholder fallback to the Arduino-sketch codegen Node-type dispatch. Any Node without a registered emitter — Cloud Nodes (`Mqtt`, `Figma`, `Llm`, `Monitor`), unknown types, and typeless Nodes — now produces a deterministic placeholder comment instead of being silently dropped. Generation never crashes or blanks the sketch, even when every Node is unsupported. Supported core hardware-IO Nodes are unaffected.

Closes #49

## Changes

- New `apps/web/src-tauri/src/codegen/placeholder.rs`: pure `emit(&FlowNode) -> NodeEmission` that returns a single declaration-region comment. Cloud Nodes get a message stating they require a networked target (Epic sub-seam); unknown/typeless Nodes get a generic "no emitter" message. No timestamps or non-deterministic data.
- `apps/web/src-tauri/src/codegen/mod.rs`: the dispatch fallback arm (`_ =>`) now calls `placeholder::emit(node)` instead of returning an empty emission; module registered; doc comment updated.

## Behaviour

- Cloud Node alongside core Nodes → placeholder for the Cloud Node, real code for the core Nodes.
- Unknown type → identified by id + type, rest of sketch still produced.
- All-unsupported Flow → valid skeleton + one placeholder per Node, no error.
- Repeated generation → byte-identical output.

## Tests

5 unit tests in `placeholder.rs` (all branches incl. all four Cloud types and the `None` case) and 4 sketch-level integration tests in `mod.rs::tests` covering each Gherkin scenario.

- `cargo test codegen`: 43 passed
- `cargo clippy --all-targets -- -W clippy::pedantic -D warnings`: clean

No frontend changes; the Code view renders the generator output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
