### PR TITLE
feat(flow): render generated sketch in read-only Monaco Code view

### DIFF
--- a/apps/web/src/components/flow/__tests__/sketch-code-view.test.ts
+++ b/apps/web/src/components/flow/__tests__/sketch-code-view.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import type { Edge, Node } from "@xyflow/react";
+import {
+  buildGenerateSketchCommand,
+  projectSketchResult,
+  type SketchInvoker,
+} from "../sketch-code-view.model";
+
+const NODE: Node = {
+  id: "led-1",
+  type: "Led",
+  position: { x: 0, y: 0 },
+  data: { pin: 13 },
+};
+
+describe("buildGenerateSketchCommand", () => {
+  test("wraps the current Flow graph in a generate_sketch command", () => {
+    const nodes: Node[] = [NODE];
+    const edges: Edge[] = [{ id: "e1", source: "a", target: "b" }];
+
+    const command = buildGenerateSketchCommand(nodes, edges);
+
+    expect(command).toEqual({
+      type: "generate_sketch",
+      flow: { nodes, edges },
+    });
+  });
+
+  test("supports an empty Flow", () => {
+    expect(buildGenerateSketchCommand([], [])).toEqual({
+      type: "generate_sketch",
+      flow: { nodes: [], edges: [] },
+    });
+  });
+});
+
+describe("projectSketchResult", () => {
+  // Scenario: Opening the Code view shows the sketch read-only
+  test("on success the editor value is the generated sketch text", async () => {
+    const invoker: SketchInvoker = async () => ({
+      success: true,
+      data: "void setup() {}\nvoid loop() {}",
+    });
+
+    const state = await projectSketchResult(invoker, [NODE], []);
+
+    expect(state).toEqual({
+      value: "void setup() {}\nvoid loop() {}",
+      isError: false,
+    });
+  });
+
+  // Scenario: The shown sketch can be copied — the full text is preserved verbatim
+  test("the full sketch text is preserved verbatim for copying", async () => {
+    const sketch = [
+      "// microflow generated sketch",
+      "void setup() {",
+      "  pinMode(13, OUTPUT);",
+      "}",
+      "void loop() {}",
+    ].join("\n");
+    const invoker: SketchInvoker = async () => ({ success: true, data: sketch });
+
+    const state = await projectSketchResult(invoker, [NODE], []);
+
+    expect(state.value).toBe(sketch);
+  });
+
+  // Scenario: An empty Flow shows a valid empty sketch (no error)
+  test("an empty Flow yields the generator's empty sketch with no error", async () => {
+    const emptySketch = "void setup() {}\nvoid loop() {}";
+    let received: { nodes: unknown[]; edges: unknown[] } | undefined;
+    const invoker: SketchInvoker = async (command) => {
+      received = command.flow;
+      return { success: true, data: emptySketch };
+    };
+
+    const state = await projectSketchResult(invoker, [], []);
+
+    expect(received).toEqual({ nodes: [], edges: [] });
+    expect(state).toEqual({ value: emptySketch, isError: false });
+  });
+
+  // Edge case: generation error surfaces as text, panel does not crash
+  test("on failure the error string is surfaced as the editor value", async () => {
+    const invoker: SketchInvoker = async () => ({
+      success: false,
+      error: "boom",
+    });
+
+    const state = await projectSketchResult(invoker, [NODE], []);
+
+    expect(state.isError).toBe(true);
+    expect(state.value).toContain("boom");
+  });
+
+  // Edge case: a missing data field still resolves to a stable empty value
+  test("a success response without data resolves to an empty string", async () => {
+    const invoker: SketchInvoker = async () => ({ success: true });
+
+    const state = await projectSketchResult(invoker, [], []);
+
+    expect(state).toEqual({ value: "", isError: false });
+  });
+});

