### PR TITLE
feat(flow): regenerate sketch on Flow change (debounced)

### DIFF
--- a/apps/web/src/components/flow/__tests__/sketch-code-view.test.ts
+++ b/apps/web/src/components/flow/__tests__/sketch-code-view.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, test } from "bun:test";
 import type { Edge, Node } from "@xyflow/react";
 import {
   buildGenerateSketchCommand,
+  createDebouncedRegenerator,
+  hasFlowChanged,
   projectSketchResult,
+  serializeFlowGraph,
+  type RegeneratorTimers,
   type SketchInvoker,
+  type SketchViewState,
 } from "../sketch-code-view.model";
 
 const NODE: Node = {
@@ -101,5 +106,220 @@ describe("projectSketchResult", () => {
     const state = await projectSketchResult(invoker, [], []);
 
     expect(state).toEqual({ value: "", isError: false });
+  });
+});
+
+describe("serializeFlowGraph / hasFlowChanged", () => {
+  test("identical graphs serialize equally and are reported unchanged", () => {
+    const a = serializeFlowGraph([NODE], []);
+    const b = serializeFlowGraph([NODE], []);
+
+    expect(a).toBe(b);
+    expect(hasFlowChanged(b, a)).toBe(false);
+  });
+
+  test("adding a node changes the serialization", () => {
+    const before = serializeFlowGraph([NODE], []);
+    const after = serializeFlowGraph([NODE, { ...NODE, id: "led-2" }], []);
+
+    expect(hasFlowChanged(after, before)).toBe(true);
+  });
+
+  test("an undefined baseline is always treated as changed", () => {
+    expect(hasFlowChanged(serializeFlowGraph([], []), undefined)).toBe(true);
+  });
+});
+
+/**
+ * Manual fake-clock harness: scheduled callbacks fire only when `tick` advances
+ * past their due time. Lets us assert debounce/coalesce behavior deterministically.
+ */
+function makeFakeTimers() {
+  let now = 0;
+  let nextId = 1;
+  const scheduled = new Map<number, { due: number; handler: () => void }>();
+
+  const timers: RegeneratorTimers = {
+    setTimeout: (handler, ms) => {
+      const id = nextId++;
+      scheduled.set(id, { due: now + ms, handler });
+      return id as unknown as ReturnType<typeof setTimeout>;
+    },
+    clearTimeout: (handle) => {
+      scheduled.delete(handle as unknown as number);
+    },
+  };
+
+  function tick(ms: number) {
+    now += ms;
+    const due = Array.from(scheduled.entries()).filter(([, entry]) => entry.due <= now);
+    for (const [id, entry] of due) {
+      scheduled.delete(id);
+      entry.handler();
+    }
+  }
+
+  return { timers, tick };
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const LED2: Node = { id: "led-2", type: "Led", position: { x: 1, y: 1 }, data: { pin: 12 } };
+
+describe("createDebouncedRegenerator", () => {
+  // Scenario: Editing the Flow updates the displayed sketch
+  test("a graph change triggers regeneration after the debounce window", async () => {
+    const { timers, tick } = makeFakeTimers();
+    const results: SketchViewState[] = [];
+    const invoker: SketchInvoker = async () => ({ success: true, data: "sketch-v1" });
+
+    const regen = createDebouncedRegenerator({
+      invoker,
+      onResult: (s) => results.push(s),
+      debounceMs: 400,
+      timers,
+    });
+
+    regen.schedule([NODE], []);
+    expect(results).toHaveLength(0); // nothing before the window elapses
+    tick(400);
+    await flush();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({ value: "sketch-v1", isError: false });
+  });
+
+  // Scenario: Rapid edits collapse into a single regeneration
+  test("rapid successive edits collapse into one regeneration with the latest graph", async () => {
+    const { timers, tick } = makeFakeTimers();
+    const seen: Array<{ nodes: number }> = [];
+    const invoker: SketchInvoker = async (command) => {
+      seen.push({ nodes: command.flow.nodes.length });
+      return { success: true, data: `nodes:${command.flow.nodes.length}` };
+    };
+    const results: SketchViewState[] = [];
+
+    const regen = createDebouncedRegenerator({
+      invoker,
+      onResult: (s) => results.push(s),
+      debounceMs: 400,
+      timers,
+    });
+
+    // Several edits in quick succession (each within the debounce window).
+    regen.schedule([NODE], []);
+    tick(100);
+    regen.schedule([NODE, LED2], []);
+    tick(100);
+    regen.schedule([NODE, LED2, { ...LED2, id: "led-3" }], []);
+
+    // Author pauses.
+    tick(400);
+    await flush();
+
+    expect(seen).toHaveLength(1); // coalesced into a single generation
+    expect(seen[0]).toEqual({ nodes: 3 }); // reflects the latest Flow
+    expect(results[results.length - 1]?.value).toBe("nodes:3");
+  });
+
+  // Scenario: Adding a Node updates the sketch
+  test("adding a node regenerates including the new node's graph", async () => {
+    const { timers, tick } = makeFakeTimers();
+    const flows: Node[][] = [];
+    const invoker: SketchInvoker = async (command) => {
+      flows.push(command.flow.nodes as Node[]);
+      return { success: true, data: "ok" };
+    };
+
+    const regen = createDebouncedRegenerator({
+      invoker,
+      onResult: () => {},
+      debounceMs: 400,
+      timers,
+      seedSerialized: serializeFlowGraph([NODE], []),
+    });
+
+    regen.schedule([NODE, LED2], []);
+    tick(400);
+    await flush();
+
+    expect(flows).toHaveLength(1);
+    expect(flows[0]?.map((n) => n.id)).toEqual(["led-1", "led-2"]);
+  });
+
+  test("an unchanged graph is not regenerated (skips redundant generation)", async () => {
+    const { timers, tick } = makeFakeTimers();
+    let calls = 0;
+    const invoker: SketchInvoker = async () => {
+      calls++;
+      return { success: true, data: "x" };
+    };
+
+    const regen = createDebouncedRegenerator({
+      invoker,
+      onResult: () => {},
+      debounceMs: 400,
+      timers,
+      seedSerialized: serializeFlowGraph([NODE], []),
+    });
+
+    regen.schedule([NODE], []); // identical to the seed
+    tick(400);
+    await flush();
+
+    expect(calls).toBe(0);
+  });
+
+  test("cancel prevents a pending regeneration from firing", async () => {
+    const { timers, tick } = makeFakeTimers();
+    let calls = 0;
+    const invoker: SketchInvoker = async () => {
+      calls++;
+      return { success: true, data: "x" };
+    };
+
+    const regen = createDebouncedRegenerator({
+      invoker,
+      onResult: () => {},
+      debounceMs: 400,
+      timers,
+    });
+
+    regen.schedule([NODE], []);
+    regen.cancel();
+    tick(400);
+    await flush();
+
+    expect(calls).toBe(0);
+  });
+
+  test("a stale in-flight response is dropped; only the latest result is applied", async () => {
+    const { timers, tick } = makeFakeTimers();
+    const results: SketchViewState[] = [];
+    // First response resolves slowly, second quickly — latest must win.
+    const resolvers: Array<(s: string) => void> = [];
+    const invoker: SketchInvoker = () =>
+      new Promise((resolve) =>
+        resolvers.push((value) => resolve({ success: true, data: value })),
+      ) as ReturnType<SketchInvoker>;
+
+    const regen = createDebouncedRegenerator({
+      invoker,
+      onResult: (s) => results.push(s),
+      debounceMs: 400,
+      timers,
+    });
+
+    regen.schedule([NODE], []);
+    tick(400); // fires request #1
+    regen.schedule([NODE, LED2], []);
+    tick(400); // fires request #2
+
+    // Resolve request #2 (latest) first, then the stale #1.
+    resolvers[1]?.("latest");
+    resolvers[0]?.("stale");
+    await flush();
+
+    expect(results.map((r) => r.value)).toEqual(["latest"]);
   });
 });

--- a/apps/web/src/components/flow/sketch-code-view.model.ts
+++ b/apps/web/src/components/flow/sketch-code-view.model.ts
@@ -32,6 +32,25 @@ export function buildGenerateSketchCommand(nodes: Node[], edges: Edge[]): Genera
 }
 
 /**
+ * Produce a stable string key for a Flow graph so successive snapshots can be
+ * compared cheaply. Two graphs that would generate the same sketch must yield
+ * the same key, so we serialize the same `{ nodes, edges }` payload sent to the
+ * generator. Used to skip redundant regeneration when the graph is unchanged.
+ */
+export function serializeFlowGraph(nodes: Node[], edges: Edge[]): string {
+  return JSON.stringify(buildGenerateSketchCommand(nodes, edges).flow);
+}
+
+/**
+ * Decide whether the current graph differs from the last one we generated a
+ * sketch for. `undefined` means nothing has been generated yet, so the first
+ * snapshot always regenerates.
+ */
+export function hasFlowChanged(current: string, lastGenerated: string | undefined): boolean {
+  return current !== lastGenerated;
+}
+
+/**
  * Request a freshly generated sketch for the given Flow and project the response
  * into editor view state. On success the editor shows the sketch (empty string
  * when the generator returns nothing); on failure it shows the error text rather
@@ -49,4 +68,91 @@ export async function projectSketchResult(
   }
 
   return { value: `// Failed to generate sketch:\n// ${response.error}`, isError: true };
+}
+
+/** Default debounce window (ms) — balances responsiveness against churn. */
+export const DEFAULT_REGENERATE_DEBOUNCE_MS = 400;
+
+/** Timer primitives, injectable so the regenerator is testable with a fake clock. */
+export type RegeneratorTimers = {
+  setTimeout: (handler: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clearTimeout: (handle: ReturnType<typeof setTimeout>) => void;
+};
+
+const realTimers: RegeneratorTimers = {
+  setTimeout: (handler, ms) => setTimeout(handler, ms),
+  clearTimeout: (handle) => clearTimeout(handle),
+};
+
+export type DebouncedRegenerator = {
+  /**
+   * Register the latest Flow graph. Coalesces rapid calls into a single
+   * regeneration that fires after the debounce window elapses with no further
+   * calls. Skips work when the graph matches the last one generated.
+   */
+  schedule: (nodes: Node[], edges: Edge[]) => void;
+  /** Cancel any pending regeneration and drop in-flight responses (call on unmount). */
+  cancel: () => void;
+};
+
+/**
+ * Create a debounced, coalescing sketch regenerator.
+ *
+ * - Rapid `schedule` calls collapse into one regeneration after the author pauses.
+ * - The regeneration always uses the latest graph (last-writer-wins).
+ * - Identical graphs are skipped (no redundant `generate_sketch`).
+ * - Only the latest in-flight response is applied; stale responses are dropped
+ *   to avoid flicker.
+ *
+ * `onResult` receives the projected view state when a regeneration completes.
+ * `seedSerialized` primes the "last generated" key (e.g. the on-open snapshot)
+ * so the first identical edit does not trigger a redundant regeneration.
+ */
+export function createDebouncedRegenerator(options: {
+  invoker: SketchInvoker;
+  onResult: (state: SketchViewState) => void;
+  debounceMs?: number;
+  timers?: RegeneratorTimers;
+  seedSerialized?: string;
+}): DebouncedRegenerator {
+  const debounceMs = options.debounceMs ?? DEFAULT_REGENERATE_DEBOUNCE_MS;
+  const timers = options.timers ?? realTimers;
+
+  let pendingHandle: ReturnType<typeof setTimeout> | undefined;
+  let lastSerialized = options.seedSerialized;
+  let latestRequestId = 0;
+  let cancelled = false;
+
+  function run(nodes: Node[], edges: Edge[]): void {
+    const serialized = serializeFlowGraph(nodes, edges);
+    if (!hasFlowChanged(serialized, lastSerialized)) return;
+    lastSerialized = serialized;
+
+    const requestId = ++latestRequestId;
+    void projectSketchResult(options.invoker, nodes, edges).then((state) => {
+      // Drop stale responses: only the most recent request may update the view.
+      if (cancelled || requestId !== latestRequestId) return;
+      options.onResult(state);
+    });
+  }
+
+  return {
+    schedule(nodes, edges) {
+      if (cancelled) return;
+      if (pendingHandle !== undefined) timers.clearTimeout(pendingHandle);
+      pendingHandle = timers.setTimeout(() => {
+        pendingHandle = undefined;
+        run(nodes, edges);
+      }, debounceMs);
+    },
+    cancel() {
+      cancelled = true;
+      if (pendingHandle !== undefined) {
+        timers.clearTimeout(pendingHandle);
+        pendingHandle = undefined;
+      }
+      // Invalidate any in-flight response.
+      latestRequestId++;
+    },
+  };
 }

--- a/apps/web/src/components/flow/sketch-code-view.tsx
+++ b/apps/web/src/components/flow/sketch-code-view.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Editor, { loader } from "@monaco-editor/react";
 import * as monaco from "monaco-editor";
 import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
@@ -7,7 +7,9 @@ import { useTheme } from "@/providers/theme-provider";
 import { useFlowSession, useFlowNodes, useFlowEdges } from "@/session";
 import { invokeCommand } from "@/lib/ipc";
 import {
+  createDebouncedRegenerator,
   projectSketchResult,
+  serializeFlowGraph,
   type SketchInvoker,
   type SketchResponse,
 } from "./sketch-code-view.model";
@@ -27,8 +29,9 @@ const invoke: SketchInvoker = (command) => invokeCommand(command) as Promise<Ske
 /**
  * Read-only Monaco view of the Arduino sketch generated from the current Flow.
  *
- * Generates once on open (Task #45); live regeneration on graph edits is Task 4.
- * The editor is always read-only — the Author can read and copy but not edit.
+ * Generates once on open (Task #45) and re-generates — debounced — whenever the
+ * Flow graph changes while the view is open (Task #47). The editor is always
+ * read-only — the Author can read and copy but not edit.
  */
 export function SketchCodeView({ onClose }: { onClose: () => void }) {
   const { theme } = useTheme();
@@ -37,22 +40,43 @@ export function SketchCodeView({ onClose }: { onClose: () => void }) {
   const edges = useFlowEdges(doc);
   const [value, setValue] = useState("// Generating sketch…");
 
+  type GenNode = Parameters<typeof projectSketchResult>[1][number];
+  type GenEdge = Parameters<typeof projectSketchResult>[2][number];
+  const genNodes = nodes as GenNode[];
+  const genEdges = edges as GenEdge[];
+
+  // Generate once on open, seeding the regenerator so an identical first edit
+  // does not trigger a redundant regeneration.
   useEffect(() => {
     let cancelled = false;
-    void projectSketchResult(
-      invoke,
-      nodes as Parameters<typeof projectSketchResult>[1],
-      edges as Parameters<typeof projectSketchResult>[2],
-    ).then((state) => {
+    void projectSketchResult(invoke, genNodes, genEdges).then((state) => {
       if (!cancelled) setValue(state.value);
     });
     return () => {
       cancelled = true;
     };
-    // Generate on open only; the node/edge snapshot is read once (Task 4 adds
-    // debounced live regeneration).
+    // Read the on-open snapshot once; live edits flow through the regenerator below.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Debounced live regeneration on Flow graph changes.
+  const regeneratorRef = useRef<ReturnType<typeof createDebouncedRegenerator> | null>(null);
+  if (regeneratorRef.current === null) {
+    regeneratorRef.current = createDebouncedRegenerator({
+      invoker: invoke,
+      onResult: (state) => setValue(state.value),
+      seedSerialized: serializeFlowGraph(genNodes, genEdges),
+    });
+  }
+
+  useEffect(() => {
+    const regenerator = regeneratorRef.current;
+    return () => regenerator?.cancel();
+  }, []);
+
+  useEffect(() => {
+    regeneratorRef.current?.schedule(genNodes, genEdges);
+  }, [genNodes, genEdges]);
 
   return (
     <Dialog defaultOpen onOpenChange={onClose}>


### PR DESCRIPTION
## Summary

While the read-only Code view (Task #45) is open, the generated Arduino sketch
now stays in sync with the Flow. Whenever the Author edits the graph, the sketch
re-generates — debounced — so the code they read and copy always reflects what
they just built. This serves Feature #23's acceptance criterion: "when the
Author changes the Flow graph, the displayed sketch regenerates to match (within
~1s)."

## Changes

- Added pure, testable model helpers in `sketch-code-view.model.ts`:
  - `serializeFlowGraph` / `hasFlowChanged` — stable graph keying so an unchanged
    graph never triggers a redundant `generate_sketch`.
  - `createDebouncedRegenerator` — coalesces rapid edits into a single
    regeneration after the Author pauses (~400ms default), always uses the latest
    graph (last-writer-wins), and drops stale in-flight responses to avoid flicker.
    Timers are injectable for deterministic testing.
- Wired the regenerator into `SketchCodeView`: an effect watches the
  `nodes`/`edges` from `FlowSessionContext` and schedules a debounced
  regeneration on each change, seeded from the on-open snapshot and cancelled on
  unmount.

## Test plan

- [x] Editing the Flow updates the displayed sketch (regenerates after the debounce window)
- [x] Rapid edits collapse into a single regeneration reflecting the latest Flow
- [x] Adding a Node regenerates including the new node's graph
- [x] An unchanged graph is not regenerated (redundant-generation skip)
- [x] A pending regeneration is cancelled on unmount
- [x] A stale in-flight response is dropped; only the latest result is applied

All 16 tests pass (`bun test src/components/flow/__tests__/sketch-code-view.test.ts`).
`oxlint` clean on changed files; no new `tsc` errors.

## Related

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)
