### PR TITLE
feat(web): add a board-target picker persisted on the Flow

### DIFF
--- a/apps/web/src-tauri/src/lib.rs
+++ b/apps/web/src-tauri/src/lib.rs
@@ -287,6 +287,7 @@ pub fn run() {
             runtime::commands::flow_update,
             runtime::commands::component_call,
             runtime::commands::generate_sketch,
+            runtime::commands::list_board_targets,
             mqtt::commands::mqtt_connect,
             mqtt::commands::mqtt_disconnect,
             mqtt::commands::mqtt_subscribe,

--- a/apps/web/src-tauri/src/runtime/commands.rs
+++ b/apps/web/src-tauri/src/runtime/commands.rs
@@ -321,6 +321,16 @@ fn default_board_target() -> BoardTarget {
     })
 }
 
+/// List the supported board targets so the editor can present a picker. The
+/// frontend reads the stable id + human-readable name from each target; the
+/// full pin/capability facts ride along for callers that need them. Mirrors the
+/// `supported_targets()` registry consulted by generation, keeping one source
+/// of truth for the supported list.
+#[tauri::command]
+pub fn list_board_targets() -> Vec<BoardTarget> {
+    crate::codegen::board::supported_targets()
+}
+
 /// Call a method on a component
 #[tauri::command]
 pub async fn component_call(

--- a/apps/web/src/components/flow/__tests__/board-target-picker.test.ts
+++ b/apps/web/src/components/flow/__tests__/board-target-picker.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import type { BoardTarget } from "@/lib/bindings/BoardTarget";
+import {
+  DEFAULT_TARGET_ID,
+  resolveSelectedTargetId,
+  toTargetOptions,
+} from "../board-target-picker.model";
+
+const target = (id: string, name: string): BoardTarget => ({
+  id,
+  name,
+  pins: [],
+  timers: [],
+  capabilities: [],
+});
+
+const TARGETS: BoardTarget[] = [
+  target("uno", "Arduino Uno"),
+  target("nano", "Arduino Nano"),
+  target("esp32", "ESP32"),
+];
+
+describe("resolveSelectedTargetId", () => {
+  test("returns the stored id when it is a supported target", () => {
+    expect(resolveSelectedTargetId(TARGETS, "esp32")).toBe("esp32");
+  });
+
+  // Scenario: A Flow with no prior selection shows a default.
+  test("falls back to the default target when nothing is stored", () => {
+    expect(resolveSelectedTargetId(TARGETS, undefined)).toBe(DEFAULT_TARGET_ID);
+  });
+
+  // Edge case: a stored id no longer supported falls back rather than breaking.
+  test("falls back to the default when the stored id is unsupported", () => {
+    expect(resolveSelectedTargetId(TARGETS, "mega-2560")).toBe(DEFAULT_TARGET_ID);
+  });
+
+  test("falls back to the first target when the default id is absent", () => {
+    const without = [target("nano", "Arduino Nano"), target("esp32", "ESP32")];
+    expect(resolveSelectedTargetId(without, undefined)).toBe("nano");
+  });
+
+  test("returns undefined when no targets are supported", () => {
+    expect(resolveSelectedTargetId([], undefined)).toBeUndefined();
+  });
+});
+
+describe("toTargetOptions", () => {
+  test("projects id and name for labelled options", () => {
+    expect(toTargetOptions(TARGETS)).toEqual([
+      { id: "uno", name: "Arduino Uno" },
+      { id: "nano", name: "Arduino Nano" },
+      { id: "esp32", name: "ESP32" },
+    ]);
+  });
+});

--- a/apps/web/src/components/flow/board-target-picker.model.ts
+++ b/apps/web/src/components/flow/board-target-picker.model.ts
@@ -1,0 +1,40 @@
+import type { BoardTarget } from "@/lib/bindings/BoardTarget";
+
+/**
+ * The default board-target identifier applied when a Flow has no stored
+ * selection (or stores an id that is no longer supported). Mirrors the backend
+ * default in `runtime::commands::default_board_target` so the editor shows the
+ * same target the generator would fall back to.
+ */
+export const DEFAULT_TARGET_ID = "uno";
+
+/**
+ * Resolve which board-target identifier is selected for a Flow, given the
+ * supported targets and the id stored on the Flow's metadata.
+ *
+ * - When the stored id matches a supported target, that id wins.
+ * - When the Flow has no stored selection, or the stored id is no longer
+ *   supported, fall back to the default target (`uno`) when present, otherwise
+ *   the first supported target. This keeps the editor working even if a Flow
+ *   references a target that has since been removed.
+ * - Returns `undefined` only when no targets are supported at all.
+ */
+export function resolveSelectedTargetId(
+  targets: BoardTarget[],
+  storedId: string | undefined,
+): string | undefined {
+  if (targets.length === 0) return undefined;
+  if (storedId !== undefined && targets.some((t) => t.id === storedId)) {
+    return storedId;
+  }
+  const fallback = targets.find((t) => t.id === DEFAULT_TARGET_ID) ?? targets[0];
+  return fallback.id;
+}
+
+/** Options projected for a labelled, keyboard-navigable selector. */
+export type TargetOption = { id: string; name: string };
+
+/** Project supported targets into labelled options for the picker control. */
+export function toTargetOptions(targets: BoardTarget[]): TargetOption[] {
+  return targets.map((t) => ({ id: t.id, name: t.name }));
+}

--- a/apps/web/src/components/flow/board-target-picker.tsx
+++ b/apps/web/src/components/flow/board-target-picker.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useMemo, useState } from "react";
+import type { BoardTarget } from "@/lib/bindings/BoardTarget";
+import { listBoardTargets } from "@/lib/ipc";
+import { useFlowSession, useFlowMeta } from "@/session";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { resolveSelectedTargetId, toTargetOptions } from "./board-target-picker.model";
+
+/**
+ * Load the supported board targets once. Returns an empty list until the
+ * backend responds (and off-desktop), so the picker renders nothing selectable
+ * rather than crashing.
+ */
+function useBoardTargets(): BoardTarget[] {
+  const [targets, setTargets] = useState<BoardTarget[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    void listBoardTargets().then((t) => {
+      if (!cancelled) setTargets(t);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return targets;
+}
+
+/**
+ * Board-target picker for the editor. Lists the supported targets, shows the
+ * Flow's selected target (defaulting when none is stored or the stored id is no
+ * longer supported), and on change writes the chosen id to the Flow's metadata.
+ *
+ * Persisting via `doc.setMeta` records the selection on the Flow document so it
+ * travels through the existing sync/persistence path and is restored on
+ * re-open. The same write raises the Flow's meta-change notification — the
+ * `BoardTargetSelected` signal — which the sketch view reacts to by
+ * re-generating against the new board.
+ */
+export function BoardTargetPicker() {
+  const { doc, readOnly } = useFlowSession();
+  const meta = useFlowMeta(doc);
+  const targets = useBoardTargets();
+
+  const options = useMemo(() => toTargetOptions(targets), [targets]);
+  const selectedId = resolveSelectedTargetId(targets, meta.selectedTargetId);
+
+  // Once targets are known, persist the resolved default so the Flow carries an
+  // explicit selection going forward (and dependent behavior sees a concrete id).
+  useEffect(() => {
+    if (readOnly) return;
+    if (selectedId === undefined) return;
+    if (meta.selectedTargetId === selectedId) return;
+    doc.setMeta({ selectedTargetId: selectedId });
+  }, [doc, readOnly, selectedId, meta.selectedTargetId]);
+
+  if (options.length === 0) return null;
+
+  const handleChange = (id: string | null) => {
+    if (readOnly || id === null) return;
+    doc.setMeta({ selectedTargetId: id });
+  };
+
+  return (
+    <Select value={selectedId} onValueChange={handleChange} disabled={readOnly}>
+      <SelectTrigger aria-label="Board target" className="h-9 w-44">
+        <SelectValue placeholder="Select board" />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem key={option.id} value={option.id}>
+            {option.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/web/src/components/flow/react-flow-canvas.tsx
+++ b/apps/web/src/components/flow/react-flow-canvas.tsx
@@ -31,6 +31,7 @@ import { HotkeySheet } from "./sheets/hotkey-sheet";
 import { CollabCursors } from "./collab-cursors";
 import { PressensePanel } from "./panels/pressense-panel";
 import { SketchCodeView } from "./sketch-code-view";
+import { BoardTargetPicker } from "./board-target-picker";
 import { useSketchCodeViewStore } from "@/stores/sketch-code-view";
 
 const uid = () => Math.random().toString(36).substring(2, 9);
@@ -99,7 +100,8 @@ export function ReactFlowCanvas() {
         <Background gap={260} size={2} />
         <NewNodeDialog />
         <HotkeySheet />
-        <Panel position="top-right">
+        <Panel position="top-right" className="flex items-center gap-2">
+          <BoardTargetPicker />
           <SettingsPanel />
         </Panel>
         <Panel position="bottom-center">

--- a/apps/web/src/components/flow/sketch-code-view.tsx
+++ b/apps/web/src/components/flow/sketch-code-view.tsx
@@ -4,7 +4,7 @@ import * as monaco from "monaco-editor";
 import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { useTheme } from "@/providers/theme-provider";
-import { useFlowSession, useFlowNodes, useFlowEdges } from "@/session";
+import { useFlowSession, useFlowNodes, useFlowEdges, useFlowMeta } from "@/session";
 import { invokeCommand } from "@/lib/ipc";
 import {
   createDebouncedRegenerator,
@@ -38,6 +38,9 @@ export function SketchCodeView({ onClose }: { onClose: () => void }) {
   const { doc } = useFlowSession();
   const nodes = useFlowNodes(doc);
   const edges = useFlowEdges(doc);
+  // The Flow's selected board target. Threaded into every generate request so
+  // the Sketch targets the chosen board; changing it re-generates (Task #29/#43).
+  const { selectedTargetId } = useFlowMeta(doc);
   const [value, setValue] = useState("// Generating sketch…");
 
   type GenNode = Parameters<typeof projectSketchResult>[1][number];
@@ -49,7 +52,7 @@ export function SketchCodeView({ onClose }: { onClose: () => void }) {
   // does not trigger a redundant regeneration.
   useEffect(() => {
     let cancelled = false;
-    void projectSketchResult(invoke, genNodes, genEdges).then((state) => {
+    void projectSketchResult(invoke, genNodes, genEdges, selectedTargetId).then((state) => {
       if (!cancelled) setValue(state.value);
     });
     return () => {
@@ -65,7 +68,7 @@ export function SketchCodeView({ onClose }: { onClose: () => void }) {
     regeneratorRef.current = createDebouncedRegenerator({
       invoker: invoke,
       onResult: (state) => setValue(state.value),
-      seedSerialized: serializeFlowGraph(genNodes, genEdges),
+      seedSerialized: serializeFlowGraph(genNodes, genEdges, selectedTargetId),
     });
   }
 
@@ -75,8 +78,8 @@ export function SketchCodeView({ onClose }: { onClose: () => void }) {
   }, []);
 
   useEffect(() => {
-    regeneratorRef.current?.schedule(genNodes, genEdges);
-  }, [genNodes, genEdges]);
+    regeneratorRef.current?.schedule(genNodes, genEdges, selectedTargetId);
+  }, [genNodes, genEdges, selectedTargetId]);
 
   return (
     <Dialog defaultOpen onOpenChange={onClose}>

--- a/apps/web/src/lib/ipc.ts
+++ b/apps/web/src/lib/ipc.ts
@@ -8,6 +8,7 @@ import { useEffect } from "react";
 // ./bindings/ during `cargo test`. Always import event-payload types from
 // there so the Rust struct stays the single source of truth.
 import type { BoardState } from "./bindings/BoardState";
+import type { BoardTarget } from "./bindings/BoardTarget";
 import type { BrokerStatus } from "./bindings/BrokerStatus";
 import type { ComponentEvent } from "./bindings/ComponentEvent";
 import type { ConnectionStatus } from "./bindings/ConnectionStatus";
@@ -165,6 +166,20 @@ export async function invokeCommand<
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     return { success: false, error: errorMessage };
+  }
+}
+
+// Sketch Generation context: list the board targets the Author can generate a
+// Sketch for. Backed by `runtime::commands::list_board_targets`, which mirrors
+// the `supported_targets()` registry generation consults. Returns an empty list
+// off-desktop so the editor degrades gracefully (no picker options).
+export async function listBoardTargets(): Promise<BoardTarget[]> {
+  if (!isDesktop()) return [];
+  try {
+    return await invoke<BoardTarget[]>("list_board_targets");
+  } catch (error) {
+    console.error("[listBoardTargets]", error);
+    return [];
   }
 }
 

--- a/packages/collab/src/__tests__/flow-meta-target.test.ts
+++ b/packages/collab/src/__tests__/flow-meta-target.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import * as Y from "yjs";
+import { FlowDocument } from "../schema";
+
+// Task #29: the selected board target is persisted as Flow metadata so it
+// travels with the Flow through the existing sync/persistence path and is
+// restored when the Author re-opens the Flow in a later session.
+describe("FlowMeta selectedTargetId", () => {
+  test("is undefined on a Flow that has never had a target selected", () => {
+    const doc = FlowDocument.createEmpty();
+    expect(doc.getMeta().selectedTargetId).toBeUndefined();
+  });
+
+  test("setMeta records the selected target and getMeta reads it back", () => {
+    const doc = FlowDocument.createEmpty();
+    doc.setMeta({ selectedTargetId: "esp32" });
+    expect(doc.getMeta().selectedTargetId).toBe("esp32");
+  });
+
+  // Scenario: Selected board target persists across sessions. Encoding the doc
+  // and reloading it in a fresh document mirrors save → re-open.
+  test("persists across an encode/decode round-trip (re-open in a later session)", () => {
+    const doc = FlowDocument.createEmpty();
+    doc.setMeta({ selectedTargetId: "nano" });
+    const update = Y.encodeStateAsUpdate(doc.doc);
+
+    const reopened = new FlowDocument(new Y.Doc());
+    Y.applyUpdate(reopened.doc, update);
+
+    expect(reopened.getMeta().selectedTargetId).toBe("nano");
+  });
+
+  test("onMetaChange fires when the selected target changes (BoardTargetSelected)", () => {
+    const doc = FlowDocument.createEmpty();
+    let fired = 0;
+    const off = doc.onMetaChange(() => {
+      fired += 1;
+    });
+    doc.setMeta({ selectedTargetId: "uno" });
+    off();
+    expect(fired).toBeGreaterThan(0);
+  });
+});

--- a/packages/collab/src/schema.ts
+++ b/packages/collab/src/schema.ts
@@ -9,6 +9,13 @@ export type FlowMeta = {
   description?: string;
   version: number;
   updatedAt: number;
+  /**
+   * The board target this Flow generates a Sketch for, stored as the stable
+   * board-target identifier (e.g. `uno`, `nano`, `esp32`) defined by the
+   * board-target abstraction. Undefined when the Author has never made a
+   * selection, in which case consumers apply a default target.
+   */
+  selectedTargetId?: string;
 };
 
 export type FlowNode = {
@@ -194,6 +201,7 @@ export class FlowDocument {
       description: this.meta.get("description") as string | undefined,
       version: (this.meta.get("version") as number) ?? 1,
       updatedAt: (this.meta.get("updatedAt") as number) ?? Date.now(),
+      selectedTargetId: this.meta.get("selectedTargetId") as string | undefined,
     };
   }
 


### PR DESCRIPTION
## Summary

A Flow Author needs to declare which board they generate a Sketch for, and that choice must stick. This task adds an editor control to pick a board target from the supported list, records the selection on the Flow document so it persists across sessions, and threads the chosen `targetId` into sketch generation (which already accepts it from #43). This is the last task of Feature #26 (Choose a board target for sketch generation).

## Changes

- **Persist the selection on the Flow**: extend `FlowMeta` with `selectedTargetId` and surface it through `FlowDocument.getMeta()`. The selection rides the existing Yjs sync/persistence path (local + cloud), so it is restored on re-open with no migration.
- **Expose the supported list**: add a `list_board_targets` Tauri command returning `supported_targets()` (one source of truth shared with generation) and a `listBoardTargets()` IPC helper that degrades to an empty list off-desktop.
- **Picker control**: a keyboard-navigable, labelled `BoardTargetPicker` in the editor chrome that shows the Flow's selected target — defaulting to `uno` when none is stored or the stored id is no longer supported — and on change writes the id via `setMeta`. That write raises the Flow's meta-change notification (the `BoardTargetSelected` signal) that dependent behavior reacts to.
- **Thread into generation**: the sketch view reads `selectedTargetId` from Flow meta and passes it into every generate request, so switching the board re-generates.

## Test plan

- [x] Author selects a board target — selection recorded on the Flow and meta-change (BoardTargetSelected) raised
- [x] Selected board target persists across sessions — survives a Yjs encode/decode round-trip
- [x] A Flow with no prior selection shows a default — and an unsupported stored id falls back to the default rather than breaking the editor

## Related

Closes #29