--- a/apps/web/src/components/flow/panels/dock-panel.tsx
+++ b/apps/web/src/components/flow/panels/dock-panel.tsx
@@ -4,6 +4,7 @@ import { Dock } from "@/components/ui/dock";
 import { Separator } from "@/components/ui/separator";
 import { useReactFlow } from "@xyflow/react";
 import {
+  CodeIcon,
   HardDriveUploadIcon,
   PlusIcon,
   RedoIcon,
@@ -18,6 +19,7 @@ import { cn } from "@/lib/utils";
 import { useAppStore } from "@/stores/app";
 import { useNavigate } from "@tanstack/react-router";
 import { useFlowImportExport } from "@/hooks/use-flow-import-export";
+import { useSketchCodeViewStore } from "@/stores/sketch-code-view";
 
 export function DockPanel() {
   const { fitView, zoomIn, zoomOut, zoomTo } = useReactFlow();
@@ -27,6 +29,11 @@ export function DockPanel() {
   const navigate = useNavigate();
   const { activeFlowId } = useAppStore();
   const { exportFlow } = useFlowImportExport();
+  const { setOpen: setSketchCodeViewOpen } = useSketchCodeViewStore();
+
+  const handleViewCode = () => {
+    setSketchCodeViewOpen(true);
+  };
 
   const handleZoomIn = (event?: KeyboardEvent | MouseEvent) => {
     event?.stopPropagation();
@@ -98,28 +105,31 @@ export function DockPanel() {
 
   useHotkey("Mod+K", handleAddNode, {
     meta: { name: "Add node", description: "Add node" },
-    preventDefault: true
+    preventDefault: true,
   });
 
   return (
-      <Dock direction="middle">
-        <DockIcon onClick={handleAddNode}>
-          <PlusIcon />
-        </DockIcon>
-        <Separator orientation="vertical" className="h-full" />
-        <DockIcon onClick={handleUndo}>
-          <UndoIcon className={cn(history.canUndo ? "text-primary" : "text-muted-foreground")} />
-        </DockIcon>
-        <DockIcon onClick={handleRedo}>
-          <RedoIcon className={cn(history.canRedo ? "text-primary" : "text-muted-foreground")} />
-        </DockIcon>
-        <Separator orientation="vertical" className="h-full" />
-        <DockIcon onClick={exportFlow}>
-          <HardDriveUploadIcon />
-        </DockIcon>
-        <DockIcon onClick={handleSettings}>
-          <SettingsIcon />
-        </DockIcon>
-      </Dock>
+    <Dock direction="middle">
+      <DockIcon onClick={handleAddNode}>
+        <PlusIcon />
+      </DockIcon>
+      <Separator orientation="vertical" className="h-full" />
+      <DockIcon onClick={handleUndo}>
+        <UndoIcon className={cn(history.canUndo ? "text-primary" : "text-muted-foreground")} />
+      </DockIcon>
+      <DockIcon onClick={handleRedo}>
+        <RedoIcon className={cn(history.canRedo ? "text-primary" : "text-muted-foreground")} />
+      </DockIcon>
+      <Separator orientation="vertical" className="h-full" />
+      <DockIcon onClick={handleViewCode}>
+        <CodeIcon />
+      </DockIcon>
+      <DockIcon onClick={exportFlow}>
+        <HardDriveUploadIcon />
+      </DockIcon>
+      <DockIcon onClick={handleSettings}>
+        <SettingsIcon />
+      </DockIcon>
+    </Dock>
   );
 }

--- a/apps/web/src/components/flow/react-flow-canvas.tsx
+++ b/apps/web/src/components/flow/react-flow-canvas.tsx
@@ -30,6 +30,8 @@ import { useTheme } from "@/providers/theme-provider";
 import { HotkeySheet } from "./sheets/hotkey-sheet";
 import { CollabCursors } from "./collab-cursors";
 import { PressensePanel } from "./panels/pressense-panel";
+import { SketchCodeView } from "./sketch-code-view";
+import { useSketchCodeViewStore } from "@/stores/sketch-code-view";
 
 const uid = () => Math.random().toString(36).substring(2, 9);
 
@@ -40,6 +42,7 @@ export function ReactFlowCanvas() {
   const { doc } = useFlowSession();
   const { otherUsers } = useCollabPresence();
   const { updateCursor } = useFlowAwareness();
+  const { open: sketchCodeViewOpen, setOpen: setSketchCodeViewOpen } = useSketchCodeViewStore();
 
   const { nodes, edges, onNodesChange, onEdgesChange } = useReactFlowBridge(doc);
 
@@ -107,6 +110,7 @@ export function ReactFlowCanvas() {
         </Panel>
       </ReactFlow>
       <CollabCursors users={otherUsers} />
+      {sketchCodeViewOpen && <SketchCodeView onClose={() => setSketchCodeViewOpen(false)} />}
     </div>
   );
 }

--- a/apps/web/src/components/flow/sketch-code-view.model.ts
+++ b/apps/web/src/components/flow/sketch-code-view.model.ts
@@ -1,0 +1,57 @@
+import type { Edge, Node } from "@xyflow/react";
+
+/**
+ * The `generate_sketch` command payload: the current Flow graph wrapped for the
+ * Tauri command (see `apps/web/src/lib/ipc.ts` and Task #45).
+ */
+export type GenerateSketchCommand = {
+  type: "generate_sketch";
+  flow: { nodes: Node[]; edges: Edge[] };
+};
+
+/**
+ * Response shape returned by `invokeCommand` for `generate_sketch`. The data is
+ * the generated `.ino` source as a plain string (or absent on web/no-op).
+ */
+export type SketchResponse =
+  | { success: true; data?: string }
+  | { success: false; error: string };
+
+/** Injectable invoker so the projection is testable without Tauri. */
+export type SketchInvoker = (command: GenerateSketchCommand) => Promise<SketchResponse>;
+
+/** View state consumed by the read-only Monaco editor. */
+export type SketchViewState = {
+  /** Text rendered in the editor — the sketch, or the error message on failure. */
+  value: string;
+  /** True when `value` holds an error message rather than a sketch. */
+  isError: boolean;
+};
+
+/** Build the `generate_sketch` command from the current Flow graph. */
+export function buildGenerateSketchCommand(
+  nodes: Node[],
+  edges: Edge[],
+): GenerateSketchCommand {
+  return { type: "generate_sketch", flow: { nodes, edges } };
+}
+
+/**
+ * Request a freshly generated sketch for the given Flow and project the response
+ * into editor view state. On success the editor shows the sketch (empty string
+ * when the generator returns nothing); on failure it shows the error text rather
+ * than crashing the panel.
+ */
+export async function projectSketchResult(
+  invoker: SketchInvoker,
+  nodes: Node[],
+  edges: Edge[],
+): Promise<SketchViewState> {
+  const response = await invoker(buildGenerateSketchCommand(nodes, edges));
+
+  if (response.success) {
+    return { value: response.data ?? "", isError: false };
+  }
+
+  return { value: `// Failed to generate sketch:\n// ${response.error}`, isError: true };
+}

--- a/apps/web/src/components/flow/sketch-code-view.model.ts
+++ b/apps/web/src/components/flow/sketch-code-view.model.ts
@@ -13,9 +13,7 @@ export type GenerateSketchCommand = {
  * Response shape returned by `invokeCommand` for `generate_sketch`. The data is
  * the generated `.ino` source as a plain string (or absent on web/no-op).
  */
-export type SketchResponse =
-  | { success: true; data?: string }
-  | { success: false; error: string };
+export type SketchResponse = { success: true; data?: string } | { success: false; error: string };
 
 /** Injectable invoker so the projection is testable without Tauri. */
 export type SketchInvoker = (command: GenerateSketchCommand) => Promise<SketchResponse>;
@@ -29,10 +27,7 @@ export type SketchViewState = {
 };
 
 /** Build the `generate_sketch` command from the current Flow graph. */
-export function buildGenerateSketchCommand(
-  nodes: Node[],
-  edges: Edge[],
-): GenerateSketchCommand {
+export function buildGenerateSketchCommand(nodes: Node[], edges: Edge[]): GenerateSketchCommand {
   return { type: "generate_sketch", flow: { nodes, edges } };
 }
 

--- a/apps/web/src/components/flow/sketch-code-view.tsx
+++ b/apps/web/src/components/flow/sketch-code-view.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import Editor, { loader } from "@monaco-editor/react";
+import * as monaco from "monaco-editor";
+import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useTheme } from "@/providers/theme-provider";
+import { useFlowSession, useFlowNodes, useFlowEdges } from "@/session";
+import { invokeCommand } from "@/lib/ipc";
+import {
+  projectSketchResult,
+  type SketchInvoker,
+  type SketchResponse,
+} from "./sketch-code-view.model";
+
+// Use local bundle + workers instead of CDN (required for offline Tauri).
+// Mirrors the Function code editor setup; the read-only view only needs the
+// base editor worker (no language services).
+(window as Window & { MonacoEnvironment?: unknown }).MonacoEnvironment = {
+  getWorker() {
+    return new EditorWorker();
+  },
+};
+loader.config({ monaco });
+
+const invoke: SketchInvoker = (command) => invokeCommand(command) as Promise<SketchResponse>;
+
+/**
+ * Read-only Monaco view of the Arduino sketch generated from the current Flow.
+ *
+ * Generates once on open (Task #45); live regeneration on graph edits is Task 4.
+ * The editor is always read-only — the Author can read and copy but not edit.
+ */
+export function SketchCodeView({ onClose }: { onClose: () => void }) {
+  const { theme } = useTheme();
+  const { doc } = useFlowSession();
+  const nodes = useFlowNodes(doc);
+  const edges = useFlowEdges(doc);
+  const [value, setValue] = useState("// Generating sketch…");
+
+  useEffect(() => {
+    let cancelled = false;
+    void projectSketchResult(
+      invoke,
+      nodes as Parameters<typeof projectSketchResult>[1],
+      edges as Parameters<typeof projectSketchResult>[2],
+    ).then((state) => {
+      if (!cancelled) setValue(state.value);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // Generate on open only; the node/edge snapshot is read once (Task 4 adds
+    // debounced live regeneration).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Dialog defaultOpen onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-4xl max-h-[85vh] p-0 gap-0 overflow-hidden flex flex-col">
+        <DialogHeader className="px-6 pt-6 pb-4 shrink-0">
+          <DialogTitle>Generated sketch</DialogTitle>
+        </DialogHeader>
+        <div className="flex-1 h-[60vh] border-y">
+          <Editor
+            height="100%"
+            language="cpp"
+            value={value}
+            theme={theme === "dark" ? "vs-dark" : "light"}
+            options={{
+              readOnly: true,
+              domReadOnly: true,
+              minimap: { enabled: false },
+              fontSize: 13,
+              lineNumbers: "on",
+              tabSize: 2,
+              scrollBeyondLastLine: false,
+              automaticLayout: true,
+              wordWrap: "on",
+              padding: { top: 12, bottom: 12 },
+            }}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/stores/sketch-code-view.ts
+++ b/apps/web/src/stores/sketch-code-view.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+
+type SketchCodeViewState = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+};
+
+/** Toggle state for the read-only generated-sketch Code view (Task #45). */
+export const useSketchCodeViewStore = create<SketchCodeViewState>((set) => ({
+  open: false,
+  setOpen: (open) => set({ open }),
+}));


### PR DESCRIPTION
## Summary

A Flow Author can now read the Arduino sketch their Flow produces without leaving microflow. This adds a read-only Code view to the flow editor: it takes the current Flow graph, calls the `generate_sketch` Tauri command, and renders the result in a Monaco editor configured `readOnly` with C++ syntax — selectable and copyable, but not editable.

This serves Feature #23 (view the generated Arduino sketch) under Epic #22. It builds on the codegen blockers (#39 skeleton, #41 core hardware-IO emit, #49 placeholders) by surfacing their output in the UI for the first time. First render on open only; debounced live regeneration is Task #4.

## Changes

- **Sketch projection model** (`sketch-code-view.model.ts`): a pure, dependency-free module that builds the `generate_sketch` command from the current Flow graph and maps the invoke response to editor view state — sketch text on success (empty string when the generator returns nothing), error text on failure so the panel never crashes.
- **Read-only Monaco Code view** (`sketch-code-view.tsx`): mirrors the Function editor's local worker/loader setup, renders `language="cpp"` with `readOnly`/`domReadOnly`, generates once on open from `FlowSessionContext` nodes/edges.
- **Dock toggle + store**: a Code icon in the dock opens the view via a small zustand store; the view is mounted in `react-flow-canvas.tsx`.
- **Tests**: 7 `bun:test` cases covering the projection (command shape, success/empty/error/missing-data paths).

## Test plan

- [x] Opening the Code view shows the sketch read-only — `sketch-code-view.test.ts`
- [x] The shown sketch can be copied (full text preserved verbatim) — `sketch-code-view.test.ts`
- [x] An empty Flow shows a valid empty sketch with no error — `sketch-code-view.test.ts`
- [x] Generation error surfaces as text rather than crashing the panel — `sketch-code-view.test.ts`
- [x] `bun test` (web): 75 pass / 0 fail
- [x] `bun run check` (oxlint + oxfmt): 0 errors on changed files
- [x] `bun run check-types`: 0 new type errors (changed files clean)

> Note: the actual DOM read-only enforcement and clipboard copy are structural (Monaco `readOnly: true`; text preserved verbatim by the projection) — no DOM-level automated test exists because the web app has no JS/DOM test framework configured (see `docs/steering/QA.md`).

## Related

Closes #45
