### PR TITLE
feat(flow): add a Download action to the sketch Code view

### DIFF
--- a/apps/web/src/components/flow/__tests__/sketch-code-view.test.ts
+++ b/apps/web/src/components/flow/__tests__/sketch-code-view.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 import type { Edge, Node } from "@xyflow/react";
 import {
   buildGenerateSketchCommand,
+  buildSketchDownloadRequest,
+  canDownloadSketch,
   createDebouncedRegenerator,
+  GENERATING_SKETCH_PLACEHOLDER,
   hasFlowChanged,
   projectSketchResult,
   serializeFlowGraph,
@@ -321,5 +324,89 @@ describe("createDebouncedRegenerator", () => {
     await flush();
 
     expect(results.map((r) => r.value)).toEqual(["latest"]);
+  });
+});
+
+describe("canDownloadSketch", () => {
+  // Scenario: Download control is available on the Code view
+  test("a generated sketch enables download", () => {
+    const state: SketchViewState = {
+      value: "void setup() {}\nvoid loop() {}",
+      isError: false,
+    };
+
+    expect(canDownloadSketch(state)).toBe(true);
+  });
+
+  // Scenario: Download control available for a Flow with unsupported Nodes
+  test("a sketch with unsupported-Node placeholder comments still enables download", () => {
+    const state: SketchViewState = {
+      value: ["// microflow generated sketch", "// Unsupported node: Mqtt", "void loop() {}"].join(
+        "\n",
+      ),
+      isError: false,
+    };
+
+    expect(canDownloadSketch(state)).toBe(true);
+  });
+
+  // Scenario: Download control available for an unnamed Flow
+  test("an unnamed Flow (empty-stub sketch) still enables download", () => {
+    const state: SketchViewState = { value: "void setup() {}\nvoid loop() {}", isError: false };
+
+    // The view state carries no Flow name; download stays enabled regardless.
+    expect(canDownloadSketch(state)).toBe(true);
+  });
+
+  test("the generating placeholder disables download until a sketch exists", () => {
+    const state: SketchViewState = { value: GENERATING_SKETCH_PLACEHOLDER, isError: false };
+
+    expect(canDownloadSketch(state)).toBe(false);
+  });
+
+  test("an empty value disables download (nothing to hand off yet)", () => {
+    expect(canDownloadSketch({ value: "", isError: false })).toBe(false);
+  });
+
+  test("a generation error disables download", () => {
+    const state: SketchViewState = {
+      value: "// Failed to generate sketch:\n// boom",
+      isError: true,
+    };
+
+    expect(canDownloadSketch(state)).toBe(false);
+  });
+});
+
+describe("buildSketchDownloadRequest", () => {
+  // Scenario: Activating Download starts the hand-off
+  test("wraps the displayed sketch in a SketchDownloaded intent", () => {
+    const sketch = "void setup() {}\nvoid loop() {}";
+
+    expect(buildSketchDownloadRequest(sketch)).toEqual({
+      type: "SketchDownloaded",
+      sketch,
+    });
+  });
+
+  // Invariant: the string handed off is byte-for-byte what the view displays
+  test("preserves the sketch string byte-for-byte", () => {
+    const sketch = [
+      "// microflow generated sketch",
+      "void setup() {",
+      "  pinMode(13, OUTPUT);",
+      "}",
+      "void loop() {}",
+      "", // trailing newline preserved
+    ].join("\n");
+
+    expect(buildSketchDownloadRequest(sketch).sketch).toBe(sketch);
+  });
+
+  // Edge case: placeholder-comment sketch is handed off verbatim
+  test("hands off an unsupported-Node placeholder sketch verbatim", () => {
+    const sketch = "// Unsupported node: Mqtt\nvoid loop() {}";
+
+    expect(buildSketchDownloadRequest(sketch).sketch).toBe(sketch);
   });
 });

--- a/apps/web/src/components/flow/sketch-code-view.model.ts
+++ b/apps/web/src/components/flow/sketch-code-view.model.ts
@@ -26,6 +26,51 @@ export type SketchViewState = {
   isError: boolean;
 };
 
