### PR TITLE
feat(web): derive a sanitised .ino filename from the Flow name (#32)

### DIFF
--- a/apps/web/src/components/flow/__tests__/sketch-download.test.ts
+++ b/apps/web/src/components/flow/__tests__/sketch-download.test.ts
@@ -57,6 +57,47 @@ describe("deriveSketchFilename", () => {
     expect(deriveSketchFilename("***")).toBe(DEFAULT_SKETCH_FILENAME);
     expect(deriveSketchFilename("   ")).toBe(DEFAULT_SKETCH_FILENAME);
   });
+
+  // Scenario: Filename derives from the Flow name
+  test("derives the filename from a plain Flow name and ends in .ino", () => {
+    const filename = deriveSketchFilename("Blink LED");
+    expect(filename).toBe("Blink_LED.ino");
+    expect(filename.endsWith(".ino")).toBe(true);
+  });
+
+  // Scenario: Unsafe characters in the Flow name are sanitised
+  test("sanitises filesystem-unsafe characters and ends in .ino", () => {
+    const filename = deriveSketchFilename('a/b\\c:d*e?f"g<h>i|j');
+    expect(filename).toBe("a_b_c_d_e_f_g_h_i_j.ino");
+    expect(/[/\\:*?"<>|]/.test(filename)).toBe(false);
+    expect(filename.endsWith(".ino")).toBe(true);
+  });
+
+  // Scenario: Unnamed Flow falls back to a default filename
+  test("falls back to sketch.ino for an unnamed Flow", () => {
+    expect(deriveSketchFilename("")).toBe("sketch.ino");
+    expect(deriveSketchFilename(undefined)).toBe("sketch.ino");
+  });
+
+  // Scenario: Name sanitising to nothing falls back to the default
+  test("falls back to sketch.ino when only unsafe characters remain", () => {
+    expect(deriveSketchFilename("/\\:*?")).toBe("sketch.ino");
+  });
+
+  // Edge case: very long names are kept within filesystem limits
+  test("truncates very long names so the filename fits filesystem limits", () => {
+    const filename = deriveSketchFilename("a".repeat(1000));
+    expect(filename.length).toBeLessThanOrEqual(255);
+    expect(filename.endsWith(".ino")).toBe(true);
+    expect(filename).toBe(`${"a".repeat(251)}.ino`);
+  });
+
+  test("does not leave a trailing separator after truncation", () => {
+    // 252 chars: 251 'a' then a separator at the cut boundary.
+    const filename = deriveSketchFilename(`${"a".repeat(251)}_extra`);
+    expect(filename.endsWith("_.ino")).toBe(false);
+    expect(filename).toBe(`${"a".repeat(251)}.ino`);
+  });
 });
 
 describe("downloadSketch (desktop)", () => {

--- a/apps/web/src/components/flow/sketch-download.model.ts
+++ b/apps/web/src/components/flow/sketch-download.model.ts
@@ -3,26 +3,44 @@ import type { SketchDownloadRequest } from "./sketch-code-view.model";
 /** Default `.ino` filename used when the Flow has no usable name. */
 export const DEFAULT_SKETCH_FILENAME = "sketch.ino";
 
+/** Extension (with dot) every derived filename ends in. */
+const SKETCH_EXTENSION = ".ino";
+
+/**
+ * Max length of a single filename component on common filesystems
+ * (ext4, APFS, NTFS all cap a name at 255). The derived `<base>.ino`
+ * is kept at or below this so the name is valid everywhere.
+ */
+const MAX_FILENAME_LENGTH = 255;
+
 /**
  * Derive a safe `.ino` filename from a Flow name.
  *
  * The Flow name is sanitised to filesystem-friendly characters: anything that
  * is not a letter, digit, dash, underscore, or dot is collapsed to an
- * underscore, leading/trailing separators are trimmed, and a `.ino` extension
- * is ensured. When the name is missing or sanitises to nothing, the default
- * (`sketch.ino`) is used so the dialog is always pre-filled.
+ * underscore, leading/trailing separators are trimmed, the result is truncated
+ * to stay within filesystem limits, and a `.ino` extension is ensured. When the
+ * name is missing or sanitises to nothing, the default (`sketch.ino`) is used so
+ * the dialog is always pre-filled.
  */
 export function deriveSketchFilename(flowName: string | null | undefined): string {
   if (flowName == null) return DEFAULT_SKETCH_FILENAME;
 
-  const base = flowName
+  let base = flowName
     .trim()
     .replace(/\.ino$/i, "")
     .replace(/[^A-Za-z0-9._-]+/g, "_")
     .replace(/^[._-]+|[._-]+$/g, "");
 
   if (base === "") return DEFAULT_SKETCH_FILENAME;
-  return `${base}.ino`;
+
+  const maxBaseLength = MAX_FILENAME_LENGTH - SKETCH_EXTENSION.length;
+  if (base.length > maxBaseLength) {
+    base = base.slice(0, maxBaseLength).replace(/[._-]+$/g, "");
+    if (base === "") return DEFAULT_SKETCH_FILENAME;
+  }
+
+  return `${base}${SKETCH_EXTENSION}`;
 }
 
 /** Outcome of a download attempt. */


### PR DESCRIPTION
## Summary

Finalises filename derivation for Task #32 — the last task of Feature #24. Sibling task #31 added `deriveSketchFilename`; this task locks it to the full #32 spec by adding the missing **long-name truncation** edge case and backing every Gherkin scenario with an explicit test.

## Changes

- `deriveSketchFilename` now truncates the sanitised base so `<base>.ino` stays within the 255-char filesystem-component limit, stripping any trailing separator left at the cut boundary (and falling back to `sketch.ino` if nothing usable remains).
- Added explicit tests mapped to each Gherkin scenario plus the long-name edge case.

## Scenarios

- Filename derives from the Flow name — passing
- Unsafe characters in the Flow name are sanitised — passing
- Unnamed Flow falls back to a default filename — passing
- Name sanitising to nothing falls back to the default — passing
- Edge: very long names kept within filesystem limits — passing

All 19 tests in `sketch-download.test.ts` pass.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)
