### PR TITLE
feat(flow): write the current sketch to a .ino file

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
     "@tanstack/react-router": "^1.167.0",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2",
+    "@tauri-apps/plugin-fs": "^2",
     "@tauri-apps/plugin-opener": "^2.5.3",
     "@tauri-apps/plugin-os": "^2.3.2",
     "@tauri-apps/plugin-process": "^2",

--- a/apps/web/src-tauri/Cargo.lock
+++ b/apps/web/src-tauri/Cargo.lock
@@ -2921,7 +2921,7 @@ dependencies = [
 
 [[package]]
 name = "microflow"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "boa_engine",
@@ -2941,6 +2941,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-fs",
  "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-process",

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ tauri = { version = "2.9.5", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-fs = "2"
 tauri-plugin-process = "2"
 tauri-plugin-opener = "2"
 firmata-rs = "0.4.3"

--- a/apps/web/src-tauri/capabilities/default.json
+++ b/apps/web/src-tauri/capabilities/default.json
@@ -7,6 +7,8 @@
     "core:default",
     "updater:default",
     "dialog:default",
+    "fs:default",
+    "fs:allow-write-text-file",
     "process:default",
     "opener:default"
   ]

--- a/apps/web/src-tauri/src/lib.rs
+++ b/apps/web/src-tauri/src/lib.rs
@@ -118,6 +118,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_opener::init())
         .setup({

--- a/apps/web/src/components/flow/__tests__/sketch-code-view.test.ts
+++ b/apps/web/src/components/flow/__tests__/sketch-code-view.test.ts
@@ -386,6 +386,18 @@ describe("buildSketchDownloadRequest", () => {
     expect(buildSketchDownloadRequest(sketch)).toEqual({
       type: "SketchDownloaded",
       sketch,
+      suggestedFilename: "sketch.ino",
+    });
+  });
+
+  // Scenario: the suggested filename is carried through to the write step
+  test("carries a provided suggested filename", () => {
+    const sketch = "void setup() {}\nvoid loop() {}";
+
+    expect(buildSketchDownloadRequest(sketch, "blinker.ino")).toEqual({
+      type: "SketchDownloaded",
+      sketch,
+      suggestedFilename: "blinker.ino",
     });
   });
 

--- a/apps/web/src/components/flow/__tests__/sketch-download.test.ts
+++ b/apps/web/src/components/flow/__tests__/sketch-download.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import { buildSketchDownloadRequest } from "../sketch-code-view.model";
+import {
+  DEFAULT_SKETCH_FILENAME,
+  deriveSketchFilename,
+  downloadSketch,
+  type DownloadSketchDeps,
+} from "../sketch-download.model";
+
+/** Build deps with sensible spies; override per test. */
+function makeDeps(overrides: Partial<DownloadSketchDeps> = {}): {
+  deps: DownloadSketchDeps;
+  writes: { path: string; contents: string }[];
+  browserDownloads: { filename: string; contents: string }[];
+} {
+  const writes: { path: string; contents: string }[] = [];
+  const browserDownloads: { filename: string; contents: string }[] = [];
+
+  const deps: DownloadSketchDeps = {
+    isDesktop: () => true,
+    saveDialog: async (o) => o.defaultPath,
+    writeTextFile: async (path, contents) => {
+      writes.push({ path, contents });
+    },
+    browserDownload: (filename, contents) => {
+      browserDownloads.push({ filename, contents });
+    },
+    ...overrides,
+  };
+
+  return { deps, writes, browserDownloads };
+}
+
+describe("deriveSketchFilename", () => {
+  test("derives a sanitised .ino name from the Flow name", () => {
+    expect(deriveSketchFilename("My Blinker Flow")).toBe("My_Blinker_Flow.ino");
+  });
+
+  test("keeps letters, digits, dashes, underscores and dots", () => {
+    expect(deriveSketchFilename("led-2.0_test")).toBe("led-2.0_test.ino");
+  });
+
+  test("does not double the .ino extension", () => {
+    expect(deriveSketchFilename("sketch.ino")).toBe("sketch.ino");
+  });
+
+  test("trims leading/trailing separators after sanitising", () => {
+    expect(deriveSketchFilename("  *weird/name*  ")).toBe("weird_name.ino");
+  });
+
+  test("falls back to the default for a null/undefined name", () => {
+    expect(deriveSketchFilename(null)).toBe(DEFAULT_SKETCH_FILENAME);
+    expect(deriveSketchFilename(undefined)).toBe(DEFAULT_SKETCH_FILENAME);
+  });
+
+  test("falls back to the default when the name sanitises to nothing", () => {
+    expect(deriveSketchFilename("***")).toBe(DEFAULT_SKETCH_FILENAME);
+    expect(deriveSketchFilename("   ")).toBe(DEFAULT_SKETCH_FILENAME);
+  });
+});
+
+describe("downloadSketch (desktop)", () => {
+  // Scenario: Sketch is saved to disk on the desktop
+  test("opens the save dialog and writes the chosen path", async () => {
+    const { deps, writes } = makeDeps({
+      saveDialog: async () => "/home/dev/blinker.ino",
+    });
+    const request = buildSketchDownloadRequest("void setup() {}\nvoid loop() {}", "blinker.ino");
+
+    const outcome = await downloadSketch(request, deps);
+
+    expect(outcome).toEqual({ status: "saved", path: "/home/dev/blinker.ino" });
+    expect(writes).toEqual([
+      { path: "/home/dev/blinker.ino", contents: "void setup() {}\nvoid loop() {}" },
+    ]);
+  });
+
+  // Scenario: the dialog is pre-filled with the suggested filename and .ino filter
+  test("pre-fills the dialog with the suggested filename and an ino filter", async () => {
+    let seen: { defaultPath: string; filters: { extensions: string[] }[] } | undefined;
+    const { deps } = makeDeps({
+      saveDialog: async (o) => {
+        seen = o;
+        return o.defaultPath;
+      },
+    });
+
+    await downloadSketch(buildSketchDownloadRequest("x", "my_flow.ino"), deps);
+
+    expect(seen?.defaultPath).toBe("my_flow.ino");
+    expect(seen?.filters[0]?.extensions).toEqual(["ino"]);
+  });
+
+  // Scenario: Downloaded contents match the Code view exactly
+  test("writes the sketch bytes verbatim", async () => {
+    const sketch = [
+      "// microflow generated sketch",
+      "void setup() {",
+      "  pinMode(13, OUTPUT);",
+      "}",
+      "void loop() {}",
+      "",
+    ].join("\n");
+    const { deps, writes } = makeDeps({ saveDialog: async () => "/tmp/s.ino" });
+
+    await downloadSketch(buildSketchDownloadRequest(sketch, "s.ino"), deps);
+
+    expect(writes[0]?.contents).toBe(sketch);
+  });
+
+  // Scenario: Flow with unsupported Nodes still downloads
+  test("writes a sketch containing unsupported-Node placeholder comments verbatim", async () => {
+    const sketch = "// Unsupported node: Mqtt\nvoid setup() {}\nvoid loop() {}";
+    const { deps, writes } = makeDeps({ saveDialog: async () => "/tmp/u.ino" });
+
+    const outcome = await downloadSketch(buildSketchDownloadRequest(sketch, "u.ino"), deps);
+
+    expect(outcome.status).toBe("saved");
+    expect(writes[0]?.contents).toBe(sketch);
+  });
+
+  // Scenario: Empty Flow downloads a valid sketch
+  test("writes the empty-Flow skeleton sketch", async () => {
+    const sketch = "void setup() {}\nvoid loop() {}";
+    const { deps, writes } = makeDeps({ saveDialog: async () => "/tmp/e.ino" });
+
+    const outcome = await downloadSketch(buildSketchDownloadRequest(sketch, "sketch.ino"), deps);
+
+    expect(outcome.status).toBe("saved");
+    expect(writes[0]?.contents).toBe(sketch);
+  });
+
+  // Scenario: Cancelling the save aborts the download
+  test("writes nothing when the save dialog is cancelled", async () => {
+    const { deps, writes } = makeDeps({ saveDialog: async () => null });
+
+    const outcome = await downloadSketch(buildSketchDownloadRequest("x", "x.ino"), deps);
+
+    expect(outcome).toEqual({ status: "cancelled" });
+    expect(writes).toHaveLength(0);
+  });
+});
+
+describe("downloadSketch (web fallback)", () => {
+  test("triggers a browser download with the suggested filename and never writes to disk", async () => {
+    const { deps, writes, browserDownloads } = makeDeps({
+      isDesktop: () => false,
+      saveDialog: async () => {
+        throw new Error("save dialog must not be used on web");
+      },
+    });
+    const sketch = "void setup() {}\nvoid loop() {}";
+
+    const outcome = await downloadSketch(buildSketchDownloadRequest(sketch, "web_flow.ino"), deps);
+
+    expect(outcome).toEqual({ status: "saved" });
+    expect(browserDownloads).toEqual([{ filename: "web_flow.ino", contents: sketch }]);
+    expect(writes).toHaveLength(0);
+  });
+});

--- a/apps/web/src/components/flow/sketch-code-view.model.ts
+++ b/apps/web/src/components/flow/sketch-code-view.model.ts
@@ -42,6 +42,8 @@ export type SketchDownloadRequest = {
   type: "SketchDownloaded";
   /** The displayed sketch, byte-for-byte. */
   sketch: string;
+  /** Suggested `.ino` filename derived from the Flow name (or `sketch.ino`). */
+  suggestedFilename: string;
 };
 
 /** Handler seam invoked when the Author activates the Download control. */
@@ -63,12 +65,16 @@ export function canDownloadSketch(state: SketchViewState): boolean {
 }
 
 /**
- * Build the `SketchDownloaded` intent from the displayed sketch. The sketch is
- * carried through unchanged so the file written downstream matches the Code
- * view byte-for-byte.
+ * Build the `SketchDownloaded` intent from the displayed sketch and a suggested
+ * filename. The sketch is carried through unchanged so the file written
+ * downstream matches the Code view byte-for-byte. The filename defaults to
+ * `sketch.ino` so a download can always proceed even before a Flow name exists.
  */
-export function buildSketchDownloadRequest(sketch: string): SketchDownloadRequest {
-  return { type: "SketchDownloaded", sketch };
+export function buildSketchDownloadRequest(
+  sketch: string,
+  suggestedFilename = "sketch.ino",
+): SketchDownloadRequest {
+  return { type: "SketchDownloaded", sketch, suggestedFilename };
 }
 
 /** Build the `generate_sketch` command from the current Flow graph. */

--- a/apps/web/src/components/flow/sketch-code-view.tsx
+++ b/apps/web/src/components/flow/sketch-code-view.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { useTheme } from "@/providers/theme-provider";
-import { useFlowSession, useFlowNodes, useFlowEdges } from "@/session";
+import { useFlowSession, useFlowNodes, useFlowEdges, useFlowMeta } from "@/session";
 import { invokeCommand } from "@/lib/ipc";
 import {
   buildSketchDownloadRequest,
@@ -26,6 +26,8 @@ import {
   type SketchResponse,
   type SketchViewState,
 } from "./sketch-code-view.model";
+import { deriveSketchFilename } from "./sketch-download.model";
+import { downloadSketch } from "./sketch-download";
 
 // Use local bundle + workers instead of CDN (required for offline Tauri).
 // Mirrors the Function code editor setup; the read-only view only needs the
@@ -47,15 +49,18 @@ const invoke: SketchInvoker = (command) => invokeCommand(command) as Promise<Ske
  * read-only — the Author can read and copy but not edit.
  */
 /**
- * No-op download handler. The real disk write / save dialog lands in sibling
- * Task #31; until then the control still emits the `SketchDownloaded` intent so
- * the trigger is wired and testable in isolation.
+ * Default download handler (Task #31): persists the sketch to a `.ino` file via
+ * the native save dialog on desktop, or an in-browser download on the web. The
+ * platform seams live in `sketch-download.ts`; callers may inject a handler to
+ * override (e.g. tests).
  */
-const noopDownload: SketchDownloadHandler = () => {};
+const defaultDownload: SketchDownloadHandler = (request) => {
+  void downloadSketch(request);
+};
 
 export function SketchCodeView({
   onClose,
-  onDownload = noopDownload,
+  onDownload = defaultDownload,
 }: {
   onClose: () => void;
   onDownload?: SketchDownloadHandler;
@@ -64,6 +69,8 @@ export function SketchCodeView({
   const { doc } = useFlowSession();
   const nodes = useFlowNodes(doc);
   const edges = useFlowEdges(doc);
+  const meta = useFlowMeta(doc);
+  const suggestedFilename = deriveSketchFilename(meta.name);
   const [state, setState] = useState<SketchViewState>({
     value: GENERATING_SKETCH_PLACEHOLDER,
     isError: false,
@@ -138,7 +145,7 @@ export function SketchCodeView({
           <Button
             type="button"
             disabled={!canDownloadSketch(state)}
-            onClick={() => onDownload(buildSketchDownloadRequest(value))}
+            onClick={() => onDownload(buildSketchDownloadRequest(value, suggestedFilename))}
             aria-label="Download sketch"
           >
             <Download aria-hidden="true" />

--- a/apps/web/src/components/flow/sketch-download.model.ts
+++ b/apps/web/src/components/flow/sketch-download.model.ts
@@ -26,9 +26,7 @@ export function deriveSketchFilename(flowName: string | null | undefined): strin
 }
 
 /** Outcome of a download attempt. */
-export type SketchDownloadOutcome =
-  | { status: "saved"; path?: string }
-  | { status: "cancelled" };
+export type SketchDownloadOutcome = { status: "saved"; path?: string } | { status: "cancelled" };
 
 /** Native save-dialog seam — returns the chosen path, or `null` when cancelled. */
 export type SaveDialog = (options: {

--- a/apps/web/src/components/flow/sketch-download.model.ts
+++ b/apps/web/src/components/flow/sketch-download.model.ts
@@ -1,0 +1,84 @@
+import type { SketchDownloadRequest } from "./sketch-code-view.model";
+
+/** Default `.ino` filename used when the Flow has no usable name. */
+export const DEFAULT_SKETCH_FILENAME = "sketch.ino";
+
+/**
+ * Derive a safe `.ino` filename from a Flow name.
+ *
+ * The Flow name is sanitised to filesystem-friendly characters: anything that
+ * is not a letter, digit, dash, underscore, or dot is collapsed to an
+ * underscore, leading/trailing separators are trimmed, and a `.ino` extension
+ * is ensured. When the name is missing or sanitises to nothing, the default
+ * (`sketch.ino`) is used so the dialog is always pre-filled.
+ */
+export function deriveSketchFilename(flowName: string | null | undefined): string {
+  if (flowName == null) return DEFAULT_SKETCH_FILENAME;
+
+  const base = flowName
+    .trim()
+    .replace(/\.ino$/i, "")
+    .replace(/[^A-Za-z0-9._-]+/g, "_")
+    .replace(/^[._-]+|[._-]+$/g, "");
+
+  if (base === "") return DEFAULT_SKETCH_FILENAME;
+  return `${base}.ino`;
+}
+
+/** Outcome of a download attempt. */
+export type SketchDownloadOutcome =
+  | { status: "saved"; path?: string }
+  | { status: "cancelled" };
+
+/** Native save-dialog seam — returns the chosen path, or `null` when cancelled. */
+export type SaveDialog = (options: {
+  defaultPath: string;
+  filters: { name: string; extensions: string[] }[];
+}) => Promise<string | null>;
+
+/** Write-to-disk seam (`@tauri-apps/plugin-fs` `writeTextFile`). */
+export type WriteTextFile = (path: string, contents: string) => Promise<void>;
+
+/** Browser-download seam — triggers an in-browser file download. */
+export type BrowserDownload = (filename: string, contents: string) => void;
+
+/** Injectable seams so the orchestrator is testable without Tauri or the DOM. */
+export type DownloadSketchDeps = {
+  isDesktop: () => boolean;
+  saveDialog: SaveDialog;
+  writeTextFile: WriteTextFile;
+  browserDownload: BrowserDownload;
+};
+
+/**
+ * Persist the sketch carried by a `SketchDownloaded` request.
+ *
+ * On the desktop shell: open the native save dialog (pre-filled with the
+ * suggested filename, filtered to `*.ino`); on confirm, write the exact sketch
+ * bytes to the chosen path; on cancel, write nothing. On the web: trigger a
+ * standard browser download of the same contents and filename.
+ *
+ * The sketch string is written verbatim so the file matches the Code view
+ * byte-for-byte.
+ */
+export async function downloadSketch(
+  request: SketchDownloadRequest,
+  deps: DownloadSketchDeps,
+): Promise<SketchDownloadOutcome> {
+  const filename = request.suggestedFilename;
+
+  if (!deps.isDesktop()) {
+    deps.browserDownload(filename, request.sketch);
+    return { status: "saved" };
+  }
+
+  const path = await deps.saveDialog({
+    defaultPath: filename,
+    filters: [{ name: "Arduino sketch", extensions: ["ino"] }],
+  });
+
+  if (path == null) return { status: "cancelled" };
+
+  await deps.writeTextFile(path, request.sketch);
+  return { status: "saved", path };
+}

--- a/apps/web/src/components/flow/sketch-download.ts
+++ b/apps/web/src/components/flow/sketch-download.ts
@@ -1,0 +1,46 @@
+import { save } from "@tauri-apps/plugin-dialog";
+import { writeTextFile } from "@tauri-apps/plugin-fs";
+import { isDesktop } from "@/lib/platform";
+import type { SketchDownloadRequest } from "./sketch-code-view.model";
+import {
+  downloadSketch as runDownloadSketch,
+  type DownloadSketchDeps,
+  type SketchDownloadOutcome,
+} from "./sketch-download.model";
+
+/**
+ * Trigger a standard in-browser download of the given text contents under the
+ * suggested filename. Used as the web fallback when there is no desktop shell to
+ * host a native save dialog.
+ */
+function browserDownload(filename: string, contents: string): void {
+  const blob = new Blob([contents], { type: "text/plain;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  try {
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+/** Real seams wiring the download orchestrator to Tauri + the browser. */
+const deps: DownloadSketchDeps = {
+  isDesktop,
+  saveDialog: (options) => save(options),
+  writeTextFile: (path, contents) => writeTextFile(path, contents),
+  browserDownload,
+};
+
+/**
+ * Persist a `SketchDownloaded` request: native save dialog + disk write on the
+ * desktop, in-browser download on the web. The pure orchestration lives in
+ * `sketch-download.model.ts`; this module only supplies the platform seams.
+ */
+export function downloadSketch(request: SketchDownloadRequest): Promise<SketchDownloadOutcome> {
+  return runDownloadSketch(request, deps);
+}

--- a/bun.lock
+++ b/bun.lock
@@ -125,6 +125,7 @@
         "@tanstack/react-router": "^1.167.0",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2",
+        "@tauri-apps/plugin-fs": "^2",
         "@tauri-apps/plugin-opener": "^2.5.3",
         "@tauri-apps/plugin-os": "^2.3.2",
         "@tauri-apps/plugin-process": "^2",
@@ -1126,6 +1127,8 @@
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.10.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg=="],
 
     "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.6.0", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg=="],
+
+    "@tauri-apps/plugin-fs": ["@tauri-apps/plugin-fs@2.5.1", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ=="],
 
@@ -3206,6 +3209,8 @@
     "@tanstack/router-plugin/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "@tanstack/router-plugin/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@tauri-apps/plugin-fs/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
 
     "@tauri-apps/plugin-os/@tauri-apps/api": ["@tauri-apps/api@2.9.1", "", {}, "sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw=="],
 


### PR DESCRIPTION
## Summary

When a Flow Author triggers Download from the Code view, the sketch they see must actually land on disk as an Arduino `.ino` file they can open and flash. Task #30 wired the Download control's `onDownload` seam but left it a no-op; this task realises the `SketchDownloaded` hand-off — the moment microflow's generated sketch crosses into the standard Arduino toolchain (Feature #24, Epic #22 "Untether the board").

On the desktop shell it opens a native save dialog (pre-filled with a filename derived from the Flow name, filtered to `*.ino`) and writes the exact displayed sketch bytes to the chosen path. On the web it falls back to a standard in-browser download of the same contents and filename.

## Changes

- **Download model** (`sketch-download.model.ts`): pure, fully-injectable logic — `deriveSketchFilename` (sanitise Flow name → `*.ino`, `sketch.ino` fallback) and `downloadSketch(request, deps)` orchestrating save-dialog → write, or web download, returning a `saved`/`cancelled` outcome.
- **Platform glue** (`sketch-download.ts`): supplies the real seams — `@tauri-apps/plugin-dialog` `save()` + `@tauri-apps/plugin-fs` `writeTextFile` on desktop; Blob + anchor download on web.
- **Code view wiring**: `SketchCodeView` now derives `suggestedFilename` from `useFlowMeta(doc).name` and uses the real download handler as its default `onDownload`; `buildSketchDownloadRequest` carries the suggested filename per the contract.
- **Tauri**: added `@tauri-apps/plugin-fs` (npm + Cargo `tauri-plugin-fs`), registered the plugin in `src-tauri/src/lib.rs`, granted `fs:default` + `fs:allow-write-text-file` in `capabilities/default.json`.

The sketch string is written verbatim, so the file matches the Code view byte-for-byte (including unsupported-Node placeholder comments and empty-stub sketches).

## Test plan

- [x] Sketch is saved to disk on the desktop
- [x] Downloaded contents match the Code view exactly (verbatim bytes)
- [x] Flow with unsupported Nodes still downloads (placeholder comments preserved)
- [x] Empty Flow downloads a valid sketch
- [x] Cancelling the save aborts the download (no write)
- [x] Web fallback download when not in the desktop shell
- [x] Filename derivation: sanitisation, `.ino` not doubled, `sketch.ino` fallback
- [x] `cargo build` + `clippy -W clippy::pedantic` clean; type-check 0 new errors

`bun test` for the flow models: 39 pass / 0 fail.

## Related

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)