+/**
+ * Placeholder text shown in the editor before the first sketch arrives. The
+ * Download control treats this as "nothing to hand off yet" (see
+ * `canDownloadSketch`).
+ */
+export const GENERATING_SKETCH_PLACEHOLDER = "// Generating sketch…";
+
+/**
+ * The `SketchDownloaded` intent — emitted when the Author activates the Download
+ * control. It carries the exact sketch string the Code view currently displays.
+ * The downstream write task (#31) consumes this to perform the disk write.
+ */
+export type SketchDownloadRequest = {
+  type: "SketchDownloaded";
+  /** The displayed sketch, byte-for-byte. */
+  sketch: string;
+};
+
+/** Handler seam invoked when the Author activates the Download control. */
+export type SketchDownloadHandler = (request: SketchDownloadRequest) => void;
+
+/**
+ * Whether the Download control should be enabled for the given view state.
+ *
+ * Enabled whenever a real sketch is displayed — including sketches that contain
+ * placeholder comments for unsupported / Cloud Nodes and sketches generated for
+ * an unnamed Flow. Disabled only when there is nothing meaningful to hand off:
+ * the not-yet-generated placeholder, an empty value, or a generation error.
+ */
+export function canDownloadSketch(state: SketchViewState): boolean {
+  if (state.isError) return false;
+  if (state.value === "") return false;
+  if (state.value === GENERATING_SKETCH_PLACEHOLDER) return false;
+  return true;
+}
+
+/**
+ * Build the `SketchDownloaded` intent from the displayed sketch. The sketch is
+ * carried through unchanged so the file written downstream matches the Code
+ * view byte-for-byte.
+ */
+export function buildSketchDownloadRequest(sketch: string): SketchDownloadRequest {
+  return { type: "SketchDownloaded", sketch };
+}
+
 /** Build the `generate_sketch` command from the current Flow graph. */
 export function buildGenerateSketchCommand(nodes: Node[], edges: Edge[]): GenerateSketchCommand {
   return { type: "generate_sketch", flow: { nodes, edges } };

--- a/apps/web/src/components/flow/sketch-code-view.tsx
+++ b/apps/web/src/components/flow/sketch-code-view.tsx
@@ -2,16 +2,29 @@ import { useEffect, useRef, useState } from "react";
 import Editor, { loader } from "@monaco-editor/react";
 import * as monaco from "monaco-editor";
 import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Download } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 import { useTheme } from "@/providers/theme-provider";
 import { useFlowSession, useFlowNodes, useFlowEdges } from "@/session";
 import { invokeCommand } from "@/lib/ipc";
 import {
+  buildSketchDownloadRequest,
+  canDownloadSketch,
   createDebouncedRegenerator,
+  GENERATING_SKETCH_PLACEHOLDER,
   projectSketchResult,
   serializeFlowGraph,
+  type SketchDownloadHandler,
   type SketchInvoker,
   type SketchResponse,
+  type SketchViewState,
 } from "./sketch-code-view.model";
 
 // Use local bundle + workers instead of CDN (required for offline Tauri).
