### PR TITLE
feat(codegen): emit control Nodes as non-blocking timers

### DIFF
--- a/apps/web/src-tauri/src/codegen/control/constant.rs
+++ b/apps/web/src-tauri/src/codegen/control/constant.rs
@@ -1,0 +1,72 @@
+//! Constant emitter — mirrors `runtime/generator/constant.rs`.
+//!
+//! The live Constant Node holds a single fixed `value` (default `1337.0`) and
+//! never changes it. Per the Task's Technical Approach, Constant emits a single
+//! compile-time `double` initialised to that value rather than any per-loop
+//! work — there is no timing or state to update. Downstream Nodes read the
+//! output variable directly.
+
+use crate::codegen::emit::{cpp_double, f64_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `double` variable holding this Constant Node's fixed value.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("constant_{}_value", node.id_token())
+}
+
+/// Emit C++ for a Constant Node. The value is fixed at declaration time, so the
+/// emitter contributes only a declaration — no `setup()` or `loop()` work. The
+/// `driver` is unused: a Constant ignores its inputs, exactly as the runtime's
+/// `dispatch` rejects every method.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let var = value_var(node);
+    let value = cpp_double(f64_or_default(node, "value", 1337.0));
+
+    NodeEmission {
+        declarations: vec![format!("double {var} = {value};")],
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn constant(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Constant".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn emits_configured_value() {
+        let e = emit(&constant("c-1", json!({ "value": 42.0 })));
+        assert!(e.declarations.iter().any(|d| d.contains("constant_c_1_value = 42.0")));
+    }
+
+    #[test]
+    fn defaults_to_live_runtime_value() {
+        let e = emit(&constant("c-1", json!({})));
+        assert!(e.declarations.iter().any(|d| d.contains("= 1337.0")));
+    }
+
+    #[test]
+    fn does_no_per_loop_work() {
+        let e = emit(&constant("c-1", json!({ "value": 1.0 })));
+        assert!(e.loop_body.is_empty(), "constant must not emit per-loop work");
+        assert!(e.setup.is_empty());
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = constant("c-1", json!({ "value": 7.5 }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/control/counter.rs
+++ b/apps/web/src-tauri/src/codegen/control/counter.rs
@@ -1,0 +1,94 @@
+//! Counter emitter — mirrors `runtime/control/counter.rs`.
+//!
+//! The live Counter starts at `0.0` and increments by one each time its
+//! `increment` port receives a signal. In the generated single-driver value
+//! model a Counter has one wired input that pulses it; the Sketch increments the
+//! running count on the *rising edge* of that driver (a transition from falsey
+//! to truthy), matching one signal == one increment. The count is a module-level
+//! `double` so it persists across `loop()` iterations exactly as the runtime's
+//! `ComponentBase` value persists across signals — the on-device count never
+//! resets between iterations.
+
+use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `double` variable holding this Counter Node's running count. Exposed
+/// as the Node's readable value for downstream Nodes.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("counter_{}_count", node.id_token())
+}
+
+/// Emit C++ for a Counter Node. `driver` is the wired pulse input, or `None`
+/// when nothing is connected (the runtime never increments without a signal).
+///
+/// The count and a `_prev` edge-tracking flag are module-level so they persist
+/// across loop iterations; the increment only fires on a rising edge so a driver
+/// that stays truthy counts once, mirroring discrete signals.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let var = value_var(node);
+    let prev = format!("counter_{token}_prev");
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("double {var} = 0.0;")],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        // Track the previous truthiness so a sustained-high driver counts once.
+        e.declarations.push(format!("bool {prev} = false;"));
+        e.loop_body.push(format!("bool counter_{token}_now = (bool)({expr});"));
+        e.loop_body
+            .push(format!("if (counter_{token}_now && !{prev}) {{ {var} += 1.0; }}"));
+        e.loop_body.push(format!("{prev} = counter_{token}_now;"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn counter(id: &str) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Counter".to_string()),
+            data: json!({}),
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn count_starts_at_zero_and_persists() {
+        let e = emit(&counter("ct-1"), Some("v"));
+        // Module-level declaration => persists across loop iterations.
+        assert!(e.declarations.iter().any(|d| d.contains("double counter_ct_1_count = 0.0")));
+    }
+
+    #[test]
+    fn increments_on_rising_edge_only() {
+        let e = emit(&counter("ct-1"), Some("v"));
+        assert!(e.loop_body.iter().any(|l| l.contains("+= 1.0")), "must increment");
+        assert!(
+            e.loop_body.iter().any(|l| l.contains("&& !counter_ct_1_prev")),
+            "increment must be guarded by a rising edge"
+        );
+    }
+
+    #[test]
+    fn no_driver_keeps_count_static() {
+        let e = emit(&counter("ct-1"), None);
+        assert!(e.loop_body.is_empty(), "no input => no increment");
+        assert!(e.declarations.iter().any(|d| d.contains("= 0.0")));
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = counter("ct-1");
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/control/delay.rs
+++ b/apps/web/src-tauri/src/codegen/control/delay.rs
@@ -1,0 +1,118 @@
+//! Delay emitter — mirrors `runtime/control/delay.rs`.
+//!
+//! The live Delay stores an incoming signal and re-emits it `delay` ms later
+//! (default `1000`) via a spawned thread that sleeps. On device the wait must be
+//! non-blocking, so the generated Sketch captures the input value and a
+//! deadline timestamp in module-level state, then fires when
+//! `millis() - armed_at >= delay`. The loop never blocks while the Delay is
+//! pending — the rest of the Flow keeps running — and the unsigned elapsed-time
+//! subtraction survives `millis()` rollover.
+//!
+//! Arming is edge-triggered (a rising edge on the driver) so a single signal
+//! schedules a single fire, matching one `trigger` call == one delayed emit.
+//! `forgetPrevious` is reproduced by re-arming on each new edge (the latest edge
+//! wins), which is the same observable result as the runtime cancelling the
+//! prior thread.
+
+use crate::codegen::emit::{u64_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `double` variable holding this Delay Node's most recently emitted
+/// (delayed) value, read by downstream Nodes.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("delay_{}_value", node.id_token())
+}
+
+/// Emit C++ for a Delay Node. `driver` is the wired input to be delayed, or
+/// `None` when nothing is connected (the runtime never arms without a signal).
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let var = value_var(node);
+    let pending = format!("delay_{token}_pending");
+    let armed = format!("delay_{token}_armed_at");
+    let stored = format!("delay_{token}_stored");
+    let prev = format!("delay_{token}_prev");
+    let delay_ms = u64_or_default(node, "delay", 1000);
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("double {var} = 0.0;")],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        e.declarations.push(format!("bool {pending} = false;"));
+        e.declarations.push(format!("unsigned long {armed} = 0;"));
+        e.declarations.push(format!("double {stored} = 0.0;"));
+        e.declarations.push(format!("bool {prev} = false;"));
+
+        // Arm on a rising edge: capture the value and the deadline start.
+        e.loop_body.push(format!("bool delay_{token}_now = (bool)({expr});"));
+        e.loop_body.push(format!("if (delay_{token}_now && !{prev}) {{"));
+        e.loop_body.push(format!("  {stored} = (double)({expr});"));
+        e.loop_body.push(format!("  {armed} = millis();"));
+        e.loop_body.push(format!("  {pending} = true;"));
+        e.loop_body.push("}".to_string());
+        e.loop_body.push(format!("{prev} = delay_{token}_now;"));
+        // Fire once the delay has elapsed — non-blocking elapsed-time compare.
+        e.loop_body
+            .push(format!("if ({pending} && millis() - {armed} >= {delay_ms}UL) {{"));
+        e.loop_body.push(format!("  {var} = {stored};"));
+        e.loop_body.push(format!("  {pending} = false;"));
+        e.loop_body.push("}".to_string());
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn delay(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Delay".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn fires_after_configured_delay_without_blocking() {
+        let e = emit(&delay("d-1", json!({ "delay": 750 })), Some("v"));
+        assert!(
+            e.loop_body.iter().any(|l| l.contains("millis() - delay_d_1_armed_at >= 750UL")),
+            "delay must fire on an elapsed-time comparison"
+        );
+        assert!(!e.loop_body.iter().any(|l| l.contains("delay(")), "must not block");
+    }
+
+    #[test]
+    fn defaults_to_one_second() {
+        let e = emit(&delay("d-1", json!({})), Some("v"));
+        assert!(e.loop_body.iter().any(|l| l.contains(">= 1000UL")));
+    }
+
+    #[test]
+    fn state_persists_across_iterations() {
+        let e = emit(&delay("d-1", json!({})), Some("v"));
+        assert!(e.declarations.iter().any(|d| d.contains("bool delay_d_1_pending")));
+        assert!(e.declarations.iter().any(|d| d.contains("unsigned long delay_d_1_armed_at")));
+    }
+
+    #[test]
+    fn no_driver_emits_no_timing() {
+        let e = emit(&delay("d-1", json!({})), None);
+        assert!(e.loop_body.is_empty());
+        assert!(e.declarations.iter().any(|d| d.contains("delay_d_1_value = 0.0")));
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = delay("d-1", json!({ "delay": 200 }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/control/interval.rs
+++ b/apps/web/src-tauri/src/codegen/control/interval.rs
@@ -1,0 +1,112 @@
+//! Interval emitter — mirrors `runtime/generator/interval.rs`.
+//!
+//! The live Interval spawns a thread that sleeps `interval` ms (clamped to a
+//! `MIN_INTERVAL_MS` of 16) and emits the elapsed milliseconds on every tick. On
+//! device there is no thread to sleep, so the generated Sketch keeps the timer's
+//! last-fire timestamp in a module-level `unsigned long` and, each `loop()`
+//! iteration, fires when `millis() - previous >= interval`. This is fully
+//! non-blocking: the loop never waits, multiple Intervals tick concurrently, and
+//! the unsigned subtraction survives `millis()` rollover (~49 days) without
+//! stalling. The output `double` holds the elapsed time since `setup()`, mirror‑
+//! ing the runtime's `start.elapsed()` value, so downstream Nodes see the same
+//! signal they do in live mode.
+
+use crate::codegen::emit::{u64_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Runtime clamps the interval to at least this many milliseconds.
+const MIN_INTERVAL_MS: u64 = 16;
+
+/// The C++ `double` variable holding this Interval Node's latest elapsed-time
+/// output (milliseconds since `setup()`), updated on each fire.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("interval_{}_value", node.id_token())
+}
+
+/// Emit C++ for an Interval Node. The Interval is self-driving (it is a
+/// generator), so it ignores any `driver`; it ticks purely off the loop
+/// scheduler's `millis()` clock.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let token = node.id_token();
+    let var = value_var(node);
+    let previous = format!("interval_{token}_previous");
+    let start = format!("interval_{token}_start");
+    let interval_ms = u64_or_default(node, "interval", 1000).max(MIN_INTERVAL_MS);
+
+    NodeEmission {
+        declarations: vec![
+            format!("unsigned long {previous} = 0;"),
+            format!("unsigned long {start} = 0;"),
+            format!("double {var} = 0.0;"),
+        ],
+        // Seed both timestamps so the first tick is measured from boot, not 0.
+        setup: vec![format!("{previous} = millis();"), format!("{start} = millis();")],
+        loop_body: vec![
+            // Non-blocking: compare elapsed time, never block the loop.
+            format!("if (millis() - {previous} >= {interval_ms}UL) {{"),
+            format!("  {previous} += {interval_ms}UL;"),
+            format!("  {var} = (double)(millis() - {start});"),
+            "}".to_string(),
+        ],
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn interval(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Interval".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn fires_on_millis_comparison_without_blocking() {
+        let e = emit(&interval("iv-1", json!({ "interval": 500 })));
+        assert!(
+            e.loop_body.iter().any(|l| l.contains("millis() - interval_iv_1_previous >= 500UL")),
+            "must compare elapsed millis against the configured interval"
+        );
+        assert!(
+            !e.loop_body.iter().any(|l| l.contains("delay(")),
+            "interval must never block"
+        );
+    }
+
+    #[test]
+    fn clamps_to_min_interval() {
+        let e = emit(&interval("iv-1", json!({ "interval": 1 })));
+        assert!(
+            e.loop_body.iter().any(|l| l.contains(">= 16UL")),
+            "interval below the runtime minimum must clamp to 16ms"
+        );
+    }
+
+    #[test]
+    fn defaults_to_one_second() {
+        let e = emit(&interval("iv-1", json!({})));
+        assert!(e.loop_body.iter().any(|l| l.contains(">= 1000UL")));
+    }
+
+    #[test]
+    fn keeps_timestamps_across_iterations() {
+        let e = emit(&interval("iv-1", json!({})));
+        assert!(e.declarations.iter().any(|d| d.contains("unsigned long interval_iv_1_previous")));
+        assert!(e.setup.iter().any(|s| s.contains("= millis()")), "timer seeded in setup");
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = interval("iv-1", json!({ "interval": 250 }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/control/mod.rs
+++ b/apps/web/src-tauri/src/codegen/control/mod.rs
@@ -1,0 +1,31 @@
+//! Control-Node C++ emitters (Delay, Interval, Trigger, Counter, Constant) —
+//! the codegen mirror of `runtime/control` and `runtime/generator/constant`.
+//!
+//! On-device there is no host event loop, so the live runtime's thread-and-sleep
+//! timing model (`std::thread::spawn` + `sleep` in `runtime/control/delay.rs` and
+//! `runtime/generator/interval.rs`) cannot be reproduced verbatim — a blocking
+//! `delay()` would freeze the whole Sketch. Instead every timing Node compares
+//! `millis()` against a stored next-fire timestamp and yields control each loop
+//! iteration, so multiple timers tick concurrently without one stalling the
+//! others. Stateful Nodes (Counter count, Delay/Interval timestamps) keep their
+//! state in module-level variables that persist across `loop()` iterations.
+//!
+//! Like the input/output and transformation emitters, every emitter is a pure
+//! function of a single [`crate::runtime::types::FlowNode`] (plus its driver)
+//! and reads the same `data` the live runtime deserializes into its `*Config`.
+//! The emitted C++ reproduces the runtime semantics so that, for identical
+//! inputs, the generated Sketch yields the same output the Flow Author sees in
+//! live mode.
+//!
+//! ## Non-blocking timer invariant
+//!
+//! No emitter in this module ever emits a blocking `delay()`. Timing is always
+//! expressed as `millis() - previous >= interval` so the scheduler in
+//! [`crate::codegen`] completes every iteration without waiting, and `millis()`
+//! rollover (~49 days) is handled by the unsigned elapsed-time subtraction.
+
+pub mod constant;
+pub mod counter;
+pub mod delay;
+pub mod interval;
+pub mod trigger;

--- a/apps/web/src-tauri/src/codegen/control/trigger.rs
+++ b/apps/web/src-tauri/src/codegen/control/trigger.rs
@@ -1,0 +1,129 @@
+//! Trigger emitter — mirrors `runtime/control/trigger.rs`.
+//!
+//! The live Trigger watches a numeric signal and emits a boolean "bang" when the
+//! value moves past `threshold` in the configured direction (`increasing` /
+//! `decreasing`) within a recent window. It keeps a baseline from which the
+//! difference is measured. The generated Sketch reproduces this with a
+//! module-level baseline `double` and a boolean output: each loop iteration it
+//! compares the current driver value against the baseline and sets the output
+//! when the threshold is crossed in the correct direction. `relative` switches
+//! the comparison to a percentage of the baseline, matching the runtime. State
+//! persists across iterations so the baseline survives, and the output `bool` is
+//! read by downstream Nodes.
+
+use crate::codegen::emit::{bool_flag, cpp_double, f64_or_default, str_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `bool` variable holding this Trigger Node's latest bang state.
+#[must_use]
+pub fn state_var(node: &FlowNode) -> String {
+    format!("trigger_{}_result", node.id_token())
+}
+
+/// Emit C++ for a Trigger Node. `driver` is the wired numeric input, or `None`
+/// when nothing is connected (the runtime never bangs without a signal).
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let var = state_var(node);
+    let baseline = format!("trigger_{token}_baseline");
+    let seeded = format!("trigger_{token}_seeded");
+    let threshold = cpp_double(f64_or_default(node, "threshold", 5.0));
+    let behaviour = str_or_default(node, "behaviour", "decreasing");
+    let relative = bool_flag(node, "relative");
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("bool {var} = false;")],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        e.declarations.push(format!("double {baseline} = 0.0;"));
+        e.declarations.push(format!("bool {seeded} = false;"));
+
+        e.loop_body.push(format!("double trigger_{token}_now = (double)({expr});"));
+        // Seed the baseline from the first reading, like the runtime's first sample.
+        e.loop_body
+            .push(format!("if (!{seeded}) {{ {baseline} = trigger_{token}_now; {seeded} = true; }}"));
+        e.loop_body
+            .push(format!("double trigger_{token}_diff = trigger_{token}_now - {baseline};"));
+
+        // Direction check mirrors `value_changes_in_correct_direction`.
+        let direction = if behaviour == "increasing" {
+            format!("trigger_{token}_diff > 0.0")
+        } else {
+            format!("trigger_{token}_diff <= 0.0")
+        };
+        // Magnitude check mirrors relative vs absolute threshold.
+        let magnitude = if relative {
+            format!("(fabs(trigger_{token}_diff / {baseline}) * 100.0) >= {threshold}")
+        } else {
+            format!("fabs(trigger_{token}_diff) >= {threshold}")
+        };
+        e.loop_body
+            .push(format!("{var} = ({direction}) && ({magnitude});"));
+        // Track the latest value as the new baseline for the next comparison.
+        e.loop_body.push(format!("{baseline} = trigger_{token}_now;"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn trigger(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Trigger".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn bangs_on_absolute_threshold() {
+        let e = emit(&trigger("tg-1", json!({ "threshold": 10.0 })), Some("v"));
+        assert!(e.declarations.iter().any(|d| d.contains("bool trigger_tg_1_result")));
+        assert!(
+            e.loop_body.iter().any(|l| l.contains(">= 10.0")),
+            "must compare against the configured threshold"
+        );
+    }
+
+    #[test]
+    fn decreasing_is_the_default_direction() {
+        let e = emit(&trigger("tg-1", json!({})), Some("v"));
+        assert!(
+            e.loop_body.iter().any(|l| l.contains("diff <= 0.0")),
+            "default behaviour is decreasing"
+        );
+    }
+
+    #[test]
+    fn increasing_flips_the_direction() {
+        let e = emit(&trigger("tg-1", json!({ "behaviour": "increasing" })), Some("v"));
+        assert!(e.loop_body.iter().any(|l| l.contains("diff > 0.0")));
+    }
+
+    #[test]
+    fn relative_uses_percentage() {
+        let e = emit(&trigger("tg-1", json!({ "relative": true, "threshold": 20.0 })), Some("v"));
+        assert!(e.loop_body.iter().any(|l| l.contains("* 100.0")), "relative => percent compare");
+    }
+
+    #[test]
+    fn no_driver_leaves_false() {
+        let e = emit(&trigger("tg-1", json!({})), None);
+        assert!(e.loop_body.is_empty());
+        assert!(e.declarations.iter().any(|d| d.contains("= false;")));
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = trigger("tg-1", json!({ "threshold": 3.0, "behaviour": "increasing" }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/emit.rs
+++ b/apps/web/src-tauri/src/codegen/emit.rs
@@ -92,6 +92,16 @@ pub fn u16_or_default(node: &FlowNode, key: &str, default: u16) -> u16 {
         .unwrap_or(default)
 }
 
+/// Read a `u64` from a Node's `data`, falling back to `default`. Used for
+/// millisecond durations (Delay/Interval) which the runtime stores as `u64`.
+#[must_use]
+pub fn u64_or_default(node: &FlowNode, key: &str, default: u64) -> u64 {
+    node.data
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(default)
+}
+
 /// Read an `f64` from a Node's `data`, falling back to `default`. Accepts a
 /// JSON number or a numeric string, mirroring the runtime's lenient config
 /// deserialization.

--- a/apps/web/src-tauri/src/codegen/mod.rs
+++ b/apps/web/src-tauri/src/codegen/mod.rs
@@ -21,6 +21,7 @@
 //! - **Validity:** the output is always syntactically valid Arduino C++ and
 //!   compiles even when the Flow is empty.
 
+pub mod control;
 pub mod emit;
 pub mod input;
 pub mod output;
@@ -148,6 +149,11 @@ fn emit_node(node: &FlowNode, drivers: &BTreeMap<&str, String>) -> NodeEmission 
         Some("Gate") => transformation::gate::emit(node, driver),
         Some("RangeMap") => transformation::range_map::emit(node, driver),
         Some("Smooth") => transformation::smooth::emit(node, driver),
+        Some("Delay") => control::delay::emit(node, driver),
+        Some("Interval") => control::interval::emit(node),
+        Some("Trigger") => control::trigger::emit(node, driver),
+        Some("Counter") => control::counter::emit(node, driver),
+        Some("Constant") => control::constant::emit(node),
         _ => placeholder::emit(node),
     }
 }
@@ -198,6 +204,11 @@ fn source_expression(node: &FlowNode) -> Option<String> {
         Some("Gate") => Some(transformation::gate::state_var(node)),
         Some("RangeMap") => Some(transformation::range_map::value_var(node)),
         Some("Smooth") => Some(transformation::smooth::value_var(node)),
+        Some("Delay") => Some(control::delay::value_var(node)),
+        Some("Interval") => Some(control::interval::value_var(node)),
+        Some("Trigger") => Some(control::trigger::state_var(node)),
+        Some("Counter") => Some(control::counter::value_var(node)),
+        Some("Constant") => Some(control::constant::value_var(node)),
         _ => None,
     }
 }
@@ -738,6 +749,193 @@ mod tests {
                 node_data("led-1", "Led", json!({ "pin": 13 })),
             ],
             edges: vec![edge("sensor-1", "rm-1"), edge("rm-1", "sm-1"), edge("sm-1", "led-1")],
+        };
+        assert_eq!(generate(&flow).unwrap(), generate(&flow).unwrap());
+    }
+
+    // --- Control Nodes as non-blocking timers (Task #34) ---
+
+    /// Scenario: Delay Node emits non-blocking timing.
+    ///
+    /// A Button arms a Delay that drives a Led. The Delay must be driven by the
+    /// loop scheduler with no blocking wait, and the rest of the Flow (the Led
+    /// write) keeps running while the Delay is pending.
+    #[test]
+    fn delay_node_emits_non_blocking_timing() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("btn-1", "Button", json!({ "pin": 6 })),
+                node_data("delay-1", "Delay", json!({ "delay": 1000 })),
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+            ],
+            edges: vec![edge("btn-1", "delay-1"), edge("delay-1", "led-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Driven by the loop scheduler via an elapsed-millis comparison.
+        assert!(
+            sketch.contains("millis() - delay_delay_1_armed_at >= 1000UL"),
+            "delay must fire on the loop scheduler, got:\n{sketch}"
+        );
+        // No blocking wait anywhere.
+        assert!(!sketch.contains("delay("), "delay must be non-blocking");
+        // The rest of the Flow keeps running: the Led is driven by the Delay output.
+        assert!(
+            sketch.contains("digitalWrite(led_led_1_pin, (delay_delay_1_value)"),
+            "led must read the delayed value, got:\n{sketch}"
+        );
+        assert!(!sketch.contains("// unsupported Node delay"), "delay must not be a placeholder");
+    }
+
+    /// Scenario: Interval Node fires repeatedly without blocking.
+    #[test]
+    fn interval_node_fires_repeatedly_without_blocking() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("iv-1", "Interval", json!({ "interval": 500 })),
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+            ],
+            edges: vec![edge("iv-1", "led-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Fires on schedule via the loop scheduler's millis() clock.
+        assert!(
+            sketch.contains("millis() - interval_iv_1_previous >= 500UL"),
+            "interval must fire on schedule, got:\n{sketch}"
+        );
+        // Without halting other Nodes — no blocking delay.
+        assert!(!sketch.contains("delay("), "interval must not block other nodes");
+        assert!(!sketch.contains("// unsupported Node iv"), "interval must not be a placeholder");
+    }
+
+    /// Scenario: Counter Node retains its count on-device.
+    #[test]
+    fn counter_node_retains_its_count_on_device() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("btn-1", "Button", json!({ "pin": 6 })),
+                node_data("ct-1", "Counter", json!({})),
+            ],
+            edges: vec![edge("btn-1", "ct-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // The count lives in a module-level declaration => persists across loop().
+        assert!(
+            sketch.contains("double counter_ct_1_count = 0.0;"),
+            "counter must keep a persistent running count, got:\n{sketch}"
+        );
+        // It is updated (incremented) inside the scheduled loop body.
+        assert!(sketch.contains("counter_ct_1_count += 1.0"), "counter must increment on signal");
+        assert!(!sketch.contains("// unsupported Node ct"), "counter must not be a placeholder");
+    }
+
+    /// Scenario: Trigger and Constant Nodes match live behavior.
+    #[test]
+    fn trigger_and_constant_nodes_match_live_behavior() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data("tg-1", "Trigger", json!({ "threshold": 5.0, "behaviour": "increasing" })),
+                node_data("const-1", "Constant", json!({ "value": 42.0 })),
+            ],
+            edges: vec![edge("sensor-1", "tg-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Trigger reproduces its threshold/direction bang from the sensor reading.
+        assert!(sketch.contains("bool trigger_tg_1_result"), "trigger bool output");
+        assert!(sketch.contains(">= 5.0"), "trigger applies its threshold");
+        assert!(sketch.contains("trigger_tg_1_diff > 0.0"), "trigger respects increasing direction");
+        // Constant emits its fixed live value.
+        assert!(
+            sketch.contains("double constant_const_1_value = 42.0;"),
+            "constant must emit its fixed value, got:\n{sketch}"
+        );
+        assert!(!sketch.contains("// unsupported Node tg"));
+        assert!(!sketch.contains("// unsupported Node const"));
+    }
+
+    /// Scenario: Nested timing Nodes run concurrently without drift.
+    ///
+    /// An Interval drives a Delay. Both timers must run concurrently on the
+    /// scheduler — each off its own `millis()` comparison — without drift or one
+    /// blocking the other.
+    #[test]
+    fn nested_timing_nodes_run_concurrently_without_drift() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("iv-1", "Interval", json!({ "interval": 200 })),
+                node_data("delay-1", "Delay", json!({ "delay": 1000 })),
+            ],
+            edges: vec![edge("iv-1", "delay-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Two independent millis-based timers, neither blocking.
+        assert!(
+            sketch.contains("millis() - interval_iv_1_previous >= 200UL"),
+            "interval timer present, got:\n{sketch}"
+        );
+        assert!(
+            sketch.contains("millis() - delay_delay_1_armed_at >= 1000UL"),
+            "delay timer present, got:\n{sketch}"
+        );
+        assert!(!sketch.contains("delay("), "concurrent timers must not block");
+        // The Delay is armed from the Interval's output (nested timing wired through).
+        assert!(
+            sketch.contains("(double)(interval_iv_1_value)") || sketch.contains("(interval_iv_1_value)"),
+            "delay must be driven by the interval, got:\n{sketch}"
+        );
+    }
+
+    /// No control Node is left as a placeholder.
+    #[test]
+    fn no_control_node_left_as_placeholder() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("delay-1", "Delay", json!({})),
+                node_data("iv-1", "Interval", json!({})),
+                node_data("tg-1", "Trigger", json!({})),
+                node_data("ct-1", "Counter", json!({})),
+                node_data("const-1", "Constant", json!({})),
+            ],
+            edges: vec![],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        assert!(sketch.contains("delay_delay_1_value"));
+        assert!(sketch.contains("interval_iv_1_value"));
+        assert!(sketch.contains("trigger_tg_1_result"));
+        assert!(sketch.contains("counter_ct_1_count"));
+        assert!(sketch.contains("constant_const_1_value"));
+        assert_eq!(
+            sketch.matches("// unsupported Node ").count(),
+            0,
+            "no control Node may be a placeholder, got:\n{sketch}"
+        );
+        assert!(!sketch.contains("delay("), "control nodes stay non-blocking");
+    }
+
+    /// Determinism holds for a control-heavy Flow.
+    #[test]
+    fn control_flow_is_deterministic() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("iv-1", "Interval", json!({ "interval": 250 })),
+                node_data("delay-1", "Delay", json!({ "delay": 500 })),
+                node_data("ct-1", "Counter", json!({})),
+                node_data("const-1", "Constant", json!({ "value": 3.0 })),
+                node_data("tg-1", "Trigger", json!({ "threshold": 2.0 })),
+            ],
+            edges: vec![edge("iv-1", "delay-1"), edge("iv-1", "ct-1")],
         };
         assert_eq!(generate(&flow).unwrap(), generate(&flow).unwrap());
     }


### PR DESCRIPTION
## Summary

Extends the Sketch Generation engine (Feature #25, Epic #22) so every **control Node** — Delay, Interval, Trigger, Counter, Constant — emits real, **non-blocking** Arduino C++ instead of a placeholder. On-device there is no host event loop, so any timing expressed with a blocking `delay()` would freeze the whole Sketch. This task makes every control Node tick off the `millis()`-based loop scheduler from Feature #23, so a Flow Author's timing and counting behavior runs standalone and stays responsive — multiple timers tick concurrently without one stalling the others, matching what the Author sees in live mode.

## Changes

- New `codegen/control/` submodule mirroring `runtime/control/*` and `runtime/generator/constant.rs`, with one pure emitter per Node:
  - **Delay** — captures its input on a rising edge and fires after `delay` ms via a `millis()` deadline comparison; never blocks while pending.
  - **Interval** — self-driving timer that fires every `interval` ms (clamped to the runtime's 16 ms minimum) off `millis()`, emitting elapsed time.
  - **Counter** — module-level running count, incremented on the rising edge of its driver; persists across `loop()` iterations.
  - **Trigger** — boolean bang when the signal crosses its threshold in the configured direction (absolute or `relative` percentage), with a persistent baseline.
  - **Constant** — a single fixed compile-time `double`, no per-loop work.
- Registered all five in the `emit_node` dispatch and the driver/`source_expression` maps in `codegen/mod.rs`.
- Added a `u64_or_default` data helper to `codegen/emit.rs` for millisecond durations.
- All timing uses unsigned elapsed-time subtraction, so `millis()` rollover (~49 days) never stalls a timer, and no emitter ever produces a blocking `delay()`.

## Test plan

- [x] Delay Node emits non-blocking timing
- [x] Interval Node fires repeatedly without blocking
- [x] Counter Node retains its count on-device
- [x] Trigger and Constant Nodes match live behavior
- [x] Nested timing Nodes run concurrently without drift
- [x] No control Node left as a placeholder; control-heavy Flow is deterministic
- [x] `cargo test` (codegen: 111 passed) and `cargo clippy -W clippy::pedantic` clean

## Related

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)
