### PR TITLE
feat(codegen): emit transformation Nodes to C++ (#33)

### DIFF
--- a/apps/web/src-tauri/src/codegen/emit.rs
+++ b/apps/web/src-tauri/src/codegen/emit.rs
@@ -92,6 +92,46 @@ pub fn u16_or_default(node: &FlowNode, key: &str, default: u16) -> u16 {
         .unwrap_or(default)
 }
 
+/// Read an `f64` from a Node's `data`, falling back to `default`. Accepts a
+/// JSON number or a numeric string, mirroring the runtime's lenient config
+/// deserialization.
+#[must_use]
+pub fn f64_or_default(node: &FlowNode, key: &str, default: f64) -> f64 {
+    let Some(value) = node.data.get(key) else {
+        return default;
+    };
+    if let Some(n) = value.as_f64() {
+        return n;
+    }
+    if let Some(s) = value.as_str() {
+        return s.parse().unwrap_or(default);
+    }
+    default
+}
+
+/// Read a string from a Node's `data`, falling back to `default`.
+#[must_use]
+pub fn str_or_default(node: &FlowNode, key: &str, default: &str) -> String {
+    node.data
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or(default)
+        .to_string()
+}
+
+/// Format an `f64` as a C++ `double` literal that round-trips deterministically.
+/// Integer-valued numbers gain a trailing `.0` so the literal is unambiguously
+/// floating point.
+#[must_use]
+pub fn cpp_double(value: f64) -> String {
+    if value.is_finite() && value.fract() == 0.0 && value.abs() < 1e15 {
+        format!("{value:.1}")
+    } else {
+        // `{}` on f64 yields the shortest round-tripping representation.
+        format!("{value}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,5 +179,27 @@ mod tests {
     #[test]
     fn empty_emission_is_empty() {
         assert!(NodeEmission::default().is_empty());
+    }
+
+    #[test]
+    fn f64_reads_number_string_and_default() {
+        assert!((f64_or_default(&node_with(json!({ "n": 2.5 })), "n", 0.0) - 2.5).abs() < f64::EPSILON);
+        assert!((f64_or_default(&node_with(json!({ "n": "3.5" })), "n", 0.0) - 3.5).abs() < f64::EPSILON);
+        assert!((f64_or_default(&node_with(json!({})), "n", 9.0) - 9.0).abs() < f64::EPSILON);
+        assert!((f64_or_default(&node_with(json!({ "n": "xyz" })), "n", 1.0) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn str_reads_value_and_default() {
+        assert_eq!(str_or_default(&node_with(json!({ "s": "hi" })), "s", "x"), "hi");
+        assert_eq!(str_or_default(&node_with(json!({})), "s", "fallback"), "fallback");
+    }
+
+    #[test]
+    fn cpp_double_formats_integers_and_fractions() {
+        assert_eq!(cpp_double(5.0), "5.0");
+        assert_eq!(cpp_double(0.0), "0.0");
+        assert_eq!(cpp_double(-3.0), "-3.0");
+        assert_eq!(cpp_double(2.5), "2.5");
     }
 }

--- a/apps/web/src-tauri/src/codegen/mod.rs
+++ b/apps/web/src-tauri/src/codegen/mod.rs
@@ -25,6 +25,7 @@ pub mod emit;
 pub mod input;
 pub mod output;
 pub mod placeholder;
+pub mod transformation;
 
 use crate::runtime::types::{FlowNode, FlowUpdate};
 use emit::NodeEmission;
@@ -142,6 +143,11 @@ fn emit_node(node: &FlowNode, drivers: &BTreeMap<&str, String>) -> NodeEmission 
         Some("Servo") => output::servo::emit(node, driver),
         Some("Button") => input::button::emit(node),
         Some("Sensor") => input::sensor::emit(node),
+        Some("Calculate") => transformation::calculate::emit(node, driver),
+        Some("Compare") => transformation::compare::emit(node, driver),
+        Some("Gate") => transformation::gate::emit(node, driver),
+        Some("RangeMap") => transformation::range_map::emit(node, driver),
+        Some("Smooth") => transformation::smooth::emit(node, driver),
         _ => placeholder::emit(node),
     }
 }
@@ -187,6 +193,11 @@ fn source_expression(node: &FlowNode) -> Option<String> {
     match node.node_type.as_deref() {
         Some("Button") => Some(input::button::state_var(node)),
         Some("Sensor") => Some(input::sensor::value_var(node)),
+        Some("Calculate") => Some(transformation::calculate::value_var(node)),
+        Some("Compare") => Some(transformation::compare::state_var(node)),
+        Some("Gate") => Some(transformation::gate::state_var(node)),
+        Some("RangeMap") => Some(transformation::range_map::value_var(node)),
+        Some("Smooth") => Some(transformation::smooth::value_var(node)),
         _ => None,
     }
 }
@@ -572,5 +583,162 @@ mod tests {
             first, second,
             "repeated generation must yield identical placeholder comments"
         );
+    }
+
+    // --- Transformation Nodes (Task #33) ---
+
+    /// Scenario: Calculate Node emits matching arithmetic.
+    ///
+    /// A Sensor drives a Calculate Node configured for `ceil`; the Sketch must
+    /// compute the Node's value from the sensor reading using the same unary
+    /// math the runtime applies, and feed it onward to a wired Led.
+    #[test]
+    fn calculate_node_emits_matching_arithmetic() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data("calc-1", "Calculate", json!({ "function": "ceil" })),
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+            ],
+            edges: vec![edge("sensor-1", "calc-1"), edge("calc-1", "led-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        assert!(sketch.contains("double calculate_calc_1_value"), "calc output decl");
+        assert!(
+            sketch.contains("calculate_calc_1_value = ceil("),
+            "calc must apply ceil to its input, got:\n{sketch}"
+        );
+        assert!(sketch.contains("sensor_sensor_1_value"), "calc reads the sensor");
+        // The Led is driven by the Calculate result, not a placeholder.
+        assert!(sketch.contains("digitalWrite(led_led_1_pin, (calculate_calc_1_value)"));
+        assert!(!sketch.contains("// unsupported Node calc"), "calc must not be a placeholder");
+        assert!(!sketch.contains("delay("), "stays non-blocking");
+    }
+
+    /// Scenario: Compare Node emits matching comparison.
+    #[test]
+    fn compare_node_emits_matching_comparison() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data(
+                    "cmp-1",
+                    "Compare",
+                    json!({ "validator": "number", "subValidator": "greater than", "number": 512.0 }),
+                ),
+            ],
+            edges: vec![edge("sensor-1", "cmp-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        assert!(sketch.contains("bool compare_cmp_1_result"), "compare bool decl");
+        assert!(
+            sketch.contains("> 512.0"),
+            "compare must emit the greater-than test, got:\n{sketch}"
+        );
+        assert!(!sketch.contains("// unsupported Node cmp"));
+    }
+
+    /// Scenario: Gate Node emits matching pass-through logic.
+    #[test]
+    fn gate_node_emits_matching_pass_through_logic() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("btn-1", "Button", json!({ "pin": 6 })),
+                node_data("gate-1", "Gate", json!({ "gate": "nand" })),
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+            ],
+            edges: vec![edge("btn-1", "gate-1"), edge("gate-1", "led-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        assert!(sketch.contains("bool gate_gate_1_result"), "gate bool decl");
+        // nand on a single input inverts it.
+        assert!(
+            sketch.contains("gate_gate_1_result = (!((bool)(button_btn_1_state)))"),
+            "nand gate must invert the button, got:\n{sketch}"
+        );
+        // The Led reads the gate result.
+        assert!(sketch.contains("digitalWrite(led_led_1_pin, (gate_gate_1_result)"));
+    }
+
+    /// Scenario: `RangeMap` and Smooth Nodes preserve their live behavior.
+    #[test]
+    fn range_map_and_smooth_preserve_live_behavior() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data(
+                    "rm-1",
+                    "RangeMap",
+                    json!({ "from": { "min": 0.0, "max": 1023.0 }, "to": { "min": 0.0, "max": 255.0 } }),
+                ),
+                node_data(
+                    "sm-1",
+                    "Smooth",
+                    json!({ "type": "movingAverage", "windowSize": 4 }),
+                ),
+            ],
+            edges: vec![edge("sensor-1", "rm-1"), edge("rm-1", "sm-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // RangeMap linear remap math with the configured bounds.
+        assert!(sketch.contains("double range_map_rm_1_value"), "range map decl");
+        assert!(sketch.contains("1023.0") && sketch.contains("255.0"), "range bounds present");
+        assert!(sketch.contains("round("), "range map rounds like the runtime");
+        // Smooth keeps a persistent rolling window (state survives loop iterations).
+        assert!(sketch.contains("double smooth_sm_1_window[4]"), "moving-average ring buffer");
+        assert!(sketch.contains("smooth_sm_1_value"), "smooth output decl");
+        assert!(!sketch.contains("delay("), "stays non-blocking despite state");
+    }
+
+    /// Scenario: No transformation Node is left as a placeholder.
+    #[test]
+    fn no_transformation_node_left_as_placeholder() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("calc-1", "Calculate", json!({ "function": "add" })),
+                node_data("cmp-1", "Compare", json!({ "validator": "boolean" })),
+                node_data("gate-1", "Gate", json!({ "gate": "and" })),
+                node_data("rm-1", "RangeMap", json!({})),
+                node_data("sm-1", "Smooth", json!({})),
+            ],
+            edges: vec![],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Every transformation Node declares real state; none is a placeholder.
+        assert!(sketch.contains("calculate_calc_1_value"));
+        assert!(sketch.contains("compare_cmp_1_result"));
+        assert!(sketch.contains("gate_gate_1_result"));
+        assert!(sketch.contains("range_map_rm_1_value"));
+        assert!(sketch.contains("smooth_sm_1_value"));
+        assert_eq!(
+            sketch.matches("// unsupported Node ").count(),
+            0,
+            "no transformation Node may be a placeholder, got:\n{sketch}"
+        );
+    }
+
+    /// Determinism holds for a transformation-heavy Flow.
+    #[test]
+    fn transformation_flow_is_deterministic() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data("rm-1", "RangeMap", json!({ "to": { "min": 0.0, "max": 5.0 } })),
+                node_data("sm-1", "Smooth", json!({ "type": "smooth", "attenuation": 0.8 })),
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+            ],
+            edges: vec![edge("sensor-1", "rm-1"), edge("rm-1", "sm-1"), edge("sm-1", "led-1")],
+        };
+        assert_eq!(generate(&flow).unwrap(), generate(&flow).unwrap());
     }
 }

