### PR TITLE
feat(codegen): cover remaining input/output/generator Nodes

### DIFF
--- a/apps/web/src-tauri/src/codegen/generator/mod.rs
+++ b/apps/web/src-tauri/src/codegen/generator/mod.rs
@@ -1,0 +1,4 @@
+//! Generator-Node C++ emitters (Oscillator) — the codegen mirror of
+//! `runtime/generator`.
+
+pub mod oscillator;

--- a/apps/web/src-tauri/src/codegen/generator/oscillator.rs
+++ b/apps/web/src-tauri/src/codegen/generator/oscillator.rs
@@ -1,0 +1,158 @@
+//! Oscillator emitter — mirrors `runtime/generator/oscillator.rs`.
+//!
+//! The live Oscillator runs a thread that samples a waveform against the elapsed
+//! time since start and emits the value. On device there is no thread; the
+//! generated sketch instead samples the same waveform against `millis()` since
+//! `setup()` on every loop iteration, writing the result into a module-level
+//! `double`. The waveform math (sine, square, sawtooth, triangle, random) is the
+//! exact port of the runtime's `calculate_waveform`, so the on-device signal
+//! matches live mode. It is self-driving and fully non-blocking — it only reads
+//! the scheduler's clock, never waits.
+
+use crate::codegen::emit::{cpp_double, f64_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default period matches `runtime/generator/oscillator.rs::default_period` (1000ms).
+const DEFAULT_PERIOD: f64 = 1000.0;
+/// Default amplitude matches `runtime/generator/oscillator.rs::default_amplitude` (1.0).
+const DEFAULT_AMPLITUDE: f64 = 1.0;
+
+/// The C++ `double` variable holding this Oscillator's current output sample.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("oscillator_{}_value", node.id_token())
+}
+
+/// The configured waveform, lowercased to match the runtime's `rename_all`.
+fn waveform(node: &FlowNode) -> String {
+    node.data
+        .get("waveform")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("sinus")
+        .to_ascii_lowercase()
+}
+
+/// Emit C++ for an Oscillator Node. The Oscillator is a generator: it ignores
+/// any wired input and ticks purely off the loop scheduler's `millis()` clock.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let token = node.id_token();
+    let value = value_var(node);
+    let start = format!("oscillator_{token}_start");
+    let t = format!("oscillator_{token}_t");
+
+    // Guard against a zero period (division by zero) by clamping to the default.
+    let period_raw = f64_or_default(node, "period", DEFAULT_PERIOD);
+    let period = cpp_double(if period_raw.abs() < f64::EPSILON { DEFAULT_PERIOD } else { period_raw });
+    let amplitude = cpp_double(f64_or_default(node, "amplitude", DEFAULT_AMPLITUDE));
+    let phase = cpp_double(f64_or_default(node, "phase", 0.0));
+    let shift = cpp_double(f64_or_default(node, "shift", 0.0));
+
+    // `t` is the elapsed-millis timestamp plus phase, mirroring the runtime which
+    // adds `config.phase` to `start.elapsed()`. All branches reduce `t` modulo
+    // the period before sampling, exactly as `calculate_waveform` does.
+    let mut loop_body = vec![
+        format!("double {t} = (double)(millis() - {start}) + {phase};"),
+    ];
+    let sample = match waveform(node).as_str() {
+        "square" => {
+            loop_body.push(format!("{t} = fmod({t}, {period});"));
+            loop_body.push(format!("if ({t} < 0.0) {{ {t} += {period}; }}"));
+            format!("{value} = (({t} * 2.0 < {period}) ? {amplitude} : -({amplitude})) + {shift};")
+        }
+        "sawtooth" => {
+            loop_body.push(format!("{t} = fmod({t}, {period});"));
+            loop_body.push(format!("if ({t} < 0.0) {{ {t} += {period}; }}"));
+            format!("{value} = {amplitude} * (-1.0 + {t} * (2.0 / {period})) + {shift};")
+        }
+        "triangle" => {
+            loop_body.push(format!("{t} = fmod(fabs({t}), {period});"));
+            format!(
+                "{value} = (({t} * 2.0 < {period}) ? ({amplitude} * (-1.0 + {t} * (4.0 / {period}))) : ({amplitude} * (3.0 - {t} * (4.0 / {period})))) + {shift};"
+            )
+        }
+        "random" => {
+            // Runtime: (shift + amplitude) * rand in [0,1).
+            format!("{value} = ({shift} + {amplitude}) * ((double)random(0, 10000) / 10000.0);")
+        }
+        // Sinus is the runtime default.
+        _ => format!(
+            "{value} = {amplitude} * sin({t} * (2.0 * PI / {period})) + {shift};"
+        ),
+    };
+    loop_body.push(sample);
+
+    NodeEmission {
+        declarations: vec![
+            format!("unsigned long {start} = 0;"),
+            format!("double {value} = 0.0;"),
+        ],
+        setup: vec![format!("{start} = millis();")],
+        loop_body,
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn oscillator(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Oscillator".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn oscillator_samples_against_millis_non_blocking() {
+        let e = emit(&oscillator("osc-1", json!({ "waveform": "sinus", "period": 1000 })));
+        assert!(e.loop_body.iter().any(|l| l.contains("millis() - oscillator_osc_1_start")));
+        assert!(e.loop_body.iter().any(|l| l.contains("sin(")), "sinus waveform");
+        assert!(!e.loop_body.iter().any(|l| l.contains("delay(")), "must not block");
+    }
+
+    #[test]
+    fn oscillator_square_waveform() {
+        let e = emit(&oscillator("osc-1", json!({ "waveform": "square" })));
+        assert!(e.loop_body.iter().any(|l| l.contains("* 2.0 <")));
+    }
+
+    #[test]
+    fn oscillator_sawtooth_and_triangle() {
+        let saw = emit(&oscillator("osc-1", json!({ "waveform": "sawtooth" })));
+        assert!(saw.loop_body.iter().any(|l| l.contains("2.0 /")));
+        let tri = emit(&oscillator("osc-1", json!({ "waveform": "triangle" })));
+        assert!(tri.loop_body.iter().any(|l| l.contains("4.0 /")));
+    }
+
+    #[test]
+    fn oscillator_random_uses_amplitude_and_shift() {
+        let e = emit(&oscillator("osc-1", json!({ "waveform": "random", "amplitude": 2.0, "shift": 1.0 })));
+        assert!(e.loop_body.iter().any(|l| l.contains("random(")));
+    }
+
+    #[test]
+    fn oscillator_clamps_zero_period() {
+        let e = emit(&oscillator("osc-1", json!({ "period": 0 })));
+        // Falls back to the default period rather than dividing by zero.
+        assert!(e.loop_body.iter().any(|l| l.contains("1000.0")));
+    }
+
+    #[test]
+    fn oscillator_seeds_start_in_setup() {
+        let e = emit(&oscillator("osc-1", json!({})));
+        assert!(e.setup.iter().any(|s| s.contains("= millis()")));
+        assert!(e.declarations.iter().any(|d| d.contains("double oscillator_osc_1_value")));
+    }
+
+    #[test]
+    fn oscillator_emits_deterministically() {
+        let n = oscillator("osc-1", json!({ "waveform": "square", "period": 500 }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/input/hotkey.rs
+++ b/apps/web/src-tauri/src/codegen/input/hotkey.rs
@@ -1,0 +1,79 @@
+//! Hotkey emitter — mirrors `runtime/input/hotkey.rs`.
+//!
+//! The live Hotkey is a software-only Node: it responds to host-keyboard
+//! press/release events routed from the desktop app's `HotkeyManager`. A
+//! standalone Arduino sketch has no host keyboard, so there is no on-device
+//! source for the key event. To keep the Flow's wiring intact, the emitter
+//! declares the Node's `bool` state variable (initialised `false`, matching the
+//! runtime's initial value) so downstream Nodes still compile and read a stable
+//! signal — and records, as a comment, that the trigger is host-only and never
+//! fires on-device.
+
+use crate::codegen::emit::{str_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `bool` variable name holding this Hotkey's pressed state.
+#[must_use]
+pub fn state_var(node: &FlowNode) -> String {
+    format!("hotkey_{}_state", node.id_token())
+}
+
+/// Emit C++ for a Hotkey Node. There is no pin or loop work: the only on-device
+/// artefact is the state variable, held at its initial `false` because no host
+/// keyboard exists on the board.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let state = state_var(node);
+    let accelerator = str_or_default(node, "accelerator", "x");
+
+    NodeEmission {
+        declarations: vec![
+            format!(
+                "// hotkey \"{accelerator}\" is host-only; no on-device keyboard drives it"
+            ),
+            format!("bool {state} = false;"),
+        ],
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn hotkey(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Hotkey".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn hotkey_declares_state_at_false() {
+        let e = emit(&hotkey("hk-1", json!({ "accelerator": "a" })));
+        assert!(e.declarations.iter().any(|d| d.contains("hotkey_hk_1_state = false")));
+    }
+
+    #[test]
+    fn hotkey_notes_host_only_origin() {
+        let e = emit(&hotkey("hk-1", json!({ "accelerator": "a" })));
+        assert!(e.declarations.iter().any(|d| d.contains("host-only")));
+    }
+
+    #[test]
+    fn hotkey_does_no_pin_or_loop_work() {
+        let e = emit(&hotkey("hk-1", json!({})));
+        assert!(e.setup.is_empty(), "hotkey has no pin to configure");
+        assert!(e.loop_body.is_empty(), "hotkey has no on-device source to poll");
+    }
+
+    #[test]
+    fn hotkey_emits_deterministically() {
+        let n = hotkey("hk-1", json!({ "accelerator": "x" }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/input/i2c_device.rs
+++ b/apps/web/src-tauri/src/codegen/input/i2c_device.rs
@@ -1,0 +1,126 @@
+//! `I2cDevice` emitter — mirrors `runtime/input/i2c_device.rs`.
+//!
+//! The live `I2cDevice` configures the I2C bus, writes the register pointer,
+//! reads `read_length` bytes, and decodes them as a big-endian unsigned or
+//! signed integer (or leaves them raw). The generated sketch uses the Arduino
+//! `Wire` library: it `#include <Wire.h>`, calls `Wire.begin()` in `setup()`,
+//! and each loop writes the register, requests the bytes, and folds them into a
+//! `long` value variable big-endian — the same decode the runtime applies for
+//! the unsigned/signed integer formats. Downstream Nodes read that value.
+
+use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default I2C address matches `runtime/input/i2c_device.rs::default_address`.
+const DEFAULT_ADDRESS: u8 = 0x48;
+/// Default read length matches `runtime/input/i2c_device.rs::default_read_length`.
+const DEFAULT_READ_LENGTH: u8 = 2;
+
+/// The C++ `long` variable name holding this device's latest decoded reading.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("i2c_{}_value", node.id_token())
+}
+
+fn u8_field(node: &FlowNode, key: &str, default: u8) -> u8 {
+    node.data
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|n| u8::try_from(n).ok())
+        .unwrap_or(default)
+}
+
+/// True when the configured output format treats the bytes as a signed integer.
+fn is_signed(node: &FlowNode) -> bool {
+    node.data
+        .get("output")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|t| t.eq_ignore_ascii_case("signed_int") || t.eq_ignore_ascii_case("signedint"))
+}
+
+/// Emit C++ for an `I2cDevice` Node.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let token = node.id_token();
+    let value = value_var(node);
+    let addr = u8_field(node, "address", DEFAULT_ADDRESS);
+    let register = u8_field(node, "register", 0);
+    let read_length = u8_field(node, "read_length", DEFAULT_READ_LENGTH).max(1);
+    let signed = is_signed(node);
+
+    let acc = format!("i2c_{token}_acc");
+    let i = format!("i2c_{token}_i");
+    let b = format!("i2c_{token}_b");
+
+    let mut loop_body = vec![
+        format!("Wire.beginTransmission((uint8_t){addr});"),
+        format!("Wire.write((uint8_t){register});"),
+        "Wire.endTransmission(false);".to_string(),
+        format!("Wire.requestFrom((uint8_t){addr}, (uint8_t){read_length});"),
+        format!("long {acc} = 0;"),
+        format!("for (uint8_t {i} = 0; {i} < {read_length} && Wire.available(); {i}++) {{"),
+        format!("  uint8_t {b} = Wire.read();"),
+    ];
+    if signed {
+        // Sign-extend from the most-significant byte, big-endian, like the runtime.
+        loop_body.push(format!("  if ({i} == 0 && ({b} & 0x80)) {{ {acc} = -1; }}"));
+    }
+    loop_body.push(format!("  {acc} = ({acc} << 8) | (long){b};"));
+    loop_body.push("}".to_string());
+    loop_body.push(format!("{value} = {acc};"));
+
+    NodeEmission {
+        includes: vec!["#include <Wire.h>".to_string()],
+        declarations: vec![format!("long {value} = 0;")],
+        setup: vec!["Wire.begin();".to_string()],
+        loop_body,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn i2c(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("I2cDevice".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn i2c_includes_wire_and_begins_bus() {
+        let e = emit(&i2c("d-1", json!({})));
+        assert!(e.includes.iter().any(|i| i.contains("Wire.h")));
+        assert!(e.setup.iter().any(|s| s.contains("Wire.begin()")));
+    }
+
+    #[test]
+    fn i2c_reads_configured_length_and_address() {
+        let e = emit(&i2c("d-1", json!({ "address": 0x40, "read_length": 3 })));
+        assert!(e.loop_body.iter().any(|l| l.contains("requestFrom") && l.contains("64")));
+        assert!(e.loop_body.iter().any(|l| l.contains("< 3 &&")));
+    }
+
+    #[test]
+    fn i2c_sign_extends_for_signed_format() {
+        let e = emit(&i2c("d-1", json!({ "output": "signed_int" })));
+        assert!(e.loop_body.iter().any(|l| l.contains("0x80")), "signed must sign-extend");
+    }
+
+    #[test]
+    fn i2c_unsigned_does_not_sign_extend() {
+        let e = emit(&i2c("d-1", json!({ "output": "unsigned_int" })));
+        assert!(!e.loop_body.iter().any(|l| l.contains("0x80")));
+    }
+
+    #[test]
+    fn i2c_emits_deterministically() {
+        let n = i2c("d-1", json!({ "address": 0x48, "read_length": 2 }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/input/mod.rs
+++ b/apps/web/src-tauri/src/codegen/input/mod.rs
@@ -1,5 +1,10 @@
-//! Input-Node C++ emitters (Button, Sensor) — the codegen mirror of
-//! `runtime/input`.
+//! Input-Node C++ emitters (Button, Sensor, Switch, Motion, Proximity, Hotkey,
+//! `I2cDevice`) — the codegen mirror of `runtime/input`.
 
 pub mod button;
+pub mod hotkey;
+pub mod i2c_device;
+pub mod motion;
+pub mod proximity;
 pub mod sensor;
+pub mod switch;

--- a/apps/web/src-tauri/src/codegen/input/motion.rs
+++ b/apps/web/src-tauri/src/codegen/input/motion.rs
@@ -1,0 +1,72 @@
+//! Motion emitter — mirrors `runtime/input/motion.rs`.
+//!
+//! The live Motion (PIR) sensor sets `pinMode(pin, INPUT)` and reports a digital
+//! HIGH when motion is detected. The generated sketch emits the INPUT pin setup
+//! and a `digitalRead` each loop stored into a `bool` state variable that
+//! downstream Nodes read — a HIGH read means motion, matching the runtime which
+//! emits `true` on a detected pin-high.
+
+use crate::codegen::emit::{pin_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default pin matches `runtime/input/motion.rs::default_pin` (8).
+const DEFAULT_PIN: u8 = 8;
+
+/// The C++ `bool` variable name holding this Motion sensor's detected state.
+#[must_use]
+pub fn state_var(node: &FlowNode) -> String {
+    format!("motion_{}_state", node.id_token())
+}
+
+/// Emit C++ for a Motion Node.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let pin = pin_or_default(node, DEFAULT_PIN);
+    let pin_var = format!("motion_{}_pin", node.id_token());
+    let state = state_var(node);
+
+    NodeEmission {
+        declarations: vec![
+            format!("const uint8_t {pin_var} = {pin};"),
+            format!("bool {state} = false;"),
+        ],
+        setup: vec![format!("pinMode({pin_var}, INPUT);")],
+        loop_body: vec![format!("{state} = (digitalRead({pin_var}) == HIGH);")],
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn motion(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Motion".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn motion_input_mode_and_reads_digital() {
+        let e = emit(&motion("m-1", json!({ "pin": 8 })));
+        assert!(e.setup.iter().any(|s| s.contains("pinMode") && s.contains("INPUT")));
+        assert!(e.loop_body.iter().any(|l| l.contains("digitalRead") && l.contains("HIGH")));
+    }
+
+    #[test]
+    fn motion_uses_default_pin() {
+        let e = emit(&motion("m-1", json!({})));
+        assert!(e.declarations.iter().any(|d| d.contains("= 8;")));
+    }
+
+    #[test]
+    fn motion_emits_deterministically() {
+        let n = motion("m-1", json!({ "pin": 8 }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/input/proximity.rs
+++ b/apps/web/src-tauri/src/codegen/input/proximity.rs
@@ -1,0 +1,73 @@
+//! Proximity emitter — mirrors `runtime/input/proximity.rs`.
+//!
+//! The live Proximity sensor (e.g. a Sharp GP2Y0A21YK IR rangefinder) sets the
+//! ANALOG pin mode and reports `analogRead` values. Its pin is stored as a
+//! string (`"A0"` or a numeric pin) and resolved to a numeric analog pin via
+//! `analog_pin()`. The generated sketch declares the analog pin and stores
+//! `analogRead(pin)` into an `int` state variable each loop, which downstream
+//! Nodes read — the same reading the runtime forwards.
+
+use crate::codegen::emit::{pin_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default analog pin matches `runtime/input/proximity.rs` (`"A0"` => 0).
+const DEFAULT_PIN: u8 = 0;
+
+/// The C++ `int` variable name holding this Proximity sensor's latest reading.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("proximity_{}_value", node.id_token())
+}
+
+/// Emit C++ for a Proximity Node.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let pin = pin_or_default(node, DEFAULT_PIN);
+    let pin_var = format!("proximity_{}_pin", node.id_token());
+    let value = value_var(node);
+
+    NodeEmission {
+        declarations: vec![
+            format!("const uint8_t {pin_var} = A{pin};"),
+            format!("int {value} = 0;"),
+        ],
+        setup: vec![format!("pinMode({pin_var}, INPUT);")],
+        loop_body: vec![format!("{value} = analogRead({pin_var});")],
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn proximity(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Proximity".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn proximity_reads_analog_pin() {
+        let e = emit(&proximity("p-1", json!({ "pin": "A0" })));
+        assert!(e.loop_body.iter().any(|l| l.contains("analogRead")));
+        assert!(e.declarations.iter().any(|d| d.contains("A0")));
+    }
+
+    #[test]
+    fn proximity_resolves_numeric_pin() {
+        let e = emit(&proximity("p-1", json!({ "pin": "3" })));
+        assert!(e.declarations.iter().any(|d| d.contains("A3")));
+    }
+
+    #[test]
+    fn proximity_emits_deterministically() {
+        let n = proximity("p-1", json!({ "pin": "A0" }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/input/switch.rs
+++ b/apps/web/src-tauri/src/codegen/input/switch.rs
@@ -1,0 +1,95 @@
+//! Switch emitter — mirrors `runtime/input/switch.rs`.
+//!
+//! The live Switch is a latching on/off toggle (unlike the momentary Button).
+//! It sets `pinMode(pin, INPUT)` and reports digital reads. A Normally-Open (NO)
+//! switch reads HIGH when actuated; a Normally-Closed (NC) switch is wired
+//! inverted, so the emitted state inverts the raw read to match the runtime's
+//! `SwitchType`. Downstream Nodes read the resulting `bool` state variable.
+
+use crate::codegen::emit::{pin_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default pin matches `runtime/input/switch.rs::default_pin` (2).
+const DEFAULT_PIN: u8 = 2;
+
+/// The C++ `bool` variable name holding this Switch's current on/off state.
+#[must_use]
+pub fn state_var(node: &FlowNode) -> String {
+    format!("switch_{}_state", node.id_token())
+}
+
+/// True when the Node's `data.type` selects a Normally-Closed switch.
+fn is_normally_closed(node: &FlowNode) -> bool {
+    node.data
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|t| t.eq_ignore_ascii_case("NC"))
+}
+
+/// Emit C++ for a Switch Node.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let pin = pin_or_default(node, DEFAULT_PIN);
+    let pin_var = format!("switch_{}_pin", node.id_token());
+    let state = state_var(node);
+    let nc = is_normally_closed(node);
+
+    // NO: actuated reads HIGH. NC: the contact is inverted, so actuated reads
+    // LOW — mirror the runtime by inverting the comparison.
+    let read_expr = if nc {
+        format!("(digitalRead({pin_var}) == LOW)")
+    } else {
+        format!("(digitalRead({pin_var}) == HIGH)")
+    };
+
+    NodeEmission {
+        declarations: vec![
+            format!("const uint8_t {pin_var} = {pin};"),
+            format!("bool {state} = false;"),
+        ],
+        setup: vec![format!("pinMode({pin_var}, INPUT);")],
+        loop_body: vec![format!("{state} = {read_expr};")],
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn switch(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Switch".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn switch_input_mode_and_reads() {
+        let e = emit(&switch("sw-1", json!({ "pin": 2 })));
+        assert!(e.setup.iter().any(|s| s.contains("pinMode") && s.contains("INPUT")));
+        assert!(e.loop_body.iter().any(|l| l.contains("digitalRead") && l.contains("HIGH")));
+    }
+
+    #[test]
+    fn switch_nc_inverts_read() {
+        let e = emit(&switch("sw-1", json!({ "pin": 2, "type": "NC" })));
+        assert!(e.loop_body.iter().any(|l| l.contains("LOW")));
+    }
+
+    #[test]
+    fn switch_uses_default_pin() {
+        let e = emit(&switch("sw-1", json!({})));
+        assert!(e.declarations.iter().any(|d| d.contains("= 2;")));
+    }
+
+    #[test]
+    fn switch_emits_deterministically() {
+        let n = switch("sw-1", json!({ "pin": 2, "type": "NC" }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/mod.rs
+++ b/apps/web/src-tauri/src/codegen/mod.rs
@@ -23,6 +23,7 @@
 
 pub mod control;
 pub mod emit;
+pub mod generator;
 pub mod input;
 pub mod output;
 pub mod placeholder;
@@ -142,8 +143,25 @@ fn emit_node(node: &FlowNode, drivers: &BTreeMap<&str, String>) -> NodeEmission 
         Some("Led") => output::led::emit(node, driver),
         Some("Relay") => output::relay::emit(node, driver),
         Some("Servo") => output::servo::emit(node, driver),
+        Some("Rgb") => output::rgb::emit(node, driver),
+        Some("Piezo") => output::piezo::emit(node, driver),
+        Some("Pixel") => output::pixel::emit(node, driver),
+        Some("Matrix") => output::matrix::emit(node, driver),
+        Some("Stepper") => output::stepper::emit(node, driver),
+        // Vibration shares the live Led implementation (digital on/off output).
+        Some("Vibration") => output::led::emit(node, driver),
         Some("Button") => input::button::emit(node),
-        Some("Sensor") => input::sensor::emit(node),
+        // Force, HallEffect, Ldr, Potentiometer, and Tilt are all analog inputs
+        // backed by the live Sensor implementation, so they share its emitter.
+        Some("Sensor" | "Force" | "HallEffect" | "Ldr" | "Potentiometer" | "Tilt") => {
+            input::sensor::emit(node)
+        }
+        Some("Switch") => input::switch::emit(node),
+        Some("Motion") => input::motion::emit(node),
+        Some("Proximity") => input::proximity::emit(node),
+        Some("Hotkey") => input::hotkey::emit(node),
+        Some("I2cDevice") => input::i2c_device::emit(node),
+        Some("Oscillator") => generator::oscillator::emit(node),
         Some("Calculate") => transformation::calculate::emit(node, driver),
         Some("Compare") => transformation::compare::emit(node, driver),
         Some("Gate") => transformation::gate::emit(node, driver),
@@ -199,7 +217,15 @@ fn driver_expressions(flow: &FlowUpdate) -> BTreeMap<&str, String> {
 fn source_expression(node: &FlowNode) -> Option<String> {
     match node.node_type.as_deref() {
         Some("Button") => Some(input::button::state_var(node)),
-        Some("Sensor") => Some(input::sensor::value_var(node)),
+        Some("Sensor" | "Force" | "HallEffect" | "Ldr" | "Potentiometer" | "Tilt") => {
+            Some(input::sensor::value_var(node))
+        }
+        Some("Switch") => Some(input::switch::state_var(node)),
+        Some("Motion") => Some(input::motion::state_var(node)),
+        Some("Proximity") => Some(input::proximity::value_var(node)),
+        Some("Hotkey") => Some(input::hotkey::state_var(node)),
+        Some("I2cDevice") => Some(input::i2c_device::value_var(node)),
+        Some("Oscillator") => Some(generator::oscillator::value_var(node)),
         Some("Calculate") => Some(transformation::calculate::value_var(node)),
         Some("Compare") => Some(transformation::compare::state_var(node)),
         Some("Gate") => Some(transformation::gate::state_var(node)),
@@ -1047,6 +1073,181 @@ mod tests {
             "no control Node may be a placeholder, got:\n{sketch}"
         );
         assert!(!sketch.contains("delay("), "control nodes stay non-blocking");
+    }
+
+    // --- Remaining input/output/generator Nodes (Task #37) ---
+
+    /// Scenario: Remaining input Nodes feed values into the Flow.
+    ///
+    /// A Flow uses every remaining non-Cloud input Node (Switch, Motion,
+    /// Proximity, Hotkey, `I2cDevice` plus the Sensor-backed aliases). Each must
+    /// read its hardware into a state/value variable that downstream Nodes can
+    /// consume, exactly as the live runtime forwards its reading.
+    #[test]
+    fn remaining_input_nodes_feed_values_into_the_flow() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sw-1", "Switch", json!({ "pin": 2 })),
+                node_data("mo-1", "Motion", json!({ "pin": 8 })),
+                node_data("px-1", "Proximity", json!({ "pin": "A1" })),
+                node_data("hk-1", "Hotkey", json!({ "accelerator": "a" })),
+                node_data("i2c-1", "I2cDevice", json!({ "address": 64, "read_length": 2 })),
+                node_data("pot-1", "Potentiometer", json!({ "pin": "A2" })),
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+            ],
+            // Switch drives the Led, so its read flows into the rest of the Flow.
+            edges: vec![edge("sw-1", "led-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Each input reads hardware into its variable.
+        assert!(sketch.contains("switch_sw_1_state = (digitalRead"), "switch reads");
+        assert!(sketch.contains("motion_mo_1_state = (digitalRead"), "motion reads");
+        assert!(sketch.contains("proximity_px_1_value = analogRead"), "proximity reads");
+        assert!(sketch.contains("bool hotkey_hk_1_state"), "hotkey declares state");
+        assert!(sketch.contains("i2c_i2c_1_value = "), "i2c reads");
+        assert!(sketch.contains("sensor_pot_1_value = analogRead"), "potentiometer is a Sensor");
+        // The Switch reading feeds the Led (value flows into the Flow).
+        assert!(
+            sketch.contains("digitalWrite(led_led_1_pin, (switch_sw_1_state)"),
+            "switch value must drive the led, got:\n{sketch}"
+        );
+        assert!(!sketch.contains("delay("), "stays non-blocking");
+    }
+
+    /// Scenario: Remaining output Nodes drive their hardware.
+    ///
+    /// A Sensor drives each remaining non-Cloud output Node (Rgb, Piezo, Pixel,
+    /// Matrix, Stepper, and the Led-backed Vibration). Each must emit real drive
+    /// logic from the incoming value, pulling in any required library.
+    #[test]
+    fn remaining_output_nodes_drive_their_hardware() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data("rgb-1", "Rgb", json!({})),
+                node_data("pz-1", "Piezo", json!({})),
+                node_data("px-1", "Pixel", json!({ "length": 8 })),
+                node_data("mx-1", "Matrix", json!({})),
+                node_data("st-1", "Stepper", json!({})),
+                node_data("vb-1", "Vibration", json!({ "pin": 5 })),
+            ],
+            edges: vec![
+                edge("sensor-1", "rgb-1"),
+                edge("sensor-1", "pz-1"),
+                edge("sensor-1", "px-1"),
+                edge("sensor-1", "mx-1"),
+                edge("sensor-1", "st-1"),
+                edge("sensor-1", "vb-1"),
+            ],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Each output drives from the sensor value.
+        assert!(sketch.contains("analogWrite(rgb_rgb_1_red_pin"), "rgb drives channels");
+        assert!(sketch.contains("tone(piezo_pz_1_pin"), "piezo sounds");
+        assert!(sketch.contains("pixel_px_1.setPixelColor"), "pixel fills");
+        assert!(sketch.contains("matrix_mx_1.setRow"), "matrix lights");
+        assert!(sketch.contains("stepper_st_1.moveTo"), "stepper targets value");
+        assert!(sketch.contains("digitalWrite(led_vb_1_pin"), "vibration is an Led output");
+        // Library-backed Nodes pull in their includes.
+        assert!(sketch.contains("#include <Adafruit_NeoPixel.h>"), "pixel include");
+        assert!(sketch.contains("#include <LedControl.h>"), "matrix include");
+        assert!(sketch.contains("#include <AccelStepper.h>"), "stepper include");
+        assert!(!sketch.contains("delay("), "stays non-blocking");
+    }
+
+    /// Scenario: The generator Node produces its signal non-blocking.
+    #[test]
+    fn generator_node_produces_signal_non_blocking() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("osc-1", "Oscillator", json!({ "waveform": "sinus", "period": 1000 })),
+                node_data("servo-1", "Servo", json!({ "pin": 9 })),
+            ],
+            edges: vec![edge("osc-1", "servo-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // The Oscillator samples its waveform off the loop scheduler's millis() clock.
+        assert!(
+            sketch.contains("millis() - oscillator_osc_1_start"),
+            "oscillator must sample against the scheduler clock, got:\n{sketch}"
+        );
+        assert!(sketch.contains("oscillator_osc_1_value = "), "oscillator output");
+        // No blocking wait anywhere.
+        assert!(!sketch.contains("delay("), "oscillator must be non-blocking");
+        // The signal flows onward to the wired Servo.
+        assert!(
+            sketch.contains("(oscillator_osc_1_value)"),
+            "oscillator must drive the servo, got:\n{sketch}"
+        );
+        assert!(!sketch.contains("// unsupported Node osc"), "oscillator must not be a placeholder");
+    }
+
+    /// Scenario: No remaining non-Cloud Node is a placeholder, while Cloud Nodes
+    /// still fall through to placeholders (Feature #27 territory).
+    #[test]
+    fn no_remaining_non_cloud_node_is_a_placeholder() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sw-1", "Switch", json!({})),
+                node_data("mo-1", "Motion", json!({})),
+                node_data("px-in", "Proximity", json!({})),
+                node_data("hk-1", "Hotkey", json!({})),
+                node_data("i2c-1", "I2cDevice", json!({})),
+                node_data("force-1", "Force", json!({})),
+                node_data("hall-1", "HallEffect", json!({})),
+                node_data("ldr-1", "Ldr", json!({})),
+                node_data("pot-1", "Potentiometer", json!({})),
+                node_data("tilt-1", "Tilt", json!({})),
+                node_data("rgb-1", "Rgb", json!({})),
+                node_data("pz-1", "Piezo", json!({})),
+                node_data("px-out", "Pixel", json!({})),
+                node_data("mx-1", "Matrix", json!({})),
+                node_data("st-1", "Stepper", json!({})),
+                node_data("vb-1", "Vibration", json!({})),
+                node_data("osc-1", "Oscillator", json!({})),
+                // Cloud Nodes remain placeholders (handled by Feature #27).
+                node("mqtt-1", "Mqtt"),
+                node("figma-1", "Figma"),
+                node("llm-1", "Llm"),
+                node("monitor-1", "Monitor"),
+            ],
+            edges: vec![],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Exactly the four Cloud Nodes are placeholders — nothing else.
+        assert_eq!(
+            sketch.matches("// unsupported Node ").count(),
+            4,
+            "only the four Cloud Nodes may be placeholders, got:\n{sketch}"
+        );
+        // Spot-check that representative remaining Nodes emit real artefacts.
+        assert!(sketch.contains("switch_sw_1_state"));
+        assert!(sketch.contains("oscillator_osc_1_value"));
+        assert!(sketch.contains("Adafruit_NeoPixel"));
+        assert!(!sketch.contains("delay("), "stays non-blocking");
+    }
+
+    /// Determinism holds for a Flow mixing the remaining Node types.
+    #[test]
+    fn remaining_nodes_flow_is_deterministic() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("osc-1", "Oscillator", json!({ "waveform": "square", "period": 500 })),
+                node_data("sw-1", "Switch", json!({ "pin": 2 })),
+                node_data("rgb-1", "Rgb", json!({})),
+                node_data("st-1", "Stepper", json!({})),
+            ],
+            edges: vec![edge("osc-1", "rgb-1"), edge("sw-1", "st-1")],
+        };
+        assert_eq!(generate(&flow).unwrap(), generate(&flow).unwrap());
     }
 
     /// Determinism holds for a control-heavy Flow.

--- a/apps/web/src-tauri/src/codegen/output/matrix.rs
+++ b/apps/web/src-tauri/src/codegen/output/matrix.rs
@@ -1,0 +1,127 @@
+//! Matrix emitter — mirrors `runtime/output/matrix.rs`.
+//!
+//! The live Matrix drives a MAX7219 LED matrix over bit-banged SPI (data, clock,
+//! CS pins), initialising the chip out of shutdown, setting a scan limit and
+//! intensity, and clearing the display. The generated sketch uses the standard
+//! Arduino `LedControl` library, whose `LedControl(dataPin, clkPin, csPin,
+//! numDevices)` wraps exactly this MAX7219 protocol: `setup()` wakes each device
+//! from power-down (`shutdown(i, false)`), sets a mid intensity, and clears the
+//! display — mirroring the runtime's `init_max7219` + blank-on-init. When wired
+//! from an upstream signal the whole display is lit or cleared accordingly.
+
+use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Pin defaults match `runtime/output/matrix.rs` (data=2, clock=3, cs=4).
+const DEFAULT_DATA: u8 = 2;
+const DEFAULT_CLOCK: u8 = 3;
+const DEFAULT_CS: u8 = 4;
+/// Device-count default matches `runtime/output/matrix.rs::default_devices` (1).
+const DEFAULT_DEVICES: u8 = 1;
+
+fn pin(node: &FlowNode, key: &str, default: u8) -> u8 {
+    node.data
+        .get("pins")
+        .and_then(|p| p.get(key))
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|n| u8::try_from(n).ok())
+        .unwrap_or(default)
+}
+
+fn devices(node: &FlowNode) -> u8 {
+    node.data
+        .get("devices")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|n| u8::try_from(n).ok())
+        .unwrap_or(DEFAULT_DEVICES)
+        .max(1)
+}
+
+/// Emit C++ for a Matrix Node. `driver` is an optional boolean: when wired, a
+/// true value lights every LED and a false value clears the display.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let obj = format!("matrix_{token}");
+    let data = pin(node, "data", DEFAULT_DATA);
+    let clock = pin(node, "clock", DEFAULT_CLOCK);
+    let cs = pin(node, "cs", DEFAULT_CS);
+    let devices = devices(node);
+    let i = format!("matrix_{token}_i");
+    let row = format!("matrix_{token}_row");
+
+    let mut e = NodeEmission {
+        includes: vec!["#include <LedControl.h>".to_string()],
+        declarations: vec![format!(
+            "LedControl {obj}({data}, {clock}, {cs}, {devices});"
+        )],
+        setup: vec![
+            format!("for (int {i} = 0; {i} < {devices}; {i}++) {{"),
+            // Mirror init_max7219: wake from shutdown, mid intensity, clear.
+            format!("  {obj}.shutdown({i}, false);"),
+            format!("  {obj}.setIntensity({i}, 8);"),
+            format!("  {obj}.clearDisplay({i});"),
+            "}".to_string(),
+        ],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        e.loop_body.push(format!("for (int {i} = 0; {i} < {devices}; {i}++) {{"));
+        e.loop_body.push(format!("  for (int {row} = 0; {row} < 8; {row}++) {{"));
+        e.loop_body.push(format!(
+            "    {obj}.setRow({i}, {row}, ({expr}) ? 0xFF : 0x00);"
+        ));
+        e.loop_body.push("  }".to_string());
+        e.loop_body.push("}".to_string());
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn matrix(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Matrix".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn matrix_includes_library_and_declares_object() {
+        let e = emit(&matrix("mx-1", json!({})), None);
+        assert!(e.includes.iter().any(|i| i.contains("LedControl.h")));
+        assert!(e.declarations.iter().any(|d| d.contains("LedControl matrix_mx_1(2, 3, 4, 1)")));
+    }
+
+    #[test]
+    fn matrix_wakes_and_clears_on_setup() {
+        let e = emit(&matrix("mx-1", json!({})), None);
+        assert!(e.setup.iter().any(|s| s.contains("shutdown") && s.contains("false")));
+        assert!(e.setup.iter().any(|s| s.contains("clearDisplay")));
+    }
+
+    #[test]
+    fn matrix_lights_display_from_value() {
+        let e = emit(&matrix("mx-1", json!({})), Some("btn_state"));
+        assert!(e.loop_body.iter().any(|l| l.contains("setRow") && l.contains("btn_state")));
+    }
+
+    #[test]
+    fn matrix_reads_custom_pins() {
+        let e = emit(&matrix("mx-1", json!({ "pins": { "data": 7, "clock": 8, "cs": 9 }, "devices": 2 })), None);
+        assert!(e.declarations.iter().any(|d| d.contains("(7, 8, 9, 2)")));
+    }
+
+    #[test]
+    fn matrix_emits_deterministically() {
+        let n = matrix("mx-1", json!({ "devices": 2 }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/output/mod.rs
+++ b/apps/web/src-tauri/src/codegen/output/mod.rs
@@ -1,6 +1,11 @@
-//! Output-Node C++ emitters (Led, Servo, Relay) — the codegen mirror of
-//! `runtime/output`.
+//! Output-Node C++ emitters (Led, Servo, Relay, Rgb, Piezo, Pixel, Matrix,
+//! Stepper) — the codegen mirror of `runtime/output`.
 
 pub mod led;
+pub mod matrix;
+pub mod piezo;
+pub mod pixel;
 pub mod relay;
+pub mod rgb;
 pub mod servo;
+pub mod stepper;

--- a/apps/web/src-tauri/src/codegen/output/piezo.rs
+++ b/apps/web/src-tauri/src/codegen/output/piezo.rs
@@ -1,0 +1,98 @@
+//! Piezo emitter — mirrors `runtime/output/piezo.rs`.
+//!
+//! The live Piezo buzzer plays a tone by toggling its pin at the note's
+//! half-period (the Johnny-Five approach). The Arduino core exposes exactly this
+//! via the built-in `tone(pin, frequency, duration)` / `noTone(pin)`, which is
+//! non-blocking (it runs off a hardware timer). The generated sketch sets the
+//! pin OUTPUT, and — when triggered from an upstream signal — sounds the
+//! configured frequency for the configured duration, falling silent otherwise.
+//! No blocking `delay()` is used: `tone(...)` returns immediately.
+
+use crate::codegen::emit::{pin_or_default, u64_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default pin matches `runtime/output/piezo.rs::default_pin` (11).
+const DEFAULT_PIN: u8 = 11;
+/// Default frequency matches `runtime/output/piezo.rs::default_frequency` (440 Hz).
+const DEFAULT_FREQUENCY: u64 = 440;
+/// Default duration matches `runtime/output/piezo.rs::default_duration` (500 ms).
+const DEFAULT_DURATION: u64 = 500;
+
+/// Emit C++ for a Piezo Node. `driver` is an optional boolean trigger: while
+/// true the buzzer sounds, otherwise it is silenced.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let pin_var = format!("piezo_{token}_pin");
+    let pin = pin_or_default(node, DEFAULT_PIN);
+    let frequency = u64_or_default(node, "frequency", DEFAULT_FREQUENCY);
+    let duration = u64_or_default(node, "duration", DEFAULT_DURATION);
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("const uint8_t {pin_var} = {pin};")],
+        setup: vec![
+            format!("pinMode({pin_var}, OUTPUT);"),
+            // Mirror runtime initialize: silent at start.
+            format!("noTone({pin_var});"),
+        ],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        e.loop_body.push(format!("if ({expr}) {{"));
+        // tone() is non-blocking — it drives a hardware timer and returns at once.
+        e.loop_body
+            .push(format!("  tone({pin_var}, {frequency}, {duration});"));
+        e.loop_body.push("} else {".to_string());
+        e.loop_body.push(format!("  noTone({pin_var});"));
+        e.loop_body.push("}".to_string());
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn piezo(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Piezo".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn piezo_sets_output_and_starts_silent() {
+        let e = emit(&piezo("pz-1", json!({ "pin": 11 })), None);
+        assert!(e.setup.iter().any(|s| s.contains("pinMode") && s.contains("OUTPUT")));
+        assert!(e.setup.iter().any(|s| s.contains("noTone")));
+    }
+
+    #[test]
+    fn piezo_sounds_configured_frequency_when_triggered() {
+        let e = emit(&piezo("pz-1", json!({ "frequency": 880, "duration": 250 })), Some("btn_state"));
+        assert!(e.loop_body.iter().any(|l| l.contains("tone(") && l.contains("880") && l.contains("250")));
+    }
+
+    #[test]
+    fn piezo_is_non_blocking() {
+        let e = emit(&piezo("pz-1", json!({})), Some("v"));
+        assert!(!e.loop_body.iter().any(|l| l.contains("delay(")), "piezo must not block");
+    }
+
+    #[test]
+    fn piezo_uses_default_frequency() {
+        let e = emit(&piezo("pz-1", json!({})), Some("v"));
+        assert!(e.loop_body.iter().any(|l| l.contains("440")));
+    }
+
+    #[test]
+    fn piezo_emits_deterministically() {
+        let n = piezo("pz-1", json!({ "frequency": 440 }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/output/pixel.rs
+++ b/apps/web/src-tauri/src/codegen/output/pixel.rs
@@ -1,0 +1,125 @@
+//! Pixel emitter — mirrors `runtime/output/pixel.rs`.
+//!
+//! The live Pixel drives an addressable `NeoPixel` strip (WS2812-style). It
+//! configures the strip length, pin and colour order, and pushes per-pixel
+//! colours, clearing the strip on initialize. The generated sketch uses the
+//! Adafruit `NeoPixel` library: it `#include <Adafruit_NeoPixel.h>`, declares a
+//! strip object sized to the configured length on the configured pin with the
+//! matching colour order, calls `begin()` + `clear()` + `show()` in `setup()`
+//! (mirroring the runtime's off-on-init), and — when wired from an upstream
+//! brightness value — fills the whole strip with that grayscale level each loop.
+
+use crate::codegen::emit::{pin_or_default, u16_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default pin matches `runtime/output/pixel.rs::default_pin` (6).
+const DEFAULT_PIN: u8 = 6;
+/// Default length matches `runtime/output/pixel.rs::default_length` (32).
+const DEFAULT_LENGTH: u16 = 32;
+
+/// Map the configured colour-order string to the `NeoPixel` type flag.
+fn neo_color_flag(node: &FlowNode) -> &'static str {
+    let order = node
+        .data
+        .get("color_order")
+        .or_else(|| node.data.get("colorOrder"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("GRB")
+        .to_ascii_uppercase();
+    match order.as_str() {
+        "RGB" => "NEO_RGB + NEO_KHZ800",
+        "BRG" => "NEO_BRG + NEO_KHZ800",
+        // GRB is the WS2812 default and the runtime default.
+        _ => "NEO_GRB + NEO_KHZ800",
+    }
+}
+
+/// Emit C++ for a Pixel Node. `driver` is an optional grayscale brightness
+/// (0..=255) applied to every pixel; `None` leaves the strip cleared.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let obj = format!("pixel_{token}");
+    let pin = pin_or_default(node, DEFAULT_PIN);
+    let length = u16_or_default(node, "length", DEFAULT_LENGTH).max(1);
+    let flag = neo_color_flag(node);
+    let i = format!("pixel_{token}_i");
+
+    let mut e = NodeEmission {
+        includes: vec!["#include <Adafruit_NeoPixel.h>".to_string()],
+        declarations: vec![format!(
+            "Adafruit_NeoPixel {obj}({length}, {pin}, {flag});"
+        )],
+        setup: vec![
+            format!("{obj}.begin();"),
+            // Mirror runtime initialize: cleared.
+            format!("{obj}.clear();"),
+            format!("{obj}.show();"),
+        ],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        let level = format!("constrain((int)({expr}), 0, 255)");
+        e.loop_body.push(format!("int {token}_level = {level};"));
+        e.loop_body.push(format!(
+            "for (uint16_t {i} = 0; {i} < {length}; {i}++) {{"
+        ));
+        e.loop_body.push(format!(
+            "  {obj}.setPixelColor({i}, {obj}.Color({token}_level, {token}_level, {token}_level));"
+        ));
+        e.loop_body.push("}".to_string());
+        e.loop_body.push(format!("{obj}.show();"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn pixel(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Pixel".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn pixel_includes_library_and_declares_strip() {
+        let e = emit(&pixel("px-1", json!({ "pin": 6, "length": 16 })), None);
+        assert!(e.includes.iter().any(|i| i.contains("Adafruit_NeoPixel.h")));
+        assert!(e.declarations.iter().any(|d| d.contains("Adafruit_NeoPixel pixel_px_1(16, 6")));
+    }
+
+    #[test]
+    fn pixel_begins_and_clears_on_setup() {
+        let e = emit(&pixel("px-1", json!({})), None);
+        assert!(e.setup.iter().any(|s| s.contains(".begin()")));
+        assert!(e.setup.iter().any(|s| s.contains(".clear()")));
+    }
+
+    #[test]
+    fn pixel_fills_strip_from_value() {
+        let e = emit(&pixel("px-1", json!({ "length": 8 })), Some("sensor_x_value"));
+        assert!(e.loop_body.iter().any(|l| l.contains("setPixelColor")));
+        assert!(e.loop_body.iter().any(|l| l.contains("sensor_x_value")));
+        assert!(e.loop_body.iter().any(|l| l.contains(".show()")));
+    }
+
+    #[test]
+    fn pixel_honours_color_order() {
+        let e = emit(&pixel("px-1", json!({ "color_order": "RGB" })), None);
+        assert!(e.declarations.iter().any(|d| d.contains("NEO_RGB")));
+    }
+
+    #[test]
+    fn pixel_emits_deterministically() {
+        let n = pixel("px-1", json!({ "length": 12 }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/output/rgb.rs
+++ b/apps/web/src-tauri/src/codegen/output/rgb.rs
@@ -1,0 +1,127 @@
+//! Rgb emitter — mirrors `runtime/output/rgb.rs`.
+//!
+//! The live RGB LED drives three PWM pins (red/green/blue). It sets each pin to
+//! PWM mode and turns the LED off on initialize. A common-anode (`isAnode`) LED
+//! is active-low, so its channel writes are inverted (`255 - value`). The
+//! generated sketch declares the three pin constants, sets them OUTPUT, writes
+//! them off in `setup()`, and — when wired from a single upstream value — drives
+//! all three channels with that brightness via `analogWrite`, honouring the
+//! anode inversion so emitted behavior matches the runtime.
+
+use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Channel pin defaults match `runtime/output/rgb.rs` (red=9, green=10, blue=11).
+const DEFAULT_RED: u8 = 9;
+const DEFAULT_GREEN: u8 = 10;
+const DEFAULT_BLUE: u8 = 11;
+
+/// Read a channel pin from `data.pins.<channel>` with the runtime default.
+fn channel_pin(node: &FlowNode, channel: &str, default: u8) -> u8 {
+    node.data
+        .get("pins")
+        .and_then(|p| p.get(channel))
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|n| u8::try_from(n).ok())
+        .unwrap_or(default)
+}
+
+/// True when the LED is common-anode (active-low channels).
+fn is_anode(node: &FlowNode) -> bool {
+    node.data.get("isAnode").and_then(serde_json::Value::as_bool).unwrap_or(false)
+}
+
+/// Emit C++ for an Rgb Node. `driver` is an optional brightness expression
+/// (0..=255) applied to every channel; `None` leaves the LED off.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let red = format!("rgb_{token}_red_pin");
+    let green = format!("rgb_{token}_green_pin");
+    let blue = format!("rgb_{token}_blue_pin");
+    let anode = is_anode(node);
+    // Off level: common-anode is active-low, so "off" is 255.
+    let off = if anode { 255 } else { 0 };
+
+    let mut e = NodeEmission {
+        declarations: vec![
+            format!("const uint8_t {red} = {};", channel_pin(node, "red", DEFAULT_RED)),
+            format!("const uint8_t {green} = {};", channel_pin(node, "green", DEFAULT_GREEN)),
+            format!("const uint8_t {blue} = {};", channel_pin(node, "blue", DEFAULT_BLUE)),
+        ],
+        setup: vec![
+            format!("pinMode({red}, OUTPUT);"),
+            format!("pinMode({green}, OUTPUT);"),
+            format!("pinMode({blue}, OUTPUT);"),
+            // Mirror runtime initialize: start off.
+            format!("analogWrite({red}, {off});"),
+            format!("analogWrite({green}, {off});"),
+            format!("analogWrite({blue}, {off});"),
+        ],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        // Common-anode inverts the duty cycle.
+        let level = if anode {
+            format!("(255 - constrain((int)({expr}), 0, 255))")
+        } else {
+            format!("constrain((int)({expr}), 0, 255)")
+        };
+        e.loop_body.push(format!("analogWrite({red}, {level});"));
+        e.loop_body.push(format!("analogWrite({green}, {level});"));
+        e.loop_body.push(format!("analogWrite({blue}, {level});"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn rgb(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Rgb".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn rgb_sets_three_pwm_pins_and_starts_off() {
+        let e = emit(&rgb("rgb-1", json!({})), None);
+        assert_eq!(e.setup.iter().filter(|s| s.contains("pinMode")).count(), 3);
+        assert!(e.declarations.iter().any(|d| d.contains("= 9;")));
+        assert!(e.setup.iter().filter(|s| s.contains("analogWrite") && s.contains(", 0)")).count() >= 3);
+    }
+
+    #[test]
+    fn rgb_drives_all_channels_from_value() {
+        let e = emit(&rgb("rgb-1", json!({})), Some("sensor_x_value"));
+        assert_eq!(e.loop_body.iter().filter(|l| l.contains("analogWrite") && l.contains("sensor_x_value")).count(), 3);
+    }
+
+    #[test]
+    fn rgb_anode_inverts_levels() {
+        let e = emit(&rgb("rgb-1", json!({ "isAnode": true })), Some("v"));
+        assert!(e.loop_body.iter().any(|l| l.contains("255 -")));
+        assert!(e.setup.iter().any(|s| s.contains("analogWrite") && s.contains(", 255)")));
+    }
+
+    #[test]
+    fn rgb_reads_custom_pins() {
+        let e = emit(&rgb("rgb-1", json!({ "pins": { "red": 3, "green": 5, "blue": 6 } })), None);
+        assert!(e.declarations.iter().any(|d| d.contains("= 3;")));
+        assert!(e.declarations.iter().any(|d| d.contains("= 5;")));
+        assert!(e.declarations.iter().any(|d| d.contains("= 6;")));
+    }
+
+    #[test]
+    fn rgb_emits_deterministically() {
+        let n = rgb("rgb-1", json!({ "isAnode": true }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/output/stepper.rs
+++ b/apps/web/src-tauri/src/codegen/output/stepper.rs
@@ -1,0 +1,112 @@
+//! Stepper emitter — mirrors `runtime/output/stepper.rs`.
+//!
+//! The live Stepper drives a stepper motor through Firmata's `AccelStepper`
+//! protocol — configuring the interface (step/direction driver or 4-wire), max
+//! speed and acceleration, then moving to absolute/relative positions. The
+//! generated sketch uses the Arduino `AccelStepper` library directly: it
+//! `#include <AccelStepper.h>`, declares the motor with the matching interface
+//! and pins, sets max speed + acceleration in `setup()`, and — when wired from
+//! an upstream value — targets that position and calls `run()` every loop. `run()`
+//! steps at most once per call and returns immediately, so motion is fully
+//! non-blocking and other Nodes keep ticking.
+
+use crate::codegen::emit::{f64_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Pin defaults match `runtime/output/stepper.rs` (step=2, dir=3).
+const DEFAULT_STEP_PIN: u8 = 2;
+const DEFAULT_DIR_PIN: u8 = 3;
+
+fn pin(node: &FlowNode, key: &str, default: u8) -> u8 {
+    node.data
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|n| u8::try_from(n).ok())
+        .unwrap_or(default)
+}
+
+/// Emit C++ for a Stepper Node. `driver` is an optional target-position
+/// expression (absolute step count); `None` leaves the motor parked at zero.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let obj = format!("stepper_{token}");
+    let step_pin = pin(node, "step_pin", DEFAULT_STEP_PIN);
+    let dir_pin = pin(node, "dir_pin", DEFAULT_DIR_PIN);
+    // Runtime stores speed/acceleration as floats; default to library-sane values.
+    let speed = f64_or_default(node, "speed", 1000.0);
+    let acceleration = f64_or_default(node, "acceleration", 500.0);
+    let speed = crate::codegen::emit::cpp_double(speed);
+    let acceleration = crate::codegen::emit::cpp_double(acceleration);
+
+    let mut e = NodeEmission {
+        includes: vec!["#include <AccelStepper.h>".to_string()],
+        declarations: vec![format!(
+            "AccelStepper {obj}(AccelStepper::DRIVER, {step_pin}, {dir_pin});"
+        )],
+        setup: vec![
+            format!("{obj}.setMaxSpeed({speed});"),
+            format!("{obj}.setAcceleration({acceleration});"),
+        ],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        // Non-blocking: moveTo sets the target, run() steps at most once per call.
+        e.loop_body.push(format!("{obj}.moveTo((long)({expr}));"));
+    }
+    // The motor must keep stepping toward its target every loop, even when
+    // unconnected (no-op until a target is set), so always emit run().
+    e.loop_body.push(format!("{obj}.run();"));
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn stepper(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Stepper".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn stepper_includes_library_and_declares_motor() {
+        let e = emit(&stepper("st-1", json!({})), None);
+        assert!(e.includes.iter().any(|i| i.contains("AccelStepper.h")));
+        assert!(e.declarations.iter().any(|d| d.contains("AccelStepper stepper_st_1(AccelStepper::DRIVER, 2, 3)")));
+    }
+
+    #[test]
+    fn stepper_sets_speed_and_acceleration() {
+        let e = emit(&stepper("st-1", json!({ "speed": 800, "acceleration": 200 })), None);
+        assert!(e.setup.iter().any(|s| s.contains("setMaxSpeed(800")));
+        assert!(e.setup.iter().any(|s| s.contains("setAcceleration(200")));
+    }
+
+    #[test]
+    fn stepper_targets_value_and_runs_non_blocking() {
+        let e = emit(&stepper("st-1", json!({})), Some("sensor_x_value"));
+        assert!(e.loop_body.iter().any(|l| l.contains("moveTo") && l.contains("sensor_x_value")));
+        assert!(e.loop_body.iter().any(|l| l.contains(".run()")));
+        assert!(!e.loop_body.iter().any(|l| l.contains("delay(")), "stepper must not block");
+    }
+
+    #[test]
+    fn stepper_runs_even_when_unconnected() {
+        let e = emit(&stepper("st-1", json!({})), None);
+        assert!(e.loop_body.iter().any(|l| l.contains(".run()")));
+    }
+
+    #[test]
+    fn stepper_emits_deterministically() {
+        let n = stepper("st-1", json!({ "speed": 1000 }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}


### PR DESCRIPTION
## Summary

Extends the Sketch Generation engine (Feature #23/#25) so that **every remaining non-Cloud input, output, and generator Node** emits real Arduino C++ instead of falling through to a placeholder. Before this change only the MVP core (Led, Button, Sensor, Servo, Relay) generated code; a Flow Author using any other hardware Node hit a placeholder and got an incomplete Sketch. After it, no Flow Author hits a placeholder for a hardware Node their board can actually drive.

Cloud Nodes (Mqtt, Figma, Llm, Monitor) intentionally remain placeholders — they belong to the Networked Device sub-context (Feature #27).

## Changes

- **Input emitters** (`codegen/input/`): Switch, Motion, Proximity, Hotkey, I2cDevice. The catalog aliases Force/HallEffect/Ldr/Potentiometer/Tilt dispatch to the existing Sensor emitter (they share its runtime impl), reconciled against `node-components.json`.
- **Output emitters** (`codegen/output/`): Rgb (PWM channels with anode inversion), Piezo (non-blocking `tone()`), Pixel (`Adafruit_NeoPixel`), Matrix (`LedControl`/MAX7219), Stepper (`AccelStepper`). Library-backed Nodes emit the matching `#include`s. Vibration dispatches to the Led emitter.
- **Generator emitter** (`codegen/generator/oscillator.rs`): a `millis()`-driven, non-blocking port of the runtime's `calculate_waveform` covering all five waveforms (sinus, square, sawtooth, triangle, random).
- **Dispatch** (`codegen/mod.rs`): every new Node type registered in the per-node emitter dispatch and the source-expression map so values flow downstream; Cloud/unknown types still route to the graceful placeholder.

Each emitter mirrors the live-runtime semantics of its matching `runtime/{input,output,generator}/*.rs` impl, stays deterministic (identical Flow → byte-identical Sketch), and uses no blocking `delay()`.

## Test plan

- [x] Remaining input Nodes feed values into the Flow
- [x] Remaining output Nodes drive their hardware
- [x] The generator Node produces its signal non-blocking
- [x] No remaining non-Cloud Node is a placeholder (Cloud Nodes still placeholdered)
- [x] Per-emitter happy-path + edge-path unit tests (defaults, NC/anode inversion, signed I2C, waveforms, zero-period guard)
- [x] `cargo test` — 352 passing; `cargo clippy --all-targets -W clippy::pedantic -D warnings` — clean

## Related

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)