@@ -33,12 +46,29 @@ const invoke: SketchInvoker = (command) => invokeCommand(command) as Promise<Ske
  * Flow graph changes while the view is open (Task #47). The editor is always
  * read-only — the Author can read and copy but not edit.
  */
-export function SketchCodeView({ onClose }: { onClose: () => void }) {
+/**
+ * No-op download handler. The real disk write / save dialog lands in sibling
+ * Task #31; until then the control still emits the `SketchDownloaded` intent so
+ * the trigger is wired and testable in isolation.
+ */
+const noopDownload: SketchDownloadHandler = () => {};
+
+export function SketchCodeView({
+  onClose,
+  onDownload = noopDownload,
+}: {
+  onClose: () => void;
+  onDownload?: SketchDownloadHandler;
+}) {
   const { theme } = useTheme();
   const { doc } = useFlowSession();
   const nodes = useFlowNodes(doc);
   const edges = useFlowEdges(doc);
-  const [value, setValue] = useState("// Generating sketch…");
+  const [state, setState] = useState<SketchViewState>({
+    value: GENERATING_SKETCH_PLACEHOLDER,
+    isError: false,
+  });
+  const { value } = state;
 
   type GenNode = Parameters<typeof projectSketchResult>[1][number];
   type GenEdge = Parameters<typeof projectSketchResult>[2][number];
@@ -49,8 +79,8 @@ export function SketchCodeView({ onClose }: { onClose: () => void }) {
   // does not trigger a redundant regeneration.
   useEffect(() => {
     let cancelled = false;
-    void projectSketchResult(invoke, genNodes, genEdges).then((state) => {
-      if (!cancelled) setValue(state.value);
+    void projectSketchResult(invoke, genNodes, genEdges).then((next) => {
+      if (!cancelled) setState(next);
     });
     return () => {
       cancelled = true;
@@ -64,7 +94,7 @@ export function SketchCodeView({ onClose }: { onClose: () => void }) {
   if (regeneratorRef.current === null) {
     regeneratorRef.current = createDebouncedRegenerator({
       invoker: invoke,
-      onResult: (state) => setValue(state.value),
+      onResult: (next) => setState(next),
       seedSerialized: serializeFlowGraph(genNodes, genEdges),
     });
   }
@@ -104,6 +134,17 @@ export function SketchCodeView({ onClose }: { onClose: () => void }) {
             }}
           />
         </div>
+        <DialogFooter className="px-6 py-4 shrink-0">
+          <Button
+            type="button"
+            disabled={!canDownloadSketch(state)}
+            onClick={() => onDownload(buildSketchDownloadRequest(value))}
+            aria-label="Download sketch"
+          >
+            <Download aria-hidden="true" />
+            Download sketch
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary

A Flow Author can already read their generated Arduino sketch in the in-app Code view (Feature #23), but has no way to take it out of microflow. This PR adds the entry point for Feature #24 ("Download the generated sketch as an `.ino` file"): a visible, keyboard-accessible **Download** control on the Code view that triggers the `SketchDownloaded` hand-off.

This task delivers the trigger surface only. The actual disk write / save dialog (sibling Task #31) and filename derivation are out of scope — the control emits a `SketchDownloaded` intent through a handler seam that defaults to a no-op until #31 lands.

## Changes

- **Download intent + enablement logic** (`sketch-code-view.model.ts`): pure, unit-tested helpers mirroring the #23 model split.
  - `canDownloadSketch(state)` — enabled whenever a real sketch is displayed (including unsupported-Node placeholder comments and unnamed-Flow sketches); disabled for the generating placeholder, empty value, or generation error.
  - `buildSketchDownloadRequest(sketch)` — builds the `SketchDownloaded` intent carrying the displayed sketch byte-for-byte; the seam Task #31 consumes.
  - `GENERATING_SKETCH_PLACEHOLDER` extracted from the component.
- **Download control** (`sketch-code-view.tsx`): a keyboard-focusable `Download sketch` button (shadcn `Button` + `lucide` `Download` icon) in the dialog footer, wired to an optional `onDownload` handler seam. The component now tracks the full view state so a generation error disables the control.

## Test plan

- [x] Download control is available on the Code view — `canDownloadSketch` enables for a generated sketch; button renders with an accessible label.
- [x] Activating Download starts the hand-off — `buildSketchDownloadRequest` emits the `SketchDownloaded` intent with the sketch preserved byte-for-byte.
- [x] Download control available for a Flow with unsupported Nodes — `canDownloadSketch` stays enabled for placeholder-comment sketches.
- [x] Download control available for an unnamed Flow — `canDownloadSketch` stays enabled for the empty-stub sketch.
- [x] `bun test` (25 pass), `oxlint` (0 warnings/errors), `oxfmt --check`, and `tsc --noEmit` all clean for the changed files.

## Related

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)