--- a/apps/web/src-tauri/src/codegen/transformation/calculate.rs
+++ b/apps/web/src-tauri/src/codegen/transformation/calculate.rs
@@ -1,0 +1,111 @@
+//! Calculate emitter — mirrors `runtime/transformation/calculate.rs`.
+//!
+//! The live Calculate Node aggregates its inputs and applies an arithmetic
+//! function (`add`, `subtract`, `multiply`, `divide`, `modulo`, `max`, `min`,
+//! `pow`, `ceil`, `floor`, `round`), storing the result as its `Number` value.
+//!
+//! The generated value-passing model feeds a single driver expression into each
+//! transformation Node (the wired source with the smallest id). With a single
+//! input the runtime's fold semantics reduce to: `subtract`/`divide`/`modulo`
+//! return `inputs[0]` unchanged (the fold body is skipped), `add`/`max`/`min`
+//! return the value itself, `multiply` returns the value, `pow` returns the
+//! value (fewer than two inputs), and `ceil`/`floor`/`round` apply their unary
+//! math. We emit the matching single-input C++ so the Sketch reproduces what
+//! the Flow Author observes when one signal drives the Node.
+
+use crate::codegen::emit::{str_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `double` variable holding this Calculate Node's latest result.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("calculate_{}_value", node.id_token())
+}
+
+/// Build the C++ expression for the configured function applied to a single
+/// input value `v` (the driver expression). Mirrors the runtime's single-input
+/// fold semantics.
+fn function_expr(function: &str, v: &str) -> String {
+    match function {
+        // Unary math functions.
+        "ceil" => format!("ceil({v})"),
+        "floor" => format!("floor({v})"),
+        "round" => format!("round({v})"),
+        // Multi-input folds collapse to the first input when only one is wired.
+        // `add`/`subtract`/`multiply`/`divide`/`modulo`/`max`/`min`/`pow` all
+        // yield the input value itself for a single input.
+        _ => format!("({v})"),
+    }
+}
+
+/// Emit C++ for a Calculate Node. `driver` is the C++ numeric expression that
+/// feeds the Node, or `None` when nothing is wired in (the runtime leaves the
+/// value at its `0.0` initial state).
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let var = value_var(node);
+    let function = str_or_default(node, "function", "add");
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("double {var} = 0.0;")],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        let computed = function_expr(&function, &format!("(double)({expr})"));
+        e.loop_body.push(format!("{var} = {computed};"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn calc(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Calculate".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn declares_output_variable() {
+        let e = emit(&calc("c-1", json!({ "function": "add" })), None);
+        assert!(e.declarations.iter().any(|d| d.contains("calculate_c_1_value")));
+    }
+
+    #[test]
+    fn add_passes_single_input_through() {
+        let e = emit(&calc("c-1", json!({ "function": "add" })), Some("sensor_s_1_value"));
+        assert!(e.loop_body.iter().any(|l| l.contains("sensor_s_1_value")));
+        assert!(!e.loop_body.iter().any(|l| l.contains("ceil")));
+    }
+
+    #[test]
+    fn ceil_floor_round_emit_unary_math() {
+        for func in ["ceil", "floor", "round"] {
+            let e = emit(&calc("c-1", json!({ "function": func })), Some("x"));
+            assert!(
+                e.loop_body.iter().any(|l| l.contains(func)),
+                "expected {func} call"
+            );
+        }
+    }
+
+    #[test]
+    fn no_driver_emits_no_loop_body() {
+        let e = emit(&calc("c-1", json!({ "function": "add" })), None);
+        assert!(e.loop_body.is_empty());
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = calc("c-1", json!({ "function": "multiply" }));
+        assert_eq!(emit(&n, Some("x")), emit(&n, Some("x")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/transformation/compare.rs
+++ b/apps/web/src-tauri/src/codegen/transformation/compare.rs
@@ -1,0 +1,167 @@
+//! Compare emitter — mirrors `runtime/transformation/compare.rs`.
+//!
+//! The live Compare Node validates its input against a configured `validator`
+//! and `subValidator`, storing a `Bool` result:
+//! - `boolean` — truthiness of the input.
+//! - `number` — `greater than` / `less than` / (default) equals `number`.
+//! - `oddeven` — `odd` / (default) even, on the rounded input.
+//! - `range` — `outside` the `[min, max]` bounds / (default) strictly inside.
+//! - `text` — string predicates; not expressible against the numeric/boolean
+//!   driver expressions of the generated value model, so it emits the runtime's
+//!   `false` default for an empty match.
+//!
+//! The generated Sketch stores the boolean outcome in a `bool` variable that
+//! downstream Nodes read, reproducing the live comparison for the wired input.
+
+use crate::codegen::emit::{cpp_double, f64_or_default, str_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `bool` variable holding this Compare Node's latest outcome.
+#[must_use]
+pub fn state_var(node: &FlowNode) -> String {
+    format!("compare_{}_result", node.id_token())
+}
+
+/// Build the C++ boolean expression for the configured comparison applied to
+/// the driver expression `v`.
+fn compare_expr(node: &FlowNode, v: &str) -> String {
+    let validator = str_or_default(node, "validator", "boolean");
+    let sub = str_or_default(node, "subValidator", "true");
+    match validator.as_str() {
+        "number" => {
+            let n = cpp_double(f64_or_default(node, "number", 0.0));
+            match sub.as_str() {
+                "greater than" => format!("((double)({v}) > {n})"),
+                "less than" => format!("((double)({v}) < {n})"),
+                _ => format!("((double)({v}) == {n})"),
+            }
+        }
+        "oddeven" => {
+            // Round to nearest integer first, matching `as i64` after `round()`.
+            let rounded = format!("((long)round((double)({v})))");
+            match sub.as_str() {
+                "odd" => format!("(({rounded} % 2) != 0)"),
+                _ => format!("(({rounded} % 2) == 0)"),
+            }
+        }
+        "range" => {
+            let min = cpp_double(f64_or_default_nested(node, "min", 0.0));
+            let max = cpp_double(f64_or_default_nested(node, "max", 100.0));
+            match sub.as_str() {
+                "outside" => format!("((double)({v}) < {min} || (double)({v}) > {max})"),
+                _ => format!("((double)({v}) > {min} && (double)({v}) < {max})"),
+            }
+        }
+        "text" => "false".to_string(),
+        // `boolean` (default): truthiness of the input.
+        _ => format!("((bool)({v}))"),
+    }
+}
+
+/// Read a numeric field from the nested `range` config object, falling back to
+/// `default` (mirrors `RangeConfig` defaults: `min` 0, `max` 100).
+fn f64_or_default_nested(node: &FlowNode, key: &str, default: f64) -> f64 {
+    node.data
+        .get("range")
+        .and_then(|r| r.get(key))
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(default)
+}
+
+/// Emit C++ for a Compare Node. `driver` is the wired input expression, or
+/// `None` when nothing is connected (the runtime leaves the result at `false`).
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let var = state_var(node);
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("bool {var} = false;")],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        let computed = compare_expr(node, expr);
+        e.loop_body.push(format!("{var} = {computed};"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn cmp(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Compare".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn boolean_validator_uses_truthiness() {
+        let e = emit(&cmp("c-1", json!({ "validator": "boolean" })), Some("x"));
+        assert!(e.loop_body.iter().any(|l| l.contains("(bool)")));
+    }
+
+    #[test]
+    fn number_greater_than_emits_comparison() {
+        let e = emit(
+            &cmp("c-1", json!({ "validator": "number", "subValidator": "greater than", "number": 5.0 })),
+            Some("v"),
+        );
+        assert!(e.loop_body.iter().any(|l| l.contains("> 5.0")));
+    }
+
+    #[test]
+    fn number_less_than_and_equals() {
+        let lt = emit(
+            &cmp("c-1", json!({ "validator": "number", "subValidator": "less than", "number": 2.0 })),
+            Some("v"),
+        );
+        assert!(lt.loop_body.iter().any(|l| l.contains("< 2.0")));
+        let eq = emit(
+            &cmp("c-1", json!({ "validator": "number", "subValidator": "equal", "number": 3.0 })),
+            Some("v"),
+        );
+        assert!(eq.loop_body.iter().any(|l| l.contains("== 3.0")));
+    }
+
+    #[test]
+    fn oddeven_emits_modulo() {
+        let odd = emit(&cmp("c-1", json!({ "validator": "oddeven", "subValidator": "odd" })), Some("v"));
+        assert!(odd.loop_body.iter().any(|l| l.contains("% 2) != 0")));
+        let even = emit(&cmp("c-1", json!({ "validator": "oddeven", "subValidator": "even" })), Some("v"));
+        assert!(even.loop_body.iter().any(|l| l.contains("% 2) == 0")));
+    }
+
+    #[test]
+    fn range_inside_and_outside() {
+        let inside = emit(
+            &cmp("c-1", json!({ "validator": "range", "range": { "min": 1.0, "max": 9.0 } })),
+            Some("v"),
+        );
+        assert!(inside.loop_body.iter().any(|l| l.contains("> 1.0") && l.contains("< 9.0")));
+        let outside = emit(
+            &cmp("c-1", json!({ "validator": "range", "subValidator": "outside", "range": { "min": 1.0, "max": 9.0 } })),
+            Some("v"),
+        );
+        assert!(outside.loop_body.iter().any(|l| l.contains("||")));
+    }
+
+    #[test]
+    fn no_driver_leaves_false() {
+        let e = emit(&cmp("c-1", json!({ "validator": "boolean" })), None);
+        assert!(e.loop_body.is_empty());
+        assert!(e.declarations.iter().any(|d| d.contains("= false;")));
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = cmp("c-1", json!({ "validator": "number", "number": 1.0 }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/transformation/gate.rs
+++ b/apps/web/src-tauri/src/codegen/transformation/gate.rs
@@ -1,0 +1,102 @@
+//! Gate emitter — mirrors `runtime/transformation/gate.rs`.
+//!
+//! The live Gate Node counts the truthy inputs and applies a boolean gate
+//! (`and`, `nand`, `or`, `xor`, `nor`, `xnor`) over `true_count` vs `total`.
+//!
+//! The generated value model feeds a single boolean driver into the Node
+//! (`total == 1`), so the gates collapse to: `and`/`or`/`xor` pass the input
+//! through (`true_count == total`, `> 0`, and `== 1` all equal the single
+//! input), while `nand`/`nor`/`xnor` invert it. We emit the matching
+//! single-input pass-through / inverting logic into a `bool` variable that
+//! downstream Nodes read, reproducing the live gate for the wired signal.
+
+use crate::codegen::emit::{str_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `bool` variable holding this Gate Node's latest outcome.
+#[must_use]
+pub fn state_var(node: &FlowNode) -> String {
+    format!("gate_{}_result", node.id_token())
+}
+
+/// Build the single-input C++ boolean expression for the configured gate over
+/// the driver expression `v`.
+fn gate_expr(gate: &str, v: &str) -> String {
+    match gate {
+        // Inverting gates for a single input.
+        "nand" | "nor" | "xnor" => format!("(!((bool)({v})))"),
+        // Pass-through gates for a single input (and / or / xor).
+        _ => format!("((bool)({v}))"),
+    }
+}
+
+/// Emit C++ for a Gate Node. `driver` is the wired boolean input, or `None`
+/// when nothing is connected (the runtime leaves the result at `false` because
+/// `check` is skipped for an empty input set).
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let var = state_var(node);
+    let gate = str_or_default(node, "gate", "and");
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("bool {var} = false;")],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        let computed = gate_expr(&gate, expr);
+        e.loop_body.push(format!("{var} = {computed};"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn gate(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Gate".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn and_or_xor_pass_through() {
+        for g in ["and", "or", "xor"] {
+            let e = emit(&gate("g-1", json!({ "gate": g })), Some("x"));
+            assert!(
+                e.loop_body.iter().any(|l| l.contains("(bool)(x)") && !l.contains("!(")),
+                "gate {g} should pass through"
+            );
+        }
+    }
+
+    #[test]
+    fn nand_nor_xnor_invert() {
+        for g in ["nand", "nor", "xnor"] {
+            let e = emit(&gate("g-1", json!({ "gate": g })), Some("x"));
+            assert!(
+                e.loop_body.iter().any(|l| l.contains("!((bool)(x))")),
+                "gate {g} should invert"
+            );
+        }
+    }
+
+    #[test]
+    fn no_driver_leaves_false() {
+        let e = emit(&gate("g-1", json!({ "gate": "and" })), None);
+        assert!(e.loop_body.is_empty());
+        assert!(e.declarations.iter().any(|d| d.contains("= false;")));
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = gate("g-1", json!({ "gate": "nand" }));
+        assert_eq!(emit(&n, Some("x")), emit(&n, Some("x")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/transformation/mod.rs
+++ b/apps/web/src-tauri/src/codegen/transformation/mod.rs
@@ -1,0 +1,21 @@
+//! Transformation-Node C++ emitters (Calculate, Compare, Gate, `RangeMap`,
+//! Smooth) — the codegen mirror of `runtime/transformation`.
+//!
+//! Each transformation Node is both a consumer and a producer in the generated
+//! value-passing model: it reads the C++ expression of its wired source (its
+//! `driver`) and writes its result into an output variable that downstream
+//! Nodes read. The output variable name is exposed by each module's
+//! `value_var`/`state_var` accessor so [`crate::codegen`] can wire it as a
+//! driver for the Node's targets.
+//!
+//! Like the input/output emitters, every emitter is a pure function of a single
+//! [`crate::runtime::types::FlowNode`] (plus its driver) and reads the same
+//! `data` the live runtime deserializes into its `*Config`. The emitted C++
+//! reproduces the runtime semantics so that, for identical inputs, the
+//! generated Sketch yields the same output the Flow Author sees in live mode.
+
+pub mod calculate;
+pub mod compare;
+pub mod gate;
+pub mod range_map;
+pub mod smooth;

--- a/apps/web/src-tauri/src/codegen/transformation/range_map.rs
+++ b/apps/web/src-tauri/src/codegen/transformation/range_map.rs
@@ -1,0 +1,131 @@
+//! `RangeMap` emitter — mirrors `runtime/transformation/range_map.rs`.
+//!
+//! The live `RangeMap` Node linearly remaps its input from a `from` range to a
+//! `to` range:
+//!
+//! ```text
+//! mapped = (input - from.min) * (to.max - to.min) / (from.max - from.min) + to.min
+//! ```
+//!
+//! then rounds `mapped` to a precision that depends on the output span: one
+//! decimal place when `|to.max - to.min| <= 10`, otherwise to the nearest whole
+//! number. It emits the normalized result as its `to` value. The runtime does
+//! not clamp — inputs at or beyond the `from` bounds extrapolate linearly — so
+//! the generated C++ mirrors that exact behavior (including the edge values).
+//!
+//! We emit the same arithmetic into a `double` variable downstream Nodes read.
+
+use crate::codegen::emit::{cpp_double, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `double` variable holding this `RangeMap` Node's mapped output.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("range_map_{}_value", node.id_token())
+}
+
+/// Read a numeric field from a nested range object (`from`/`to`) in the Node's
+/// `data`, falling back to `default`.
+fn range_field(node: &FlowNode, range: &str, key: &str, default: f64) -> f64 {
+    node.data
+        .get(range)
+        .and_then(|r| r.get(key))
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(default)
+}
+
+/// Emit C++ for a `RangeMap` Node. `driver` is the wired numeric input, or
+/// `None` when nothing is connected (the runtime leaves the value at `0.0`).
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let var = value_var(node);
+    // Mirror `Range` defaults: from 0..1023, to 0..1023.
+    let in_min = cpp_double(range_field(node, "from", "min", 0.0));
+    let in_max = cpp_double(range_field(node, "from", "max", 1023.0));
+    let out_min = cpp_double(range_field(node, "to", "min", 0.0));
+    let out_max = cpp_double(range_field(node, "to", "max", 1023.0));
+
+    // Precision factor: one decimal place when the output span is small, else
+    // whole numbers — matching the runtime's `distance <= 10.0` rule.
+    let distance = (range_field(node, "to", "max", 1023.0) - range_field(node, "to", "min", 0.0)).abs();
+    let factor = if distance <= 10.0 { "10.0" } else { "1.0" };
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("double {var} = 0.0;")],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        let mapped = format!(
+            "(((double)({expr}) - {in_min}) * ({out_max} - {out_min}) / ({in_max} - {in_min}) + {out_min})"
+        );
+        e.loop_body
+            .push(format!("{var} = round(({mapped}) * {factor}) / {factor};"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn rm(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("RangeMap".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn declares_output_variable() {
+        let e = emit(&rm("r-1", json!({})), None);
+        assert!(e.declarations.iter().any(|d| d.contains("range_map_r_1_value")));
+    }
+
+    #[test]
+    fn emits_linear_remap_math() {
+        let e = emit(
+            &rm("r-1", json!({ "from": { "min": 0.0, "max": 1023.0 }, "to": { "min": 0.0, "max": 255.0 } })),
+            Some("sensor_s_1_value"),
+        );
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("sensor_s_1_value"));
+        assert!(body.contains("1023.0"));
+        assert!(body.contains("255.0"));
+        assert!(body.contains("round("));
+    }
+
+    #[test]
+    fn small_output_span_uses_decimal_precision() {
+        let e = emit(
+            &rm("r-1", json!({ "from": { "min": 0.0, "max": 100.0 }, "to": { "min": 0.0, "max": 5.0 } })),
+            Some("v"),
+        );
+        assert!(e.loop_body.iter().any(|l| l.contains("* 10.0") && l.contains("/ 10.0")));
+    }
+
+    #[test]
+    fn large_output_span_uses_whole_numbers() {
+        let e = emit(
+            &rm("r-1", json!({ "from": { "min": 0.0, "max": 100.0 }, "to": { "min": 0.0, "max": 255.0 } })),
+            Some("v"),
+        );
+        assert!(e.loop_body.iter().any(|l| l.contains("* 1.0") && l.contains("/ 1.0")));
+    }
+
+    #[test]
+    fn no_driver_emits_no_loop_body() {
+        let e = emit(&rm("r-1", json!({})), None);
+        assert!(e.loop_body.is_empty());
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = rm("r-1", json!({ "to": { "min": 0.0, "max": 255.0 } }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/transformation/smooth.rs
+++ b/apps/web/src-tauri/src/codegen/transformation/smooth.rs
@@ -1,0 +1,151 @@
+//! Smooth emitter — mirrors `runtime/transformation/smooth.rs`.
+//!
+//! The live Smooth Node holds state across evaluations:
+//! - `smooth` (default) — exponential smoothing:
+//!   `result = attenuation * value + (1 - attenuation) * previous`,
+//!   seeded from the Node's running value.
+//! - `movingAverage` — the mean of the last `windowSize` inputs (a rolling
+//!   window that drops the oldest sample once full).
+//!
+//! Per the Feature's stateful-Node approach, the generated Sketch keeps a
+//! module-level state variable updated each loop iteration rather than
+//! recomputing from a full history. Exponential smoothing persists a single
+//! running `double`; the moving average persists a fixed-size ring buffer plus
+//! its fill count, reproducing the same rolling mean on-device. The output
+//! `double` is read by downstream Nodes.
+
+use crate::codegen::emit::{cpp_double, f64_or_default, str_or_default, u16_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `double` variable holding this Smooth Node's latest output.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("smooth_{}_value", node.id_token())
+}
+
+/// Emit C++ for a Smooth Node. `driver` is the wired numeric input, or `None`
+/// when nothing is connected (the runtime leaves the value at `0.0`).
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let var = value_var(node);
+    let smooth_type = str_or_default(node, "type", "smooth");
+
+    if smooth_type == "movingAverage" {
+        return moving_average(node, &token, &var, driver);
+    }
+    exponential(node, &var, driver)
+}
+
+/// Exponential smoothing: a single persistent running value.
+fn exponential(node: &FlowNode, var: &str, driver: Option<&str>) -> NodeEmission {
+    let attenuation = cpp_double(f64_or_default(node, "attenuation", 0.995));
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("double {var} = 0.0;")],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        e.loop_body.push(format!(
+            "{var} = {attenuation} * (double)({expr}) + (1.0 - {attenuation}) * {var};"
+        ));
+    }
+    e
+}
+
+/// Moving average over a fixed-size ring buffer plus fill count.
+fn moving_average(node: &FlowNode, token: &str, var: &str, driver: Option<&str>) -> NodeEmission {
+    // `windowSize` defaults to 25 in the runtime; guard against 0 to avoid a
+    // zero-length buffer / divide-by-zero in the emitted C++.
+    let window = u16_or_default(node, "windowSize", 25).max(1);
+    let buf = format!("smooth_{token}_window");
+    let idx = format!("smooth_{token}_index");
+    let count = format!("smooth_{token}_count");
+
+    let mut e = NodeEmission {
+        declarations: vec![
+            format!("double {buf}[{window}] = {{0}};"),
+            format!("int {idx} = 0;"),
+            format!("int {count} = 0;"),
+            format!("double {var} = 0.0;"),
+        ],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        e.loop_body.push(format!("{buf}[{idx}] = (double)({expr});"));
+        e.loop_body.push(format!("{idx} = ({idx} + 1) % {window};"));
+        e.loop_body
+            .push(format!("if ({count} < {window}) {{ {count}++; }}"));
+        e.loop_body.push(format!("double smooth_{token}_sum = 0.0;"));
+        e.loop_body
+            .push(format!("for (int i = 0; i < {count}; i++) {{ smooth_{token}_sum += {buf}[i]; }}"));
+        e.loop_body
+            .push(format!("{var} = smooth_{token}_sum / {count};"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn smooth(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Smooth".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn exponential_persists_running_value() {
+        let e = emit(&smooth("s-1", json!({ "type": "smooth", "attenuation": 0.9 })), Some("v"));
+        // Decl is a single persistent double; loop updates it from itself.
+        assert!(e.declarations.iter().any(|d| d.contains("smooth_s_1_value")));
+        assert!(e.loop_body.iter().any(|l| l.contains("0.9") && l.contains("smooth_s_1_value")));
+    }
+
+    #[test]
+    fn moving_average_uses_ring_buffer() {
+        let e = emit(
+            &smooth("s-1", json!({ "type": "movingAverage", "windowSize": 5 })),
+            Some("v"),
+        );
+        assert!(e.declarations.iter().any(|d| d.contains("smooth_s_1_window[5]")));
+        assert!(e.loop_body.iter().any(|l| l.contains("% 5")));
+        assert!(e.loop_body.iter().any(|l| l.contains("sum")));
+    }
+
+    #[test]
+    fn moving_average_guards_zero_window() {
+        let e = emit(
+            &smooth("s-1", json!({ "type": "movingAverage", "windowSize": 0 })),
+            Some("v"),
+        );
+        assert!(e.declarations.iter().any(|d| d.contains("smooth_s_1_window[1]")));
+    }
+
+    #[test]
+    fn default_type_is_exponential() {
+        let e = emit(&smooth("s-1", json!({})), Some("v"));
+        assert!(e.loop_body.iter().any(|l| l.contains("0.995")));
+    }
+
+    #[test]
+    fn no_driver_emits_no_loop_body() {
+        let e = emit(&smooth("s-1", json!({})), None);
+        assert!(e.loop_body.is_empty());
+        assert!(e.declarations.iter().any(|d| d.contains("= 0.0;")));
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = smooth("s-1", json!({ "type": "movingAverage", "windowSize": 3 }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}


### PR DESCRIPTION
## Summary

First codegen-emit task of Feature #25. Adds a `codegen/transformation/` submodule mirroring `runtime/transformation/`, with per-Node C++ emitters for **Calculate, Compare, Gate, RangeMap, Smooth**, dispatched by `FlowNode.node_type`. Each emitter reads the same config fields its live-runtime counterpart reads and writes its result into the shared value-passing model so downstream Nodes consume it. Previously these Nodes rendered as placeholders.

## What changed

- `codegen/transformation/{calculate,compare,gate,range_map,smooth}.rs` — new emitters, each a pure function of a `FlowNode` (+ its driver expression).
- `codegen/mod.rs` — register the five types in `emit_node` dispatch and as `source_expression` drivers; integration tests for all five Gherkin scenarios + determinism.
- `codegen/emit.rs` — added `f64_or_default`, `str_or_default`, `cpp_double` helpers (with tests).

## Semantics mirrored

- **Calculate**: single-input fold semantics (unary `ceil`/`floor`/`round`; pass-through for binary folds with one wired input).
- **Compare**: `boolean` / `number` (gt/lt/eq) / `oddeven` / `range` (inside/outside); `text` → runtime `false` default (not expressible against numeric drivers).
- **Gate**: single-input collapse — `and`/`or`/`xor` pass through, `nand`/`nor`/`xnor` invert.
- **RangeMap**: exact linear remap + precision rounding (`distance <= 10` → 1 decimal else whole), no clamp (matches runtime).
- **Smooth**: stateful — persistent running value (exponential) or module-level ring buffer + count (moving average), updated each loop. Non-blocking.

## Verification

- `cargo test codegen::` — 80 passed.
- `cargo clippy --all-targets` clean; `-W clippy::pedantic` clean for changed files.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)