### PR TITLE
feat(codegen): emit the full Node catalogue to Arduino C++

### DIFF
--- a/apps/web/src-tauri/src/codegen/control/constant.rs
+++ b/apps/web/src-tauri/src/codegen/control/constant.rs
@@ -1,0 +1,72 @@
+//! Constant emitter — mirrors `runtime/generator/constant.rs`.
+//!
+//! The live Constant Node holds a single fixed `value` (default `1337.0`) and
+//! never changes it. Per the Task's Technical Approach, Constant emits a single
+//! compile-time `double` initialised to that value rather than any per-loop
+//! work — there is no timing or state to update. Downstream Nodes read the
+//! output variable directly.
+
+use crate::codegen::emit::{cpp_double, f64_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `double` variable holding this Constant Node's fixed value.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("constant_{}_value", node.id_token())
+}
+
+/// Emit C++ for a Constant Node. The value is fixed at declaration time, so the
+/// emitter contributes only a declaration — no `setup()` or `loop()` work. The
+/// `driver` is unused: a Constant ignores its inputs, exactly as the runtime's
+/// `dispatch` rejects every method.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let var = value_var(node);
+    let value = cpp_double(f64_or_default(node, "value", 1337.0));
+
+    NodeEmission {
+        declarations: vec![format!("double {var} = {value};")],
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn constant(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Constant".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn emits_configured_value() {
+        let e = emit(&constant("c-1", json!({ "value": 42.0 })));
+        assert!(e.declarations.iter().any(|d| d.contains("constant_c_1_value = 42.0")));
+    }
+
+    #[test]
+    fn defaults_to_live_runtime_value() {
+        let e = emit(&constant("c-1", json!({})));
+        assert!(e.declarations.iter().any(|d| d.contains("= 1337.0")));
+    }
+
+    #[test]
+    fn does_no_per_loop_work() {
+        let e = emit(&constant("c-1", json!({ "value": 1.0 })));
+        assert!(e.loop_body.is_empty(), "constant must not emit per-loop work");
+        assert!(e.setup.is_empty());
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = constant("c-1", json!({ "value": 7.5 }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/control/counter.rs
+++ b/apps/web/src-tauri/src/codegen/control/counter.rs
@@ -1,0 +1,94 @@
+//! Counter emitter — mirrors `runtime/control/counter.rs`.
+//!
+//! The live Counter starts at `0.0` and increments by one each time its
+//! `increment` port receives a signal. In the generated single-driver value
+//! model a Counter has one wired input that pulses it; the Sketch increments the
+//! running count on the *rising edge* of that driver (a transition from falsey
+//! to truthy), matching one signal == one increment. The count is a module-level
+//! `double` so it persists across `loop()` iterations exactly as the runtime's
+//! `ComponentBase` value persists across signals — the on-device count never
+//! resets between iterations.
+
+use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `double` variable holding this Counter Node's running count. Exposed
+/// as the Node's readable value for downstream Nodes.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("counter_{}_count", node.id_token())
+}
+
+/// Emit C++ for a Counter Node. `driver` is the wired pulse input, or `None`
+/// when nothing is connected (the runtime never increments without a signal).
+///
+/// The count and a `_prev` edge-tracking flag are module-level so they persist
+/// across loop iterations; the increment only fires on a rising edge so a driver
+/// that stays truthy counts once, mirroring discrete signals.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let var = value_var(node);
+    let prev = format!("counter_{token}_prev");
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("double {var} = 0.0;")],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        // Track the previous truthiness so a sustained-high driver counts once.
+        e.declarations.push(format!("bool {prev} = false;"));
+        e.loop_body.push(format!("bool counter_{token}_now = (bool)({expr});"));
+        e.loop_body
+            .push(format!("if (counter_{token}_now && !{prev}) {{ {var} += 1.0; }}"));
+        e.loop_body.push(format!("{prev} = counter_{token}_now;"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn counter(id: &str) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Counter".to_string()),
+            data: json!({}),
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn count_starts_at_zero_and_persists() {
+        let e = emit(&counter("ct-1"), Some("v"));
+        // Module-level declaration => persists across loop iterations.
+        assert!(e.declarations.iter().any(|d| d.contains("double counter_ct_1_count = 0.0")));
+    }
+
+    #[test]
+    fn increments_on_rising_edge_only() {
+        let e = emit(&counter("ct-1"), Some("v"));
+        assert!(e.loop_body.iter().any(|l| l.contains("+= 1.0")), "must increment");
+        assert!(
+            e.loop_body.iter().any(|l| l.contains("&& !counter_ct_1_prev")),
+            "increment must be guarded by a rising edge"
+        );
+    }
+
+    #[test]
+    fn no_driver_keeps_count_static() {
+        let e = emit(&counter("ct-1"), None);
+        assert!(e.loop_body.is_empty(), "no input => no increment");
+        assert!(e.declarations.iter().any(|d| d.contains("= 0.0")));
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = counter("ct-1");
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/control/delay.rs
+++ b/apps/web/src-tauri/src/codegen/control/delay.rs
@@ -1,0 +1,118 @@
+//! Delay emitter — mirrors `runtime/control/delay.rs`.
+//!
+//! The live Delay stores an incoming signal and re-emits it `delay` ms later
+//! (default `1000`) via a spawned thread that sleeps. On device the wait must be
+//! non-blocking, so the generated Sketch captures the input value and a
+//! deadline timestamp in module-level state, then fires when
+//! `millis() - armed_at >= delay`. The loop never blocks while the Delay is
+//! pending — the rest of the Flow keeps running — and the unsigned elapsed-time
+//! subtraction survives `millis()` rollover.
+//!
+//! Arming is edge-triggered (a rising edge on the driver) so a single signal
+//! schedules a single fire, matching one `trigger` call == one delayed emit.
+//! `forgetPrevious` is reproduced by re-arming on each new edge (the latest edge
+//! wins), which is the same observable result as the runtime cancelling the
+//! prior thread.
+
+use crate::codegen::emit::{u64_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `double` variable holding this Delay Node's most recently emitted
+/// (delayed) value, read by downstream Nodes.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("delay_{}_value", node.id_token())
+}
+
+/// Emit C++ for a Delay Node. `driver` is the wired input to be delayed, or
+/// `None` when nothing is connected (the runtime never arms without a signal).
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let var = value_var(node);
+    let pending = format!("delay_{token}_pending");
+    let armed = format!("delay_{token}_armed_at");
+    let stored = format!("delay_{token}_stored");
+    let prev = format!("delay_{token}_prev");
+    let delay_ms = u64_or_default(node, "delay", 1000);
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("double {var} = 0.0;")],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        e.declarations.push(format!("bool {pending} = false;"));
+        e.declarations.push(format!("unsigned long {armed} = 0;"));
+        e.declarations.push(format!("double {stored} = 0.0;"));
+        e.declarations.push(format!("bool {prev} = false;"));
+
+        // Arm on a rising edge: capture the value and the deadline start.
+        e.loop_body.push(format!("bool delay_{token}_now = (bool)({expr});"));
+        e.loop_body.push(format!("if (delay_{token}_now && !{prev}) {{"));
+        e.loop_body.push(format!("  {stored} = (double)({expr});"));
+        e.loop_body.push(format!("  {armed} = millis();"));
+        e.loop_body.push(format!("  {pending} = true;"));
+        e.loop_body.push("}".to_string());
+        e.loop_body.push(format!("{prev} = delay_{token}_now;"));
+        // Fire once the delay has elapsed — non-blocking elapsed-time compare.
+        e.loop_body
+            .push(format!("if ({pending} && millis() - {armed} >= {delay_ms}UL) {{"));
+        e.loop_body.push(format!("  {var} = {stored};"));
+        e.loop_body.push(format!("  {pending} = false;"));
+        e.loop_body.push("}".to_string());
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn delay(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Delay".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn fires_after_configured_delay_without_blocking() {
+        let e = emit(&delay("d-1", json!({ "delay": 750 })), Some("v"));
+        assert!(
+            e.loop_body.iter().any(|l| l.contains("millis() - delay_d_1_armed_at >= 750UL")),
+            "delay must fire on an elapsed-time comparison"
+        );
+        assert!(!e.loop_body.iter().any(|l| l.contains("delay(")), "must not block");
+    }
+
+    #[test]
+    fn defaults_to_one_second() {
+        let e = emit(&delay("d-1", json!({})), Some("v"));
+        assert!(e.loop_body.iter().any(|l| l.contains(">= 1000UL")));
+    }
+
+    #[test]
+    fn state_persists_across_iterations() {
+        let e = emit(&delay("d-1", json!({})), Some("v"));
+        assert!(e.declarations.iter().any(|d| d.contains("bool delay_d_1_pending")));
+        assert!(e.declarations.iter().any(|d| d.contains("unsigned long delay_d_1_armed_at")));
+    }
+
+    #[test]
+    fn no_driver_emits_no_timing() {
+        let e = emit(&delay("d-1", json!({})), None);
+        assert!(e.loop_body.is_empty());
+        assert!(e.declarations.iter().any(|d| d.contains("delay_d_1_value = 0.0")));
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = delay("d-1", json!({ "delay": 200 }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/control/interval.rs
+++ b/apps/web/src-tauri/src/codegen/control/interval.rs
@@ -1,0 +1,112 @@
+//! Interval emitter — mirrors `runtime/generator/interval.rs`.
+//!
+//! The live Interval spawns a thread that sleeps `interval` ms (clamped to a
+//! `MIN_INTERVAL_MS` of 16) and emits the elapsed milliseconds on every tick. On
+//! device there is no thread to sleep, so the generated Sketch keeps the timer's
+//! last-fire timestamp in a module-level `unsigned long` and, each `loop()`
+//! iteration, fires when `millis() - previous >= interval`. This is fully
+//! non-blocking: the loop never waits, multiple Intervals tick concurrently, and
+//! the unsigned subtraction survives `millis()` rollover (~49 days) without
+//! stalling. The output `double` holds the elapsed time since `setup()`, mirror‑
+//! ing the runtime's `start.elapsed()` value, so downstream Nodes see the same
+//! signal they do in live mode.
+
+use crate::codegen::emit::{u64_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Runtime clamps the interval to at least this many milliseconds.
+const MIN_INTERVAL_MS: u64 = 16;
+
+/// The C++ `double` variable holding this Interval Node's latest elapsed-time
+/// output (milliseconds since `setup()`), updated on each fire.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("interval_{}_value", node.id_token())
+}
+
+/// Emit C++ for an Interval Node. The Interval is self-driving (it is a
+/// generator), so it ignores any `driver`; it ticks purely off the loop
+/// scheduler's `millis()` clock.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let token = node.id_token();
+    let var = value_var(node);
+    let previous = format!("interval_{token}_previous");
+    let start = format!("interval_{token}_start");
+    let interval_ms = u64_or_default(node, "interval", 1000).max(MIN_INTERVAL_MS);
+
+    NodeEmission {
+        declarations: vec![
+            format!("unsigned long {previous} = 0;"),
+            format!("unsigned long {start} = 0;"),
+            format!("double {var} = 0.0;"),
+        ],
+        // Seed both timestamps so the first tick is measured from boot, not 0.
+        setup: vec![format!("{previous} = millis();"), format!("{start} = millis();")],
+        loop_body: vec![
+            // Non-blocking: compare elapsed time, never block the loop.
+            format!("if (millis() - {previous} >= {interval_ms}UL) {{"),
+            format!("  {previous} += {interval_ms}UL;"),
+            format!("  {var} = (double)(millis() - {start});"),
+            "}".to_string(),
+        ],
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn interval(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Interval".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn fires_on_millis_comparison_without_blocking() {
+        let e = emit(&interval("iv-1", json!({ "interval": 500 })));
+        assert!(
+            e.loop_body.iter().any(|l| l.contains("millis() - interval_iv_1_previous >= 500UL")),
+            "must compare elapsed millis against the configured interval"
+        );
+        assert!(
+            !e.loop_body.iter().any(|l| l.contains("delay(")),
+            "interval must never block"
+        );
+    }
+
+    #[test]
+    fn clamps_to_min_interval() {
+        let e = emit(&interval("iv-1", json!({ "interval": 1 })));
+        assert!(
+            e.loop_body.iter().any(|l| l.contains(">= 16UL")),
+            "interval below the runtime minimum must clamp to 16ms"
+        );
+    }
+
+    #[test]
+    fn defaults_to_one_second() {
+        let e = emit(&interval("iv-1", json!({})));
+        assert!(e.loop_body.iter().any(|l| l.contains(">= 1000UL")));
+    }
+
+    #[test]
+    fn keeps_timestamps_across_iterations() {
+        let e = emit(&interval("iv-1", json!({})));
+        assert!(e.declarations.iter().any(|d| d.contains("unsigned long interval_iv_1_previous")));
+        assert!(e.setup.iter().any(|s| s.contains("= millis()")), "timer seeded in setup");
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = interval("iv-1", json!({ "interval": 250 }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/control/mod.rs
+++ b/apps/web/src-tauri/src/codegen/control/mod.rs
@@ -1,0 +1,31 @@
+//! Control-Node C++ emitters (Delay, Interval, Trigger, Counter, Constant) —
+//! the codegen mirror of `runtime/control` and `runtime/generator/constant`.
+//!
+//! On-device there is no host event loop, so the live runtime's thread-and-sleep
+//! timing model (`std::thread::spawn` + `sleep` in `runtime/control/delay.rs` and
+//! `runtime/generator/interval.rs`) cannot be reproduced verbatim — a blocking
+//! `delay()` would freeze the whole Sketch. Instead every timing Node compares
+//! `millis()` against a stored next-fire timestamp and yields control each loop
+//! iteration, so multiple timers tick concurrently without one stalling the
+//! others. Stateful Nodes (Counter count, Delay/Interval timestamps) keep their
+//! state in module-level variables that persist across `loop()` iterations.
+//!
+//! Like the input/output and transformation emitters, every emitter is a pure
+//! function of a single [`crate::runtime::types::FlowNode`] (plus its driver)
+//! and reads the same `data` the live runtime deserializes into its `*Config`.
+//! The emitted C++ reproduces the runtime semantics so that, for identical
+//! inputs, the generated Sketch yields the same output the Flow Author sees in
+//! live mode.
+//!
+//! ## Non-blocking timer invariant
+//!
+//! No emitter in this module ever emits a blocking `delay()`. Timing is always
+//! expressed as `millis() - previous >= interval` so the scheduler in
+//! [`crate::codegen`] completes every iteration without waiting, and `millis()`
+//! rollover (~49 days) is handled by the unsigned elapsed-time subtraction.
+
+pub mod constant;
+pub mod counter;
+pub mod delay;
+pub mod interval;
+pub mod trigger;

--- a/apps/web/src-tauri/src/codegen/control/trigger.rs
+++ b/apps/web/src-tauri/src/codegen/control/trigger.rs
@@ -1,0 +1,129 @@
+//! Trigger emitter — mirrors `runtime/control/trigger.rs`.
+//!
+//! The live Trigger watches a numeric signal and emits a boolean "bang" when the
+//! value moves past `threshold` in the configured direction (`increasing` /
+//! `decreasing`) within a recent window. It keeps a baseline from which the
+//! difference is measured. The generated Sketch reproduces this with a
+//! module-level baseline `double` and a boolean output: each loop iteration it
+//! compares the current driver value against the baseline and sets the output
+//! when the threshold is crossed in the correct direction. `relative` switches
+//! the comparison to a percentage of the baseline, matching the runtime. State
+//! persists across iterations so the baseline survives, and the output `bool` is
+//! read by downstream Nodes.
+
+use crate::codegen::emit::{bool_flag, cpp_double, f64_or_default, str_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `bool` variable holding this Trigger Node's latest bang state.
+#[must_use]
+pub fn state_var(node: &FlowNode) -> String {
+    format!("trigger_{}_result", node.id_token())
+}
+
+/// Emit C++ for a Trigger Node. `driver` is the wired numeric input, or `None`
+/// when nothing is connected (the runtime never bangs without a signal).
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let var = state_var(node);
+    let baseline = format!("trigger_{token}_baseline");
+    let seeded = format!("trigger_{token}_seeded");
+    let threshold = cpp_double(f64_or_default(node, "threshold", 5.0));
+    let behaviour = str_or_default(node, "behaviour", "decreasing");
+    let relative = bool_flag(node, "relative");
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("bool {var} = false;")],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        e.declarations.push(format!("double {baseline} = 0.0;"));
+        e.declarations.push(format!("bool {seeded} = false;"));
+
+        e.loop_body.push(format!("double trigger_{token}_now = (double)({expr});"));
+        // Seed the baseline from the first reading, like the runtime's first sample.
+        e.loop_body
+            .push(format!("if (!{seeded}) {{ {baseline} = trigger_{token}_now; {seeded} = true; }}"));
+        e.loop_body
+            .push(format!("double trigger_{token}_diff = trigger_{token}_now - {baseline};"));
+
+        // Direction check mirrors `value_changes_in_correct_direction`.
+        let direction = if behaviour == "increasing" {
+            format!("trigger_{token}_diff > 0.0")
+        } else {
+            format!("trigger_{token}_diff <= 0.0")
+        };
+        // Magnitude check mirrors relative vs absolute threshold.
+        let magnitude = if relative {
+            format!("(fabs(trigger_{token}_diff / {baseline}) * 100.0) >= {threshold}")
+        } else {
+            format!("fabs(trigger_{token}_diff) >= {threshold}")
+        };
+        e.loop_body
+            .push(format!("{var} = ({direction}) && ({magnitude});"));
+        // Track the latest value as the new baseline for the next comparison.
+        e.loop_body.push(format!("{baseline} = trigger_{token}_now;"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn trigger(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Trigger".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn bangs_on_absolute_threshold() {
+        let e = emit(&trigger("tg-1", json!({ "threshold": 10.0 })), Some("v"));
+        assert!(e.declarations.iter().any(|d| d.contains("bool trigger_tg_1_result")));
+        assert!(
+            e.loop_body.iter().any(|l| l.contains(">= 10.0")),
+            "must compare against the configured threshold"
+        );
+    }
+
+    #[test]
+    fn decreasing_is_the_default_direction() {
+        let e = emit(&trigger("tg-1", json!({})), Some("v"));
+        assert!(
+            e.loop_body.iter().any(|l| l.contains("diff <= 0.0")),
+            "default behaviour is decreasing"
+        );
+    }
+
+    #[test]
+    fn increasing_flips_the_direction() {
+        let e = emit(&trigger("tg-1", json!({ "behaviour": "increasing" })), Some("v"));
+        assert!(e.loop_body.iter().any(|l| l.contains("diff > 0.0")));
+    }
+
+    #[test]
+    fn relative_uses_percentage() {
+        let e = emit(&trigger("tg-1", json!({ "relative": true, "threshold": 20.0 })), Some("v"));
+        assert!(e.loop_body.iter().any(|l| l.contains("* 100.0")), "relative => percent compare");
+    }
+
+    #[test]
+    fn no_driver_leaves_false() {
+        let e = emit(&trigger("tg-1", json!({})), None);
+        assert!(e.loop_body.is_empty());
+        assert!(e.declarations.iter().any(|d| d.contains("= false;")));
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = trigger("tg-1", json!({ "threshold": 3.0, "behaviour": "increasing" }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/emit.rs
+++ b/apps/web/src-tauri/src/codegen/emit.rs
@@ -92,6 +92,46 @@ pub fn u16_or_default(node: &FlowNode, key: &str, default: u16) -> u16 {
         .unwrap_or(default)
 }
 
+/// Read an `f64` from a Node's `data`, falling back to `default`. Accepts a
+/// JSON number or a numeric string, mirroring the runtime's lenient config
+/// deserialization.
+#[must_use]
+pub fn f64_or_default(node: &FlowNode, key: &str, default: f64) -> f64 {
+    let Some(value) = node.data.get(key) else {
+        return default;
+    };
+    if let Some(n) = value.as_f64() {
+        return n;
+    }
+    if let Some(s) = value.as_str() {
+        return s.parse().unwrap_or(default);
+    }
+    default
+}
+
+/// Read a string from a Node's `data`, falling back to `default`.
+#[must_use]
+pub fn str_or_default(node: &FlowNode, key: &str, default: &str) -> String {
+    node.data
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or(default)
+        .to_string()
+}
+
+/// Format an `f64` as a C++ `double` literal that round-trips deterministically.
+/// Integer-valued numbers gain a trailing `.0` so the literal is unambiguously
+/// floating point.
+#[must_use]
+pub fn cpp_double(value: f64) -> String {
+    if value.is_finite() && value.fract() == 0.0 && value.abs() < 1e15 {
+        format!("{value:.1}")
+    } else {
+        // `{}` on f64 yields the shortest round-tripping representation.
+        format!("{value}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,5 +179,27 @@ mod tests {
     #[test]
     fn empty_emission_is_empty() {
         assert!(NodeEmission::default().is_empty());
+    }
+
+    #[test]
+    fn f64_reads_number_string_and_default() {
+        assert!((f64_or_default(&node_with(json!({ "n": 2.5 })), "n", 0.0) - 2.5).abs() < f64::EPSILON);
+        assert!((f64_or_default(&node_with(json!({ "n": "3.5" })), "n", 0.0) - 3.5).abs() < f64::EPSILON);
+        assert!((f64_or_default(&node_with(json!({})), "n", 9.0) - 9.0).abs() < f64::EPSILON);
+        assert!((f64_or_default(&node_with(json!({ "n": "xyz" })), "n", 1.0) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn str_reads_value_and_default() {
+        assert_eq!(str_or_default(&node_with(json!({ "s": "hi" })), "s", "x"), "hi");
+        assert_eq!(str_or_default(&node_with(json!({})), "s", "fallback"), "fallback");
+    }
+
+    #[test]
+    fn cpp_double_formats_integers_and_fractions() {
+        assert_eq!(cpp_double(5.0), "5.0");
+        assert_eq!(cpp_double(0.0), "0.0");
+        assert_eq!(cpp_double(-3.0), "-3.0");
+        assert_eq!(cpp_double(2.5), "2.5");
     }
 }

--- a/apps/web/src-tauri/src/codegen/emit.rs
+++ b/apps/web/src-tauri/src/codegen/emit.rs
@@ -92,6 +92,16 @@ pub fn u16_or_default(node: &FlowNode, key: &str, default: u16) -> u16 {
         .unwrap_or(default)
 }
 
+/// Read a `u64` from a Node's `data`, falling back to `default`. Used for
+/// millisecond durations (Delay/Interval) which the runtime stores as `u64`.
+#[must_use]
+pub fn u64_or_default(node: &FlowNode, key: &str, default: u64) -> u64 {
+    node.data
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(default)
+}
+
 /// Read an `f64` from a Node's `data`, falling back to `default`. Accepts a
 /// JSON number or a numeric string, mirroring the runtime's lenient config
 /// deserialization.

--- a/apps/web/src-tauri/src/codegen/generator/mod.rs
+++ b/apps/web/src-tauri/src/codegen/generator/mod.rs
@@ -1,0 +1,4 @@
+//! Generator-Node C++ emitters (Oscillator) — the codegen mirror of
+//! `runtime/generator`.
+
+pub mod oscillator;

--- a/apps/web/src-tauri/src/codegen/generator/oscillator.rs
+++ b/apps/web/src-tauri/src/codegen/generator/oscillator.rs
@@ -1,0 +1,158 @@
+//! Oscillator emitter — mirrors `runtime/generator/oscillator.rs`.
+//!
+//! The live Oscillator runs a thread that samples a waveform against the elapsed
+//! time since start and emits the value. On device there is no thread; the
+//! generated sketch instead samples the same waveform against `millis()` since
+//! `setup()` on every loop iteration, writing the result into a module-level
+//! `double`. The waveform math (sine, square, sawtooth, triangle, random) is the
+//! exact port of the runtime's `calculate_waveform`, so the on-device signal
+//! matches live mode. It is self-driving and fully non-blocking — it only reads
+//! the scheduler's clock, never waits.
+
+use crate::codegen::emit::{cpp_double, f64_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default period matches `runtime/generator/oscillator.rs::default_period` (1000ms).
+const DEFAULT_PERIOD: f64 = 1000.0;
+/// Default amplitude matches `runtime/generator/oscillator.rs::default_amplitude` (1.0).
+const DEFAULT_AMPLITUDE: f64 = 1.0;
+
+/// The C++ `double` variable holding this Oscillator's current output sample.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("oscillator_{}_value", node.id_token())
+}
+
+/// The configured waveform, lowercased to match the runtime's `rename_all`.
+fn waveform(node: &FlowNode) -> String {
+    node.data
+        .get("waveform")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("sinus")
+        .to_ascii_lowercase()
+}
+
+/// Emit C++ for an Oscillator Node. The Oscillator is a generator: it ignores
+/// any wired input and ticks purely off the loop scheduler's `millis()` clock.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let token = node.id_token();
+    let value = value_var(node);
+    let start = format!("oscillator_{token}_start");
+    let t = format!("oscillator_{token}_t");
+
+    // Guard against a zero period (division by zero) by clamping to the default.
+    let period_raw = f64_or_default(node, "period", DEFAULT_PERIOD);
+    let period = cpp_double(if period_raw.abs() < f64::EPSILON { DEFAULT_PERIOD } else { period_raw });
+    let amplitude = cpp_double(f64_or_default(node, "amplitude", DEFAULT_AMPLITUDE));
+    let phase = cpp_double(f64_or_default(node, "phase", 0.0));
+    let shift = cpp_double(f64_or_default(node, "shift", 0.0));
+
+    // `t` is the elapsed-millis timestamp plus phase, mirroring the runtime which
+    // adds `config.phase` to `start.elapsed()`. All branches reduce `t` modulo
+    // the period before sampling, exactly as `calculate_waveform` does.
+    let mut loop_body = vec![
+        format!("double {t} = (double)(millis() - {start}) + {phase};"),
+    ];
+    let sample = match waveform(node).as_str() {
+        "square" => {
+            loop_body.push(format!("{t} = fmod({t}, {period});"));
+            loop_body.push(format!("if ({t} < 0.0) {{ {t} += {period}; }}"));
+            format!("{value} = (({t} * 2.0 < {period}) ? {amplitude} : -({amplitude})) + {shift};")
+        }
+        "sawtooth" => {
+            loop_body.push(format!("{t} = fmod({t}, {period});"));
+            loop_body.push(format!("if ({t} < 0.0) {{ {t} += {period}; }}"));
+            format!("{value} = {amplitude} * (-1.0 + {t} * (2.0 / {period})) + {shift};")
+        }
+        "triangle" => {
+            loop_body.push(format!("{t} = fmod(fabs({t}), {period});"));
+            format!(
+                "{value} = (({t} * 2.0 < {period}) ? ({amplitude} * (-1.0 + {t} * (4.0 / {period}))) : ({amplitude} * (3.0 - {t} * (4.0 / {period})))) + {shift};"
+            )
+        }
+        "random" => {
+            // Runtime: (shift + amplitude) * rand in [0,1).
+            format!("{value} = ({shift} + {amplitude}) * ((double)random(0, 10000) / 10000.0);")
+        }
+        // Sinus is the runtime default.
+        _ => format!(
+            "{value} = {amplitude} * sin({t} * (2.0 * PI / {period})) + {shift};"
+        ),
+    };
+    loop_body.push(sample);
+
+    NodeEmission {
+        declarations: vec![
+            format!("unsigned long {start} = 0;"),
+            format!("double {value} = 0.0;"),
+        ],
+        setup: vec![format!("{start} = millis();")],
+        loop_body,
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn oscillator(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Oscillator".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn oscillator_samples_against_millis_non_blocking() {
+        let e = emit(&oscillator("osc-1", json!({ "waveform": "sinus", "period": 1000 })));
+        assert!(e.loop_body.iter().any(|l| l.contains("millis() - oscillator_osc_1_start")));
+        assert!(e.loop_body.iter().any(|l| l.contains("sin(")), "sinus waveform");
+        assert!(!e.loop_body.iter().any(|l| l.contains("delay(")), "must not block");
+    }
+
+    #[test]
+    fn oscillator_square_waveform() {
+        let e = emit(&oscillator("osc-1", json!({ "waveform": "square" })));
+        assert!(e.loop_body.iter().any(|l| l.contains("* 2.0 <")));
+    }
+
+    #[test]
+    fn oscillator_sawtooth_and_triangle() {
+        let saw = emit(&oscillator("osc-1", json!({ "waveform": "sawtooth" })));
+        assert!(saw.loop_body.iter().any(|l| l.contains("2.0 /")));
+        let tri = emit(&oscillator("osc-1", json!({ "waveform": "triangle" })));
+        assert!(tri.loop_body.iter().any(|l| l.contains("4.0 /")));
+    }
+
+    #[test]
+    fn oscillator_random_uses_amplitude_and_shift() {
+        let e = emit(&oscillator("osc-1", json!({ "waveform": "random", "amplitude": 2.0, "shift": 1.0 })));
+        assert!(e.loop_body.iter().any(|l| l.contains("random(")));
+    }
+
+    #[test]
+    fn oscillator_clamps_zero_period() {
+        let e = emit(&oscillator("osc-1", json!({ "period": 0 })));
+        // Falls back to the default period rather than dividing by zero.
+        assert!(e.loop_body.iter().any(|l| l.contains("1000.0")));
+    }
+
+    #[test]
+    fn oscillator_seeds_start_in_setup() {
+        let e = emit(&oscillator("osc-1", json!({})));
+        assert!(e.setup.iter().any(|s| s.contains("= millis()")));
+        assert!(e.declarations.iter().any(|d| d.contains("double oscillator_osc_1_value")));
+    }
+
+    #[test]
+    fn oscillator_emits_deterministically() {
+        let n = oscillator("osc-1", json!({ "waveform": "square", "period": 500 }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/input/hotkey.rs
+++ b/apps/web/src-tauri/src/codegen/input/hotkey.rs
@@ -1,0 +1,79 @@
+//! Hotkey emitter — mirrors `runtime/input/hotkey.rs`.
+//!
+//! The live Hotkey is a software-only Node: it responds to host-keyboard
+//! press/release events routed from the desktop app's `HotkeyManager`. A
+//! standalone Arduino sketch has no host keyboard, so there is no on-device
+//! source for the key event. To keep the Flow's wiring intact, the emitter
+//! declares the Node's `bool` state variable (initialised `false`, matching the
+//! runtime's initial value) so downstream Nodes still compile and read a stable
+//! signal — and records, as a comment, that the trigger is host-only and never
+//! fires on-device.
+
+use crate::codegen::emit::{str_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `bool` variable name holding this Hotkey's pressed state.
+#[must_use]
+pub fn state_var(node: &FlowNode) -> String {
+    format!("hotkey_{}_state", node.id_token())
+}
+
+/// Emit C++ for a Hotkey Node. There is no pin or loop work: the only on-device
+/// artefact is the state variable, held at its initial `false` because no host
+/// keyboard exists on the board.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let state = state_var(node);
+    let accelerator = str_or_default(node, "accelerator", "x");
+
+    NodeEmission {
+        declarations: vec![
+            format!(
+                "// hotkey \"{accelerator}\" is host-only; no on-device keyboard drives it"
+            ),
+            format!("bool {state} = false;"),
+        ],
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn hotkey(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Hotkey".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn hotkey_declares_state_at_false() {
+        let e = emit(&hotkey("hk-1", json!({ "accelerator": "a" })));
+        assert!(e.declarations.iter().any(|d| d.contains("hotkey_hk_1_state = false")));
+    }
+
+    #[test]
+    fn hotkey_notes_host_only_origin() {
+        let e = emit(&hotkey("hk-1", json!({ "accelerator": "a" })));
+        assert!(e.declarations.iter().any(|d| d.contains("host-only")));
+    }
+
+    #[test]
+    fn hotkey_does_no_pin_or_loop_work() {
+        let e = emit(&hotkey("hk-1", json!({})));
+        assert!(e.setup.is_empty(), "hotkey has no pin to configure");
+        assert!(e.loop_body.is_empty(), "hotkey has no on-device source to poll");
+    }
+
+    #[test]
+    fn hotkey_emits_deterministically() {
+        let n = hotkey("hk-1", json!({ "accelerator": "x" }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/input/i2c_device.rs
+++ b/apps/web/src-tauri/src/codegen/input/i2c_device.rs
@@ -1,0 +1,126 @@
+//! `I2cDevice` emitter — mirrors `runtime/input/i2c_device.rs`.
+//!
+//! The live `I2cDevice` configures the I2C bus, writes the register pointer,
+//! reads `read_length` bytes, and decodes them as a big-endian unsigned or
+//! signed integer (or leaves them raw). The generated sketch uses the Arduino
+//! `Wire` library: it `#include <Wire.h>`, calls `Wire.begin()` in `setup()`,
+//! and each loop writes the register, requests the bytes, and folds them into a
+//! `long` value variable big-endian — the same decode the runtime applies for
+//! the unsigned/signed integer formats. Downstream Nodes read that value.
+
+use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default I2C address matches `runtime/input/i2c_device.rs::default_address`.
+const DEFAULT_ADDRESS: u8 = 0x48;
+/// Default read length matches `runtime/input/i2c_device.rs::default_read_length`.
+const DEFAULT_READ_LENGTH: u8 = 2;
+
+/// The C++ `long` variable name holding this device's latest decoded reading.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("i2c_{}_value", node.id_token())
+}
+
+fn u8_field(node: &FlowNode, key: &str, default: u8) -> u8 {
+    node.data
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|n| u8::try_from(n).ok())
+        .unwrap_or(default)
+}
+
+/// True when the configured output format treats the bytes as a signed integer.
+fn is_signed(node: &FlowNode) -> bool {
+    node.data
+        .get("output")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|t| t.eq_ignore_ascii_case("signed_int") || t.eq_ignore_ascii_case("signedint"))
+}
+
+/// Emit C++ for an `I2cDevice` Node.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let token = node.id_token();
+    let value = value_var(node);
+    let addr = u8_field(node, "address", DEFAULT_ADDRESS);
+    let register = u8_field(node, "register", 0);
+    let read_length = u8_field(node, "read_length", DEFAULT_READ_LENGTH).max(1);
+    let signed = is_signed(node);
+
+    let acc = format!("i2c_{token}_acc");
+    let i = format!("i2c_{token}_i");
+    let b = format!("i2c_{token}_b");
+
+    let mut loop_body = vec![
+        format!("Wire.beginTransmission((uint8_t){addr});"),
+        format!("Wire.write((uint8_t){register});"),
+        "Wire.endTransmission(false);".to_string(),
+        format!("Wire.requestFrom((uint8_t){addr}, (uint8_t){read_length});"),
+        format!("long {acc} = 0;"),
+        format!("for (uint8_t {i} = 0; {i} < {read_length} && Wire.available(); {i}++) {{"),
+        format!("  uint8_t {b} = Wire.read();"),
+    ];
+    if signed {
+        // Sign-extend from the most-significant byte, big-endian, like the runtime.
+        loop_body.push(format!("  if ({i} == 0 && ({b} & 0x80)) {{ {acc} = -1; }}"));
+    }
+    loop_body.push(format!("  {acc} = ({acc} << 8) | (long){b};"));
+    loop_body.push("}".to_string());
+    loop_body.push(format!("{value} = {acc};"));
+
+    NodeEmission {
+        includes: vec!["#include <Wire.h>".to_string()],
+        declarations: vec![format!("long {value} = 0;")],
+        setup: vec!["Wire.begin();".to_string()],
+        loop_body,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn i2c(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("I2cDevice".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn i2c_includes_wire_and_begins_bus() {
+        let e = emit(&i2c("d-1", json!({})));
+        assert!(e.includes.iter().any(|i| i.contains("Wire.h")));
+        assert!(e.setup.iter().any(|s| s.contains("Wire.begin()")));
+    }
+
+    #[test]
+    fn i2c_reads_configured_length_and_address() {
+        let e = emit(&i2c("d-1", json!({ "address": 0x40, "read_length": 3 })));
+        assert!(e.loop_body.iter().any(|l| l.contains("requestFrom") && l.contains("64")));
+        assert!(e.loop_body.iter().any(|l| l.contains("< 3 &&")));
+    }
+
+    #[test]
+    fn i2c_sign_extends_for_signed_format() {
+        let e = emit(&i2c("d-1", json!({ "output": "signed_int" })));
+        assert!(e.loop_body.iter().any(|l| l.contains("0x80")), "signed must sign-extend");
+    }
+
+    #[test]
+    fn i2c_unsigned_does_not_sign_extend() {
+        let e = emit(&i2c("d-1", json!({ "output": "unsigned_int" })));
+        assert!(!e.loop_body.iter().any(|l| l.contains("0x80")));
+    }
+
+    #[test]
+    fn i2c_emits_deterministically() {
+        let n = i2c("d-1", json!({ "address": 0x48, "read_length": 2 }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/input/mod.rs
+++ b/apps/web/src-tauri/src/codegen/input/mod.rs
@@ -1,5 +1,10 @@
-//! Input-Node C++ emitters (Button, Sensor) — the codegen mirror of
-//! `runtime/input`.
+//! Input-Node C++ emitters (Button, Sensor, Switch, Motion, Proximity, Hotkey,
+//! `I2cDevice`) — the codegen mirror of `runtime/input`.
 
 pub mod button;
+pub mod hotkey;
+pub mod i2c_device;
+pub mod motion;
+pub mod proximity;
 pub mod sensor;
+pub mod switch;

--- a/apps/web/src-tauri/src/codegen/input/motion.rs
+++ b/apps/web/src-tauri/src/codegen/input/motion.rs
@@ -1,0 +1,72 @@
+//! Motion emitter — mirrors `runtime/input/motion.rs`.
+//!
+//! The live Motion (PIR) sensor sets `pinMode(pin, INPUT)` and reports a digital
+//! HIGH when motion is detected. The generated sketch emits the INPUT pin setup
+//! and a `digitalRead` each loop stored into a `bool` state variable that
+//! downstream Nodes read — a HIGH read means motion, matching the runtime which
+//! emits `true` on a detected pin-high.
+
+use crate::codegen::emit::{pin_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default pin matches `runtime/input/motion.rs::default_pin` (8).
+const DEFAULT_PIN: u8 = 8;
+
+/// The C++ `bool` variable name holding this Motion sensor's detected state.
+#[must_use]
+pub fn state_var(node: &FlowNode) -> String {
+    format!("motion_{}_state", node.id_token())
+}
+
+/// Emit C++ for a Motion Node.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let pin = pin_or_default(node, DEFAULT_PIN);
+    let pin_var = format!("motion_{}_pin", node.id_token());
+    let state = state_var(node);
+
+    NodeEmission {
+        declarations: vec![
+            format!("const uint8_t {pin_var} = {pin};"),
+            format!("bool {state} = false;"),
+        ],
+        setup: vec![format!("pinMode({pin_var}, INPUT);")],
+        loop_body: vec![format!("{state} = (digitalRead({pin_var}) == HIGH);")],
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn motion(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Motion".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn motion_input_mode_and_reads_digital() {
+        let e = emit(&motion("m-1", json!({ "pin": 8 })));
+        assert!(e.setup.iter().any(|s| s.contains("pinMode") && s.contains("INPUT")));
+        assert!(e.loop_body.iter().any(|l| l.contains("digitalRead") && l.contains("HIGH")));
+    }
+
+    #[test]
+    fn motion_uses_default_pin() {
+        let e = emit(&motion("m-1", json!({})));
+        assert!(e.declarations.iter().any(|d| d.contains("= 8;")));
+    }
+
+    #[test]
+    fn motion_emits_deterministically() {
+        let n = motion("m-1", json!({ "pin": 8 }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/input/proximity.rs
+++ b/apps/web/src-tauri/src/codegen/input/proximity.rs
@@ -1,0 +1,73 @@
+//! Proximity emitter — mirrors `runtime/input/proximity.rs`.
+//!
+//! The live Proximity sensor (e.g. a Sharp GP2Y0A21YK IR rangefinder) sets the
+//! ANALOG pin mode and reports `analogRead` values. Its pin is stored as a
+//! string (`"A0"` or a numeric pin) and resolved to a numeric analog pin via
+//! `analog_pin()`. The generated sketch declares the analog pin and stores
+//! `analogRead(pin)` into an `int` state variable each loop, which downstream
+//! Nodes read — the same reading the runtime forwards.
+
+use crate::codegen::emit::{pin_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default analog pin matches `runtime/input/proximity.rs` (`"A0"` => 0).
+const DEFAULT_PIN: u8 = 0;
+
+/// The C++ `int` variable name holding this Proximity sensor's latest reading.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("proximity_{}_value", node.id_token())
+}
+
+/// Emit C++ for a Proximity Node.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let pin = pin_or_default(node, DEFAULT_PIN);
+    let pin_var = format!("proximity_{}_pin", node.id_token());
+    let value = value_var(node);
+
+    NodeEmission {
+        declarations: vec![
+            format!("const uint8_t {pin_var} = A{pin};"),
+            format!("int {value} = 0;"),
+        ],
+        setup: vec![format!("pinMode({pin_var}, INPUT);")],
+        loop_body: vec![format!("{value} = analogRead({pin_var});")],
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn proximity(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Proximity".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn proximity_reads_analog_pin() {
+        let e = emit(&proximity("p-1", json!({ "pin": "A0" })));
+        assert!(e.loop_body.iter().any(|l| l.contains("analogRead")));
+        assert!(e.declarations.iter().any(|d| d.contains("A0")));
+    }
+
+    #[test]
+    fn proximity_resolves_numeric_pin() {
+        let e = emit(&proximity("p-1", json!({ "pin": "3" })));
+        assert!(e.declarations.iter().any(|d| d.contains("A3")));
+    }
+
+    #[test]
+    fn proximity_emits_deterministically() {
+        let n = proximity("p-1", json!({ "pin": "A0" }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/input/switch.rs
+++ b/apps/web/src-tauri/src/codegen/input/switch.rs
@@ -1,0 +1,95 @@
+//! Switch emitter — mirrors `runtime/input/switch.rs`.
+//!
+//! The live Switch is a latching on/off toggle (unlike the momentary Button).
+//! It sets `pinMode(pin, INPUT)` and reports digital reads. A Normally-Open (NO)
+//! switch reads HIGH when actuated; a Normally-Closed (NC) switch is wired
+//! inverted, so the emitted state inverts the raw read to match the runtime's
+//! `SwitchType`. Downstream Nodes read the resulting `bool` state variable.
+
+use crate::codegen::emit::{pin_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default pin matches `runtime/input/switch.rs::default_pin` (2).
+const DEFAULT_PIN: u8 = 2;
+
+/// The C++ `bool` variable name holding this Switch's current on/off state.
+#[must_use]
+pub fn state_var(node: &FlowNode) -> String {
+    format!("switch_{}_state", node.id_token())
+}
+
+/// True when the Node's `data.type` selects a Normally-Closed switch.
+fn is_normally_closed(node: &FlowNode) -> bool {
+    node.data
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|t| t.eq_ignore_ascii_case("NC"))
+}
+
+/// Emit C++ for a Switch Node.
+#[must_use]
+pub fn emit(node: &FlowNode) -> NodeEmission {
+    let pin = pin_or_default(node, DEFAULT_PIN);
+    let pin_var = format!("switch_{}_pin", node.id_token());
+    let state = state_var(node);
+    let nc = is_normally_closed(node);
+
+    // NO: actuated reads HIGH. NC: the contact is inverted, so actuated reads
+    // LOW — mirror the runtime by inverting the comparison.
+    let read_expr = if nc {
+        format!("(digitalRead({pin_var}) == LOW)")
+    } else {
+        format!("(digitalRead({pin_var}) == HIGH)")
+    };
+
+    NodeEmission {
+        declarations: vec![
+            format!("const uint8_t {pin_var} = {pin};"),
+            format!("bool {state} = false;"),
+        ],
+        setup: vec![format!("pinMode({pin_var}, INPUT);")],
+        loop_body: vec![format!("{state} = {read_expr};")],
+        ..NodeEmission::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn switch(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Switch".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn switch_input_mode_and_reads() {
+        let e = emit(&switch("sw-1", json!({ "pin": 2 })));
+        assert!(e.setup.iter().any(|s| s.contains("pinMode") && s.contains("INPUT")));
+        assert!(e.loop_body.iter().any(|l| l.contains("digitalRead") && l.contains("HIGH")));
+    }
+
+    #[test]
+    fn switch_nc_inverts_read() {
+        let e = emit(&switch("sw-1", json!({ "pin": 2, "type": "NC" })));
+        assert!(e.loop_body.iter().any(|l| l.contains("LOW")));
+    }
+
+    #[test]
+    fn switch_uses_default_pin() {
+        let e = emit(&switch("sw-1", json!({})));
+        assert!(e.declarations.iter().any(|d| d.contains("= 2;")));
+    }
+
+    #[test]
+    fn switch_emits_deterministically() {
+        let n = switch("sw-1", json!({ "pin": 2, "type": "NC" }));
+        assert_eq!(emit(&n), emit(&n));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/mod.rs
+++ b/apps/web/src-tauri/src/codegen/mod.rs
@@ -149,6 +149,7 @@ fn emit_node(node: &FlowNode, drivers: &BTreeMap<&str, String>) -> NodeEmission 
         Some("Gate") => transformation::gate::emit(node, driver),
         Some("RangeMap") => transformation::range_map::emit(node, driver),
         Some("Smooth") => transformation::smooth::emit(node, driver),
+        Some("Function") => transformation::function::emit(node, driver),
         Some("Delay") => control::delay::emit(node, driver),
         Some("Interval") => control::interval::emit(node),
         Some("Trigger") => control::trigger::emit(node, driver),
@@ -204,6 +205,7 @@ fn source_expression(node: &FlowNode) -> Option<String> {
         Some("Gate") => Some(transformation::gate::state_var(node)),
         Some("RangeMap") => Some(transformation::range_map::value_var(node)),
         Some("Smooth") => Some(transformation::smooth::value_var(node)),
+        Some("Function") => Some(transformation::function::value_var(node)),
         Some("Delay") => Some(control::delay::value_var(node)),
         Some("Interval") => Some(control::interval::value_var(node)),
         Some("Trigger") => Some(control::trigger::state_var(node)),
@@ -749,6 +751,129 @@ mod tests {
                 node_data("led-1", "Led", json!({ "pin": 13 })),
             ],
             edges: vec![edge("sensor-1", "rm-1"), edge("rm-1", "sm-1"), edge("sm-1", "led-1")],
+        };
+        assert_eq!(generate(&flow).unwrap(), generate(&flow).unwrap());
+    }
+
+    // --- Function Node translated to C++ (Task #36) ---
+
+    /// Scenario: Supported Function logic is translated.
+    ///
+    /// A Sensor drives a Function Node whose JS uses only the supported
+    /// expression subset; the Sketch must translate it to C++ that reads the
+    /// sensor value and feeds the wired Led — not a placeholder.
+    #[test]
+    fn supported_function_logic_is_translated() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data(
+                    "fn-1",
+                    "Function",
+                    json!({ "code": "const v = input * 2;\nreturn v + 1;" }),
+                ),
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+            ],
+            edges: vec![edge("sensor-1", "fn-1"), edge("fn-1", "led-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        assert!(
+            sketch.contains("double function_fn_1_value"),
+            "function output decl, got:\n{sketch}"
+        );
+        assert!(
+            sketch.contains("function_fn_1_value = "),
+            "function assigns its translated expression, got:\n{sketch}"
+        );
+        assert!(
+            sketch.contains("sensor_sensor_1_value"),
+            "function reads the sensor input"
+        );
+        // The Led is driven by the Function result, not a placeholder.
+        assert!(sketch.contains("digitalWrite(led_led_1_pin, (function_fn_1_value)"));
+        assert!(
+            !sketch.contains("unsupported Function Node fn_1"),
+            "supported logic must not be marked unsupported, got:\n{sketch}"
+        );
+        assert!(!sketch.contains("delay("), "stays non-blocking");
+    }
+
+    /// Scenario: Unsupported Function logic is clearly marked.
+    ///
+    /// A Function Node using a construct outside the subset (a `for` loop) is
+    /// clearly marked in the Sketch and contributes no broken or silently-wrong
+    /// C++ assignment.
+    #[test]
+    fn unsupported_function_logic_is_clearly_marked() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data(
+                    "fn-1",
+                    "Function",
+                    json!({ "code": "let s = 0;\nfor (let i = 0; i < input; i++) { s += i; }\nreturn s;" }),
+                ),
+            ],
+            edges: vec![edge("sensor-1", "fn-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        assert!(
+            sketch.contains("unsupported Function Node fn_1"),
+            "unsupported construct must be clearly marked, got:\n{sketch}"
+        );
+        // The output variable still exists at its safe default; no guessed C++.
+        assert!(sketch.contains("double function_fn_1_value = 0.0;"));
+        assert!(
+            !sketch.contains("function_fn_1_value = (double)"),
+            "no broken/silently-wrong assignment is emitted, got:\n{sketch}"
+        );
+        // Generation is not blanked.
+        assert!(sketch.contains("void setup()") && sketch.contains("void loop()"));
+    }
+
+    /// Scenario: Function Node is no longer a placeholder.
+    ///
+    /// A Flow containing a Function Node emits translated logic (its own value
+    /// variable), never the generic unsupported-Node placeholder reserved for
+    /// Nodes with no emitter.
+    #[test]
+    fn function_node_is_no_longer_a_placeholder() {
+        let flow = FlowUpdate {
+            nodes: vec![node_data(
+                "fn-1",
+                "Function",
+                json!({ "code": "return input;" }),
+            )],
+            edges: vec![],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        assert!(sketch.contains("function_fn_1_value"), "emits real state");
+        assert_eq!(
+            sketch.matches("// unsupported Node ").count(),
+            0,
+            "Function must not fall through to the no-emitter placeholder, got:\n{sketch}"
+        );
+    }
+
+    /// Determinism holds for a Function-bearing Flow.
+    #[test]
+    fn function_flow_is_deterministic() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data(
+                    "fn-1",
+                    "Function",
+                    json!({ "code": "return input > 500 ? 1 : 0;" }),
+                ),
+            ],
+            edges: vec![edge("sensor-1", "fn-1")],
         };
         assert_eq!(generate(&flow).unwrap(), generate(&flow).unwrap());
     }

--- a/apps/web/src-tauri/src/codegen/mod.rs
+++ b/apps/web/src-tauri/src/codegen/mod.rs
@@ -25,6 +25,7 @@ pub mod emit;
 pub mod input;
 pub mod output;
 pub mod placeholder;
+pub mod transformation;
 
 use crate::runtime::types::{FlowNode, FlowUpdate};
 use emit::NodeEmission;
@@ -142,6 +143,11 @@ fn emit_node(node: &FlowNode, drivers: &BTreeMap<&str, String>) -> NodeEmission 
         Some("Servo") => output::servo::emit(node, driver),
         Some("Button") => input::button::emit(node),
         Some("Sensor") => input::sensor::emit(node),
+        Some("Calculate") => transformation::calculate::emit(node, driver),
+        Some("Compare") => transformation::compare::emit(node, driver),
+        Some("Gate") => transformation::gate::emit(node, driver),
+        Some("RangeMap") => transformation::range_map::emit(node, driver),
+        Some("Smooth") => transformation::smooth::emit(node, driver),
         _ => placeholder::emit(node),
     }
 }
@@ -187,6 +193,11 @@ fn source_expression(node: &FlowNode) -> Option<String> {
     match node.node_type.as_deref() {
         Some("Button") => Some(input::button::state_var(node)),
         Some("Sensor") => Some(input::sensor::value_var(node)),
+        Some("Calculate") => Some(transformation::calculate::value_var(node)),
+        Some("Compare") => Some(transformation::compare::state_var(node)),
+        Some("Gate") => Some(transformation::gate::state_var(node)),
+        Some("RangeMap") => Some(transformation::range_map::value_var(node)),
+        Some("Smooth") => Some(transformation::smooth::value_var(node)),
         _ => None,
     }
 }
@@ -572,5 +583,162 @@ mod tests {
             first, second,
             "repeated generation must yield identical placeholder comments"
         );
+    }
+
+    // --- Transformation Nodes (Task #33) ---
+
+    /// Scenario: Calculate Node emits matching arithmetic.
+    ///
+    /// A Sensor drives a Calculate Node configured for `ceil`; the Sketch must
+    /// compute the Node's value from the sensor reading using the same unary
+    /// math the runtime applies, and feed it onward to a wired Led.
+    #[test]
+    fn calculate_node_emits_matching_arithmetic() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data("calc-1", "Calculate", json!({ "function": "ceil" })),
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+            ],
+            edges: vec![edge("sensor-1", "calc-1"), edge("calc-1", "led-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        assert!(sketch.contains("double calculate_calc_1_value"), "calc output decl");
+        assert!(
+            sketch.contains("calculate_calc_1_value = ceil("),
+            "calc must apply ceil to its input, got:\n{sketch}"
+        );
+        assert!(sketch.contains("sensor_sensor_1_value"), "calc reads the sensor");
+        // The Led is driven by the Calculate result, not a placeholder.
+        assert!(sketch.contains("digitalWrite(led_led_1_pin, (calculate_calc_1_value)"));
+        assert!(!sketch.contains("// unsupported Node calc"), "calc must not be a placeholder");
+        assert!(!sketch.contains("delay("), "stays non-blocking");
+    }
+
+    /// Scenario: Compare Node emits matching comparison.
+    #[test]
+    fn compare_node_emits_matching_comparison() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data(
+                    "cmp-1",
+                    "Compare",
+                    json!({ "validator": "number", "subValidator": "greater than", "number": 512.0 }),
+                ),
+            ],
+            edges: vec![edge("sensor-1", "cmp-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        assert!(sketch.contains("bool compare_cmp_1_result"), "compare bool decl");
+        assert!(
+            sketch.contains("> 512.0"),
+            "compare must emit the greater-than test, got:\n{sketch}"
+        );
+        assert!(!sketch.contains("// unsupported Node cmp"));
+    }
+
+    /// Scenario: Gate Node emits matching pass-through logic.
+    #[test]
+    fn gate_node_emits_matching_pass_through_logic() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("btn-1", "Button", json!({ "pin": 6 })),
+                node_data("gate-1", "Gate", json!({ "gate": "nand" })),
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+            ],
+            edges: vec![edge("btn-1", "gate-1"), edge("gate-1", "led-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        assert!(sketch.contains("bool gate_gate_1_result"), "gate bool decl");
+        // nand on a single input inverts it.
+        assert!(
+            sketch.contains("gate_gate_1_result = (!((bool)(button_btn_1_state)))"),
+            "nand gate must invert the button, got:\n{sketch}"
+        );
+        // The Led reads the gate result.
+        assert!(sketch.contains("digitalWrite(led_led_1_pin, (gate_gate_1_result)"));
+    }
+
+    /// Scenario: `RangeMap` and Smooth Nodes preserve their live behavior.
+    #[test]
+    fn range_map_and_smooth_preserve_live_behavior() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data(
+                    "rm-1",
+                    "RangeMap",
+                    json!({ "from": { "min": 0.0, "max": 1023.0 }, "to": { "min": 0.0, "max": 255.0 } }),
+                ),
+                node_data(
+                    "sm-1",
+                    "Smooth",
+                    json!({ "type": "movingAverage", "windowSize": 4 }),
+                ),
+            ],
+            edges: vec![edge("sensor-1", "rm-1"), edge("rm-1", "sm-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // RangeMap linear remap math with the configured bounds.
+        assert!(sketch.contains("double range_map_rm_1_value"), "range map decl");
+        assert!(sketch.contains("1023.0") && sketch.contains("255.0"), "range bounds present");
+        assert!(sketch.contains("round("), "range map rounds like the runtime");
+        // Smooth keeps a persistent rolling window (state survives loop iterations).
+        assert!(sketch.contains("double smooth_sm_1_window[4]"), "moving-average ring buffer");
+        assert!(sketch.contains("smooth_sm_1_value"), "smooth output decl");
+        assert!(!sketch.contains("delay("), "stays non-blocking despite state");
+    }
+
+    /// Scenario: No transformation Node is left as a placeholder.
+    #[test]
+    fn no_transformation_node_left_as_placeholder() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("calc-1", "Calculate", json!({ "function": "add" })),
+                node_data("cmp-1", "Compare", json!({ "validator": "boolean" })),
+                node_data("gate-1", "Gate", json!({ "gate": "and" })),
+                node_data("rm-1", "RangeMap", json!({})),
+                node_data("sm-1", "Smooth", json!({})),
+            ],
+            edges: vec![],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Every transformation Node declares real state; none is a placeholder.
+        assert!(sketch.contains("calculate_calc_1_value"));
+        assert!(sketch.contains("compare_cmp_1_result"));
+        assert!(sketch.contains("gate_gate_1_result"));
+        assert!(sketch.contains("range_map_rm_1_value"));
+        assert!(sketch.contains("smooth_sm_1_value"));
+        assert_eq!(
+            sketch.matches("// unsupported Node ").count(),
+            0,
+            "no transformation Node may be a placeholder, got:\n{sketch}"
+        );
+    }
+
+    /// Determinism holds for a transformation-heavy Flow.
+    #[test]
+    fn transformation_flow_is_deterministic() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data("rm-1", "RangeMap", json!({ "to": { "min": 0.0, "max": 5.0 } })),
+                node_data("sm-1", "Smooth", json!({ "type": "smooth", "attenuation": 0.8 })),
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+            ],
+            edges: vec![edge("sensor-1", "rm-1"), edge("rm-1", "sm-1"), edge("sm-1", "led-1")],
+        };
+        assert_eq!(generate(&flow).unwrap(), generate(&flow).unwrap());
     }
 }

--- a/apps/web/src-tauri/src/codegen/mod.rs
+++ b/apps/web/src-tauri/src/codegen/mod.rs
@@ -21,6 +21,7 @@
 //! - **Validity:** the output is always syntactically valid Arduino C++ and
 //!   compiles even when the Flow is empty.
 
+pub mod control;
 pub mod emit;
 pub mod input;
 pub mod output;
@@ -148,6 +149,11 @@ fn emit_node(node: &FlowNode, drivers: &BTreeMap<&str, String>) -> NodeEmission 
         Some("Gate") => transformation::gate::emit(node, driver),
         Some("RangeMap") => transformation::range_map::emit(node, driver),
         Some("Smooth") => transformation::smooth::emit(node, driver),
+        Some("Delay") => control::delay::emit(node, driver),
+        Some("Interval") => control::interval::emit(node),
+        Some("Trigger") => control::trigger::emit(node, driver),
+        Some("Counter") => control::counter::emit(node, driver),
+        Some("Constant") => control::constant::emit(node),
         _ => placeholder::emit(node),
     }
 }
@@ -198,6 +204,11 @@ fn source_expression(node: &FlowNode) -> Option<String> {
         Some("Gate") => Some(transformation::gate::state_var(node)),
         Some("RangeMap") => Some(transformation::range_map::value_var(node)),
         Some("Smooth") => Some(transformation::smooth::value_var(node)),
+        Some("Delay") => Some(control::delay::value_var(node)),
+        Some("Interval") => Some(control::interval::value_var(node)),
+        Some("Trigger") => Some(control::trigger::state_var(node)),
+        Some("Counter") => Some(control::counter::value_var(node)),
+        Some("Constant") => Some(control::constant::value_var(node)),
         _ => None,
     }
 }
@@ -738,6 +749,193 @@ mod tests {
                 node_data("led-1", "Led", json!({ "pin": 13 })),
             ],
             edges: vec![edge("sensor-1", "rm-1"), edge("rm-1", "sm-1"), edge("sm-1", "led-1")],
+        };
+        assert_eq!(generate(&flow).unwrap(), generate(&flow).unwrap());
+    }
+
+    // --- Control Nodes as non-blocking timers (Task #34) ---
+
+    /// Scenario: Delay Node emits non-blocking timing.
+    ///
+    /// A Button arms a Delay that drives a Led. The Delay must be driven by the
+    /// loop scheduler with no blocking wait, and the rest of the Flow (the Led
+    /// write) keeps running while the Delay is pending.
+    #[test]
+    fn delay_node_emits_non_blocking_timing() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("btn-1", "Button", json!({ "pin": 6 })),
+                node_data("delay-1", "Delay", json!({ "delay": 1000 })),
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+            ],
+            edges: vec![edge("btn-1", "delay-1"), edge("delay-1", "led-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Driven by the loop scheduler via an elapsed-millis comparison.
+        assert!(
+            sketch.contains("millis() - delay_delay_1_armed_at >= 1000UL"),
+            "delay must fire on the loop scheduler, got:\n{sketch}"
+        );
+        // No blocking wait anywhere.
+        assert!(!sketch.contains("delay("), "delay must be non-blocking");
+        // The rest of the Flow keeps running: the Led is driven by the Delay output.
+        assert!(
+            sketch.contains("digitalWrite(led_led_1_pin, (delay_delay_1_value)"),
+            "led must read the delayed value, got:\n{sketch}"
+        );
+        assert!(!sketch.contains("// unsupported Node delay"), "delay must not be a placeholder");
+    }
+
+    /// Scenario: Interval Node fires repeatedly without blocking.
+    #[test]
+    fn interval_node_fires_repeatedly_without_blocking() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("iv-1", "Interval", json!({ "interval": 500 })),
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+            ],
+            edges: vec![edge("iv-1", "led-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Fires on schedule via the loop scheduler's millis() clock.
+        assert!(
+            sketch.contains("millis() - interval_iv_1_previous >= 500UL"),
+            "interval must fire on schedule, got:\n{sketch}"
+        );
+        // Without halting other Nodes — no blocking delay.
+        assert!(!sketch.contains("delay("), "interval must not block other nodes");
+        assert!(!sketch.contains("// unsupported Node iv"), "interval must not be a placeholder");
+    }
+
+    /// Scenario: Counter Node retains its count on-device.
+    #[test]
+    fn counter_node_retains_its_count_on_device() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("btn-1", "Button", json!({ "pin": 6 })),
+                node_data("ct-1", "Counter", json!({})),
+            ],
+            edges: vec![edge("btn-1", "ct-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // The count lives in a module-level declaration => persists across loop().
+        assert!(
+            sketch.contains("double counter_ct_1_count = 0.0;"),
+            "counter must keep a persistent running count, got:\n{sketch}"
+        );
+        // It is updated (incremented) inside the scheduled loop body.
+        assert!(sketch.contains("counter_ct_1_count += 1.0"), "counter must increment on signal");
+        assert!(!sketch.contains("// unsupported Node ct"), "counter must not be a placeholder");
+    }
+
+    /// Scenario: Trigger and Constant Nodes match live behavior.
+    #[test]
+    fn trigger_and_constant_nodes_match_live_behavior() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data("tg-1", "Trigger", json!({ "threshold": 5.0, "behaviour": "increasing" })),
+                node_data("const-1", "Constant", json!({ "value": 42.0 })),
+            ],
+            edges: vec![edge("sensor-1", "tg-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Trigger reproduces its threshold/direction bang from the sensor reading.
+        assert!(sketch.contains("bool trigger_tg_1_result"), "trigger bool output");
+        assert!(sketch.contains(">= 5.0"), "trigger applies its threshold");
+        assert!(sketch.contains("trigger_tg_1_diff > 0.0"), "trigger respects increasing direction");
+        // Constant emits its fixed live value.
+        assert!(
+            sketch.contains("double constant_const_1_value = 42.0;"),
+            "constant must emit its fixed value, got:\n{sketch}"
+        );
+        assert!(!sketch.contains("// unsupported Node tg"));
+        assert!(!sketch.contains("// unsupported Node const"));
+    }
+
+    /// Scenario: Nested timing Nodes run concurrently without drift.
+    ///
+    /// An Interval drives a Delay. Both timers must run concurrently on the
+    /// scheduler — each off its own `millis()` comparison — without drift or one
+    /// blocking the other.
+    #[test]
+    fn nested_timing_nodes_run_concurrently_without_drift() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("iv-1", "Interval", json!({ "interval": 200 })),
+                node_data("delay-1", "Delay", json!({ "delay": 1000 })),
+            ],
+            edges: vec![edge("iv-1", "delay-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Two independent millis-based timers, neither blocking.
+        assert!(
+            sketch.contains("millis() - interval_iv_1_previous >= 200UL"),
+            "interval timer present, got:\n{sketch}"
+        );
+        assert!(
+            sketch.contains("millis() - delay_delay_1_armed_at >= 1000UL"),
+            "delay timer present, got:\n{sketch}"
+        );
+        assert!(!sketch.contains("delay("), "concurrent timers must not block");
+        // The Delay is armed from the Interval's output (nested timing wired through).
+        assert!(
+            sketch.contains("(double)(interval_iv_1_value)") || sketch.contains("(interval_iv_1_value)"),
+            "delay must be driven by the interval, got:\n{sketch}"
+        );
+    }
+
+    /// No control Node is left as a placeholder.
+    #[test]
+    fn no_control_node_left_as_placeholder() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("delay-1", "Delay", json!({})),
+                node_data("iv-1", "Interval", json!({})),
+                node_data("tg-1", "Trigger", json!({})),
+                node_data("ct-1", "Counter", json!({})),
+                node_data("const-1", "Constant", json!({})),
+            ],
+            edges: vec![],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        assert!(sketch.contains("delay_delay_1_value"));
+        assert!(sketch.contains("interval_iv_1_value"));
+        assert!(sketch.contains("trigger_tg_1_result"));
+        assert!(sketch.contains("counter_ct_1_count"));
+        assert!(sketch.contains("constant_const_1_value"));
+        assert_eq!(
+            sketch.matches("// unsupported Node ").count(),
+            0,
+            "no control Node may be a placeholder, got:\n{sketch}"
+        );
+        assert!(!sketch.contains("delay("), "control nodes stay non-blocking");
+    }
+
+    /// Determinism holds for a control-heavy Flow.
+    #[test]
+    fn control_flow_is_deterministic() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("iv-1", "Interval", json!({ "interval": 250 })),
+                node_data("delay-1", "Delay", json!({ "delay": 500 })),
+                node_data("ct-1", "Counter", json!({})),
+                node_data("const-1", "Constant", json!({ "value": 3.0 })),
+                node_data("tg-1", "Trigger", json!({ "threshold": 2.0 })),
+            ],
+            edges: vec![edge("iv-1", "delay-1"), edge("iv-1", "ct-1")],
         };
         assert_eq!(generate(&flow).unwrap(), generate(&flow).unwrap());
     }

--- a/apps/web/src-tauri/src/codegen/mod.rs
+++ b/apps/web/src-tauri/src/codegen/mod.rs
@@ -23,6 +23,7 @@
 
 pub mod control;
 pub mod emit;
+pub mod generator;
 pub mod input;
 pub mod output;
 pub mod placeholder;
@@ -142,8 +143,25 @@ fn emit_node(node: &FlowNode, drivers: &BTreeMap<&str, String>) -> NodeEmission 
         Some("Led") => output::led::emit(node, driver),
         Some("Relay") => output::relay::emit(node, driver),
         Some("Servo") => output::servo::emit(node, driver),
+        Some("Rgb") => output::rgb::emit(node, driver),
+        Some("Piezo") => output::piezo::emit(node, driver),
+        Some("Pixel") => output::pixel::emit(node, driver),
+        Some("Matrix") => output::matrix::emit(node, driver),
+        Some("Stepper") => output::stepper::emit(node, driver),
+        // Vibration shares the live Led implementation (digital on/off output).
+        Some("Vibration") => output::led::emit(node, driver),
         Some("Button") => input::button::emit(node),
-        Some("Sensor") => input::sensor::emit(node),
+        // Force, HallEffect, Ldr, Potentiometer, and Tilt are all analog inputs
+        // backed by the live Sensor implementation, so they share its emitter.
+        Some("Sensor" | "Force" | "HallEffect" | "Ldr" | "Potentiometer" | "Tilt") => {
+            input::sensor::emit(node)
+        }
+        Some("Switch") => input::switch::emit(node),
+        Some("Motion") => input::motion::emit(node),
+        Some("Proximity") => input::proximity::emit(node),
+        Some("Hotkey") => input::hotkey::emit(node),
+        Some("I2cDevice") => input::i2c_device::emit(node),
+        Some("Oscillator") => generator::oscillator::emit(node),
         Some("Calculate") => transformation::calculate::emit(node, driver),
         Some("Compare") => transformation::compare::emit(node, driver),
         Some("Gate") => transformation::gate::emit(node, driver),
@@ -199,7 +217,15 @@ fn driver_expressions(flow: &FlowUpdate) -> BTreeMap<&str, String> {
 fn source_expression(node: &FlowNode) -> Option<String> {
     match node.node_type.as_deref() {
         Some("Button") => Some(input::button::state_var(node)),
-        Some("Sensor") => Some(input::sensor::value_var(node)),
+        Some("Sensor" | "Force" | "HallEffect" | "Ldr" | "Potentiometer" | "Tilt") => {
+            Some(input::sensor::value_var(node))
+        }
+        Some("Switch") => Some(input::switch::state_var(node)),
+        Some("Motion") => Some(input::motion::state_var(node)),
+        Some("Proximity") => Some(input::proximity::value_var(node)),
+        Some("Hotkey") => Some(input::hotkey::state_var(node)),
+        Some("I2cDevice") => Some(input::i2c_device::value_var(node)),
+        Some("Oscillator") => Some(generator::oscillator::value_var(node)),
         Some("Calculate") => Some(transformation::calculate::value_var(node)),
         Some("Compare") => Some(transformation::compare::state_var(node)),
         Some("Gate") => Some(transformation::gate::state_var(node)),
@@ -1047,6 +1073,181 @@ mod tests {
             "no control Node may be a placeholder, got:\n{sketch}"
         );
         assert!(!sketch.contains("delay("), "control nodes stay non-blocking");
+    }
+
+    // --- Remaining input/output/generator Nodes (Task #37) ---
+
+    /// Scenario: Remaining input Nodes feed values into the Flow.
+    ///
+    /// A Flow uses every remaining non-Cloud input Node (Switch, Motion,
+    /// Proximity, Hotkey, `I2cDevice` plus the Sensor-backed aliases). Each must
+    /// read its hardware into a state/value variable that downstream Nodes can
+    /// consume, exactly as the live runtime forwards its reading.
+    #[test]
+    fn remaining_input_nodes_feed_values_into_the_flow() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sw-1", "Switch", json!({ "pin": 2 })),
+                node_data("mo-1", "Motion", json!({ "pin": 8 })),
+                node_data("px-1", "Proximity", json!({ "pin": "A1" })),
+                node_data("hk-1", "Hotkey", json!({ "accelerator": "a" })),
+                node_data("i2c-1", "I2cDevice", json!({ "address": 64, "read_length": 2 })),
+                node_data("pot-1", "Potentiometer", json!({ "pin": "A2" })),
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+            ],
+            // Switch drives the Led, so its read flows into the rest of the Flow.
+            edges: vec![edge("sw-1", "led-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Each input reads hardware into its variable.
+        assert!(sketch.contains("switch_sw_1_state = (digitalRead"), "switch reads");
+        assert!(sketch.contains("motion_mo_1_state = (digitalRead"), "motion reads");
+        assert!(sketch.contains("proximity_px_1_value = analogRead"), "proximity reads");
+        assert!(sketch.contains("bool hotkey_hk_1_state"), "hotkey declares state");
+        assert!(sketch.contains("i2c_i2c_1_value = "), "i2c reads");
+        assert!(sketch.contains("sensor_pot_1_value = analogRead"), "potentiometer is a Sensor");
+        // The Switch reading feeds the Led (value flows into the Flow).
+        assert!(
+            sketch.contains("digitalWrite(led_led_1_pin, (switch_sw_1_state)"),
+            "switch value must drive the led, got:\n{sketch}"
+        );
+        assert!(!sketch.contains("delay("), "stays non-blocking");
+    }
+
+    /// Scenario: Remaining output Nodes drive their hardware.
+    ///
+    /// A Sensor drives each remaining non-Cloud output Node (Rgb, Piezo, Pixel,
+    /// Matrix, Stepper, and the Led-backed Vibration). Each must emit real drive
+    /// logic from the incoming value, pulling in any required library.
+    #[test]
+    fn remaining_output_nodes_drive_their_hardware() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data("rgb-1", "Rgb", json!({})),
+                node_data("pz-1", "Piezo", json!({})),
+                node_data("px-1", "Pixel", json!({ "length": 8 })),
+                node_data("mx-1", "Matrix", json!({})),
+                node_data("st-1", "Stepper", json!({})),
+                node_data("vb-1", "Vibration", json!({ "pin": 5 })),
+            ],
+            edges: vec![
+                edge("sensor-1", "rgb-1"),
+                edge("sensor-1", "pz-1"),
+                edge("sensor-1", "px-1"),
+                edge("sensor-1", "mx-1"),
+                edge("sensor-1", "st-1"),
+                edge("sensor-1", "vb-1"),
+            ],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Each output drives from the sensor value.
+        assert!(sketch.contains("analogWrite(rgb_rgb_1_red_pin"), "rgb drives channels");
+        assert!(sketch.contains("tone(piezo_pz_1_pin"), "piezo sounds");
+        assert!(sketch.contains("pixel_px_1.setPixelColor"), "pixel fills");
+        assert!(sketch.contains("matrix_mx_1.setRow"), "matrix lights");
+        assert!(sketch.contains("stepper_st_1.moveTo"), "stepper targets value");
+        assert!(sketch.contains("digitalWrite(led_vb_1_pin"), "vibration is an Led output");
+        // Library-backed Nodes pull in their includes.
+        assert!(sketch.contains("#include <Adafruit_NeoPixel.h>"), "pixel include");
+        assert!(sketch.contains("#include <LedControl.h>"), "matrix include");
+        assert!(sketch.contains("#include <AccelStepper.h>"), "stepper include");
+        assert!(!sketch.contains("delay("), "stays non-blocking");
+    }
+
+    /// Scenario: The generator Node produces its signal non-blocking.
+    #[test]
+    fn generator_node_produces_signal_non_blocking() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("osc-1", "Oscillator", json!({ "waveform": "sinus", "period": 1000 })),
+                node_data("servo-1", "Servo", json!({ "pin": 9 })),
+            ],
+            edges: vec![edge("osc-1", "servo-1")],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // The Oscillator samples its waveform off the loop scheduler's millis() clock.
+        assert!(
+            sketch.contains("millis() - oscillator_osc_1_start"),
+            "oscillator must sample against the scheduler clock, got:\n{sketch}"
+        );
+        assert!(sketch.contains("oscillator_osc_1_value = "), "oscillator output");
+        // No blocking wait anywhere.
+        assert!(!sketch.contains("delay("), "oscillator must be non-blocking");
+        // The signal flows onward to the wired Servo.
+        assert!(
+            sketch.contains("(oscillator_osc_1_value)"),
+            "oscillator must drive the servo, got:\n{sketch}"
+        );
+        assert!(!sketch.contains("// unsupported Node osc"), "oscillator must not be a placeholder");
+    }
+
+    /// Scenario: No remaining non-Cloud Node is a placeholder, while Cloud Nodes
+    /// still fall through to placeholders (Feature #27 territory).
+    #[test]
+    fn no_remaining_non_cloud_node_is_a_placeholder() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sw-1", "Switch", json!({})),
+                node_data("mo-1", "Motion", json!({})),
+                node_data("px-in", "Proximity", json!({})),
+                node_data("hk-1", "Hotkey", json!({})),
+                node_data("i2c-1", "I2cDevice", json!({})),
+                node_data("force-1", "Force", json!({})),
+                node_data("hall-1", "HallEffect", json!({})),
+                node_data("ldr-1", "Ldr", json!({})),
+                node_data("pot-1", "Potentiometer", json!({})),
+                node_data("tilt-1", "Tilt", json!({})),
+                node_data("rgb-1", "Rgb", json!({})),
+                node_data("pz-1", "Piezo", json!({})),
+                node_data("px-out", "Pixel", json!({})),
+                node_data("mx-1", "Matrix", json!({})),
+                node_data("st-1", "Stepper", json!({})),
+                node_data("vb-1", "Vibration", json!({})),
+                node_data("osc-1", "Oscillator", json!({})),
+                // Cloud Nodes remain placeholders (handled by Feature #27).
+                node("mqtt-1", "Mqtt"),
+                node("figma-1", "Figma"),
+                node("llm-1", "Llm"),
+                node("monitor-1", "Monitor"),
+            ],
+            edges: vec![],
+        };
+
+        let sketch = generate(&flow).expect("generation should succeed");
+
+        // Exactly the four Cloud Nodes are placeholders — nothing else.
+        assert_eq!(
+            sketch.matches("// unsupported Node ").count(),
+            4,
+            "only the four Cloud Nodes may be placeholders, got:\n{sketch}"
+        );
+        // Spot-check that representative remaining Nodes emit real artefacts.
+        assert!(sketch.contains("switch_sw_1_state"));
+        assert!(sketch.contains("oscillator_osc_1_value"));
+        assert!(sketch.contains("Adafruit_NeoPixel"));
+        assert!(!sketch.contains("delay("), "stays non-blocking");
+    }
+
+    /// Determinism holds for a Flow mixing the remaining Node types.
+    #[test]
+    fn remaining_nodes_flow_is_deterministic() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("osc-1", "Oscillator", json!({ "waveform": "square", "period": 500 })),
+                node_data("sw-1", "Switch", json!({ "pin": 2 })),
+                node_data("rgb-1", "Rgb", json!({})),
+                node_data("st-1", "Stepper", json!({})),
+            ],
+            edges: vec![edge("osc-1", "rgb-1"), edge("sw-1", "st-1")],
+        };
+        assert_eq!(generate(&flow).unwrap(), generate(&flow).unwrap());
     }
 
     /// Determinism holds for a control-heavy Flow.

--- a/apps/web/src-tauri/src/codegen/output/matrix.rs
+++ b/apps/web/src-tauri/src/codegen/output/matrix.rs
@@ -1,0 +1,127 @@
+//! Matrix emitter — mirrors `runtime/output/matrix.rs`.
+//!
+//! The live Matrix drives a MAX7219 LED matrix over bit-banged SPI (data, clock,
+//! CS pins), initialising the chip out of shutdown, setting a scan limit and
+//! intensity, and clearing the display. The generated sketch uses the standard
+//! Arduino `LedControl` library, whose `LedControl(dataPin, clkPin, csPin,
+//! numDevices)` wraps exactly this MAX7219 protocol: `setup()` wakes each device
+//! from power-down (`shutdown(i, false)`), sets a mid intensity, and clears the
+//! display — mirroring the runtime's `init_max7219` + blank-on-init. When wired
+//! from an upstream signal the whole display is lit or cleared accordingly.
+
+use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Pin defaults match `runtime/output/matrix.rs` (data=2, clock=3, cs=4).
+const DEFAULT_DATA: u8 = 2;
+const DEFAULT_CLOCK: u8 = 3;
+const DEFAULT_CS: u8 = 4;
+/// Device-count default matches `runtime/output/matrix.rs::default_devices` (1).
+const DEFAULT_DEVICES: u8 = 1;
+
+fn pin(node: &FlowNode, key: &str, default: u8) -> u8 {
+    node.data
+        .get("pins")
+        .and_then(|p| p.get(key))
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|n| u8::try_from(n).ok())
+        .unwrap_or(default)
+}
+
+fn devices(node: &FlowNode) -> u8 {
+    node.data
+        .get("devices")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|n| u8::try_from(n).ok())
+        .unwrap_or(DEFAULT_DEVICES)
+        .max(1)
+}
+
+/// Emit C++ for a Matrix Node. `driver` is an optional boolean: when wired, a
+/// true value lights every LED and a false value clears the display.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let obj = format!("matrix_{token}");
+    let data = pin(node, "data", DEFAULT_DATA);
+    let clock = pin(node, "clock", DEFAULT_CLOCK);
+    let cs = pin(node, "cs", DEFAULT_CS);
+    let devices = devices(node);
+    let i = format!("matrix_{token}_i");
+    let row = format!("matrix_{token}_row");
+
+    let mut e = NodeEmission {
+        includes: vec!["#include <LedControl.h>".to_string()],
+        declarations: vec![format!(
+            "LedControl {obj}({data}, {clock}, {cs}, {devices});"
+        )],
+        setup: vec![
+            format!("for (int {i} = 0; {i} < {devices}; {i}++) {{"),
+            // Mirror init_max7219: wake from shutdown, mid intensity, clear.
+            format!("  {obj}.shutdown({i}, false);"),
+            format!("  {obj}.setIntensity({i}, 8);"),
+            format!("  {obj}.clearDisplay({i});"),
+            "}".to_string(),
+        ],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        e.loop_body.push(format!("for (int {i} = 0; {i} < {devices}; {i}++) {{"));
+        e.loop_body.push(format!("  for (int {row} = 0; {row} < 8; {row}++) {{"));
+        e.loop_body.push(format!(
+            "    {obj}.setRow({i}, {row}, ({expr}) ? 0xFF : 0x00);"
+        ));
+        e.loop_body.push("  }".to_string());
+        e.loop_body.push("}".to_string());
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn matrix(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Matrix".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn matrix_includes_library_and_declares_object() {
+        let e = emit(&matrix("mx-1", json!({})), None);
+        assert!(e.includes.iter().any(|i| i.contains("LedControl.h")));
+        assert!(e.declarations.iter().any(|d| d.contains("LedControl matrix_mx_1(2, 3, 4, 1)")));
+    }
+
+    #[test]
+    fn matrix_wakes_and_clears_on_setup() {
+        let e = emit(&matrix("mx-1", json!({})), None);
+        assert!(e.setup.iter().any(|s| s.contains("shutdown") && s.contains("false")));
+        assert!(e.setup.iter().any(|s| s.contains("clearDisplay")));
+    }
+
+    #[test]
+    fn matrix_lights_display_from_value() {
+        let e = emit(&matrix("mx-1", json!({})), Some("btn_state"));
+        assert!(e.loop_body.iter().any(|l| l.contains("setRow") && l.contains("btn_state")));
+    }
+
+    #[test]
+    fn matrix_reads_custom_pins() {
+        let e = emit(&matrix("mx-1", json!({ "pins": { "data": 7, "clock": 8, "cs": 9 }, "devices": 2 })), None);
+        assert!(e.declarations.iter().any(|d| d.contains("(7, 8, 9, 2)")));
+    }
+
+    #[test]
+    fn matrix_emits_deterministically() {
+        let n = matrix("mx-1", json!({ "devices": 2 }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/output/mod.rs
+++ b/apps/web/src-tauri/src/codegen/output/mod.rs
@@ -1,6 +1,11 @@
-//! Output-Node C++ emitters (Led, Servo, Relay) — the codegen mirror of
-//! `runtime/output`.
+//! Output-Node C++ emitters (Led, Servo, Relay, Rgb, Piezo, Pixel, Matrix,
+//! Stepper) — the codegen mirror of `runtime/output`.
 
 pub mod led;
+pub mod matrix;
+pub mod piezo;
+pub mod pixel;
 pub mod relay;
+pub mod rgb;
 pub mod servo;
+pub mod stepper;

--- a/apps/web/src-tauri/src/codegen/output/piezo.rs
+++ b/apps/web/src-tauri/src/codegen/output/piezo.rs
@@ -1,0 +1,98 @@
+//! Piezo emitter — mirrors `runtime/output/piezo.rs`.
+//!
+//! The live Piezo buzzer plays a tone by toggling its pin at the note's
+//! half-period (the Johnny-Five approach). The Arduino core exposes exactly this
+//! via the built-in `tone(pin, frequency, duration)` / `noTone(pin)`, which is
+//! non-blocking (it runs off a hardware timer). The generated sketch sets the
+//! pin OUTPUT, and — when triggered from an upstream signal — sounds the
+//! configured frequency for the configured duration, falling silent otherwise.
+//! No blocking `delay()` is used: `tone(...)` returns immediately.
+
+use crate::codegen::emit::{pin_or_default, u64_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default pin matches `runtime/output/piezo.rs::default_pin` (11).
+const DEFAULT_PIN: u8 = 11;
+/// Default frequency matches `runtime/output/piezo.rs::default_frequency` (440 Hz).
+const DEFAULT_FREQUENCY: u64 = 440;
+/// Default duration matches `runtime/output/piezo.rs::default_duration` (500 ms).
+const DEFAULT_DURATION: u64 = 500;
+
+/// Emit C++ for a Piezo Node. `driver` is an optional boolean trigger: while
+/// true the buzzer sounds, otherwise it is silenced.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let pin_var = format!("piezo_{token}_pin");
+    let pin = pin_or_default(node, DEFAULT_PIN);
+    let frequency = u64_or_default(node, "frequency", DEFAULT_FREQUENCY);
+    let duration = u64_or_default(node, "duration", DEFAULT_DURATION);
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("const uint8_t {pin_var} = {pin};")],
+        setup: vec![
+            format!("pinMode({pin_var}, OUTPUT);"),
+            // Mirror runtime initialize: silent at start.
+            format!("noTone({pin_var});"),
+        ],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        e.loop_body.push(format!("if ({expr}) {{"));
+        // tone() is non-blocking — it drives a hardware timer and returns at once.
+        e.loop_body
+            .push(format!("  tone({pin_var}, {frequency}, {duration});"));
+        e.loop_body.push("} else {".to_string());
+        e.loop_body.push(format!("  noTone({pin_var});"));
+        e.loop_body.push("}".to_string());
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn piezo(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Piezo".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn piezo_sets_output_and_starts_silent() {
+        let e = emit(&piezo("pz-1", json!({ "pin": 11 })), None);
+        assert!(e.setup.iter().any(|s| s.contains("pinMode") && s.contains("OUTPUT")));
+        assert!(e.setup.iter().any(|s| s.contains("noTone")));
+    }
+
+    #[test]
+    fn piezo_sounds_configured_frequency_when_triggered() {
+        let e = emit(&piezo("pz-1", json!({ "frequency": 880, "duration": 250 })), Some("btn_state"));
+        assert!(e.loop_body.iter().any(|l| l.contains("tone(") && l.contains("880") && l.contains("250")));
+    }
+
+    #[test]
+    fn piezo_is_non_blocking() {
+        let e = emit(&piezo("pz-1", json!({})), Some("v"));
+        assert!(!e.loop_body.iter().any(|l| l.contains("delay(")), "piezo must not block");
+    }
+
+    #[test]
+    fn piezo_uses_default_frequency() {
+        let e = emit(&piezo("pz-1", json!({})), Some("v"));
+        assert!(e.loop_body.iter().any(|l| l.contains("440")));
+    }
+
+    #[test]
+    fn piezo_emits_deterministically() {
+        let n = piezo("pz-1", json!({ "frequency": 440 }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/output/pixel.rs
+++ b/apps/web/src-tauri/src/codegen/output/pixel.rs
@@ -1,0 +1,125 @@
+//! Pixel emitter — mirrors `runtime/output/pixel.rs`.
+//!
+//! The live Pixel drives an addressable `NeoPixel` strip (WS2812-style). It
+//! configures the strip length, pin and colour order, and pushes per-pixel
+//! colours, clearing the strip on initialize. The generated sketch uses the
+//! Adafruit `NeoPixel` library: it `#include <Adafruit_NeoPixel.h>`, declares a
+//! strip object sized to the configured length on the configured pin with the
+//! matching colour order, calls `begin()` + `clear()` + `show()` in `setup()`
+//! (mirroring the runtime's off-on-init), and — when wired from an upstream
+//! brightness value — fills the whole strip with that grayscale level each loop.
+
+use crate::codegen::emit::{pin_or_default, u16_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default pin matches `runtime/output/pixel.rs::default_pin` (6).
+const DEFAULT_PIN: u8 = 6;
+/// Default length matches `runtime/output/pixel.rs::default_length` (32).
+const DEFAULT_LENGTH: u16 = 32;
+
+/// Map the configured colour-order string to the `NeoPixel` type flag.
+fn neo_color_flag(node: &FlowNode) -> &'static str {
+    let order = node
+        .data
+        .get("color_order")
+        .or_else(|| node.data.get("colorOrder"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("GRB")
+        .to_ascii_uppercase();
+    match order.as_str() {
+        "RGB" => "NEO_RGB + NEO_KHZ800",
+        "BRG" => "NEO_BRG + NEO_KHZ800",
+        // GRB is the WS2812 default and the runtime default.
+        _ => "NEO_GRB + NEO_KHZ800",
+    }
+}
+
+/// Emit C++ for a Pixel Node. `driver` is an optional grayscale brightness
+/// (0..=255) applied to every pixel; `None` leaves the strip cleared.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let obj = format!("pixel_{token}");
+    let pin = pin_or_default(node, DEFAULT_PIN);
+    let length = u16_or_default(node, "length", DEFAULT_LENGTH).max(1);
+    let flag = neo_color_flag(node);
+    let i = format!("pixel_{token}_i");
+
+    let mut e = NodeEmission {
+        includes: vec!["#include <Adafruit_NeoPixel.h>".to_string()],
+        declarations: vec![format!(
+            "Adafruit_NeoPixel {obj}({length}, {pin}, {flag});"
+        )],
+        setup: vec![
+            format!("{obj}.begin();"),
+            // Mirror runtime initialize: cleared.
+            format!("{obj}.clear();"),
+            format!("{obj}.show();"),
+        ],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        let level = format!("constrain((int)({expr}), 0, 255)");
+        e.loop_body.push(format!("int {token}_level = {level};"));
+        e.loop_body.push(format!(
+            "for (uint16_t {i} = 0; {i} < {length}; {i}++) {{"
+        ));
+        e.loop_body.push(format!(
+            "  {obj}.setPixelColor({i}, {obj}.Color({token}_level, {token}_level, {token}_level));"
+        ));
+        e.loop_body.push("}".to_string());
+        e.loop_body.push(format!("{obj}.show();"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn pixel(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Pixel".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn pixel_includes_library_and_declares_strip() {
+        let e = emit(&pixel("px-1", json!({ "pin": 6, "length": 16 })), None);
+        assert!(e.includes.iter().any(|i| i.contains("Adafruit_NeoPixel.h")));
+        assert!(e.declarations.iter().any(|d| d.contains("Adafruit_NeoPixel pixel_px_1(16, 6")));
+    }
+
+    #[test]
+    fn pixel_begins_and_clears_on_setup() {
+        let e = emit(&pixel("px-1", json!({})), None);
+        assert!(e.setup.iter().any(|s| s.contains(".begin()")));
+        assert!(e.setup.iter().any(|s| s.contains(".clear()")));
+    }
+
+    #[test]
+    fn pixel_fills_strip_from_value() {
+        let e = emit(&pixel("px-1", json!({ "length": 8 })), Some("sensor_x_value"));
+        assert!(e.loop_body.iter().any(|l| l.contains("setPixelColor")));
+        assert!(e.loop_body.iter().any(|l| l.contains("sensor_x_value")));
+        assert!(e.loop_body.iter().any(|l| l.contains(".show()")));
+    }
+
+    #[test]
+    fn pixel_honours_color_order() {
+        let e = emit(&pixel("px-1", json!({ "color_order": "RGB" })), None);
+        assert!(e.declarations.iter().any(|d| d.contains("NEO_RGB")));
+    }
+
+    #[test]
+    fn pixel_emits_deterministically() {
+        let n = pixel("px-1", json!({ "length": 12 }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/output/rgb.rs
+++ b/apps/web/src-tauri/src/codegen/output/rgb.rs
@@ -1,0 +1,127 @@
+//! Rgb emitter — mirrors `runtime/output/rgb.rs`.
+//!
+//! The live RGB LED drives three PWM pins (red/green/blue). It sets each pin to
+//! PWM mode and turns the LED off on initialize. A common-anode (`isAnode`) LED
+//! is active-low, so its channel writes are inverted (`255 - value`). The
+//! generated sketch declares the three pin constants, sets them OUTPUT, writes
+//! them off in `setup()`, and — when wired from a single upstream value — drives
+//! all three channels with that brightness via `analogWrite`, honouring the
+//! anode inversion so emitted behavior matches the runtime.
+
+use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Channel pin defaults match `runtime/output/rgb.rs` (red=9, green=10, blue=11).
+const DEFAULT_RED: u8 = 9;
+const DEFAULT_GREEN: u8 = 10;
+const DEFAULT_BLUE: u8 = 11;
+
+/// Read a channel pin from `data.pins.<channel>` with the runtime default.
+fn channel_pin(node: &FlowNode, channel: &str, default: u8) -> u8 {
+    node.data
+        .get("pins")
+        .and_then(|p| p.get(channel))
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|n| u8::try_from(n).ok())
+        .unwrap_or(default)
+}
+
+/// True when the LED is common-anode (active-low channels).
+fn is_anode(node: &FlowNode) -> bool {
+    node.data.get("isAnode").and_then(serde_json::Value::as_bool).unwrap_or(false)
+}
+
+/// Emit C++ for an Rgb Node. `driver` is an optional brightness expression
+/// (0..=255) applied to every channel; `None` leaves the LED off.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let red = format!("rgb_{token}_red_pin");
+    let green = format!("rgb_{token}_green_pin");
+    let blue = format!("rgb_{token}_blue_pin");
+    let anode = is_anode(node);
+    // Off level: common-anode is active-low, so "off" is 255.
+    let off = if anode { 255 } else { 0 };
+
+    let mut e = NodeEmission {
+        declarations: vec![
+            format!("const uint8_t {red} = {};", channel_pin(node, "red", DEFAULT_RED)),
+            format!("const uint8_t {green} = {};", channel_pin(node, "green", DEFAULT_GREEN)),
+            format!("const uint8_t {blue} = {};", channel_pin(node, "blue", DEFAULT_BLUE)),
+        ],
+        setup: vec![
+            format!("pinMode({red}, OUTPUT);"),
+            format!("pinMode({green}, OUTPUT);"),
+            format!("pinMode({blue}, OUTPUT);"),
+            // Mirror runtime initialize: start off.
+            format!("analogWrite({red}, {off});"),
+            format!("analogWrite({green}, {off});"),
+            format!("analogWrite({blue}, {off});"),
+        ],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        // Common-anode inverts the duty cycle.
+        let level = if anode {
+            format!("(255 - constrain((int)({expr}), 0, 255))")
+        } else {
+            format!("constrain((int)({expr}), 0, 255)")
+        };
+        e.loop_body.push(format!("analogWrite({red}, {level});"));
+        e.loop_body.push(format!("analogWrite({green}, {level});"));
+        e.loop_body.push(format!("analogWrite({blue}, {level});"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn rgb(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Rgb".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn rgb_sets_three_pwm_pins_and_starts_off() {
+        let e = emit(&rgb("rgb-1", json!({})), None);
+        assert_eq!(e.setup.iter().filter(|s| s.contains("pinMode")).count(), 3);
+        assert!(e.declarations.iter().any(|d| d.contains("= 9;")));
+        assert!(e.setup.iter().filter(|s| s.contains("analogWrite") && s.contains(", 0)")).count() >= 3);
+    }
+
+    #[test]
+    fn rgb_drives_all_channels_from_value() {
+        let e = emit(&rgb("rgb-1", json!({})), Some("sensor_x_value"));
+        assert_eq!(e.loop_body.iter().filter(|l| l.contains("analogWrite") && l.contains("sensor_x_value")).count(), 3);
+    }
+
+    #[test]
+    fn rgb_anode_inverts_levels() {
+        let e = emit(&rgb("rgb-1", json!({ "isAnode": true })), Some("v"));
+        assert!(e.loop_body.iter().any(|l| l.contains("255 -")));
+        assert!(e.setup.iter().any(|s| s.contains("analogWrite") && s.contains(", 255)")));
+    }
+
+    #[test]
+    fn rgb_reads_custom_pins() {
+        let e = emit(&rgb("rgb-1", json!({ "pins": { "red": 3, "green": 5, "blue": 6 } })), None);
+        assert!(e.declarations.iter().any(|d| d.contains("= 3;")));
+        assert!(e.declarations.iter().any(|d| d.contains("= 5;")));
+        assert!(e.declarations.iter().any(|d| d.contains("= 6;")));
+    }
+
+    #[test]
+    fn rgb_emits_deterministically() {
+        let n = rgb("rgb-1", json!({ "isAnode": true }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/output/stepper.rs
+++ b/apps/web/src-tauri/src/codegen/output/stepper.rs
@@ -1,0 +1,112 @@
+//! Stepper emitter — mirrors `runtime/output/stepper.rs`.
+//!
+//! The live Stepper drives a stepper motor through Firmata's `AccelStepper`
+//! protocol — configuring the interface (step/direction driver or 4-wire), max
+//! speed and acceleration, then moving to absolute/relative positions. The
+//! generated sketch uses the Arduino `AccelStepper` library directly: it
+//! `#include <AccelStepper.h>`, declares the motor with the matching interface
+//! and pins, sets max speed + acceleration in `setup()`, and — when wired from
+//! an upstream value — targets that position and calls `run()` every loop. `run()`
+//! steps at most once per call and returns immediately, so motion is fully
+//! non-blocking and other Nodes keep ticking.
+
+use crate::codegen::emit::{f64_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Pin defaults match `runtime/output/stepper.rs` (step=2, dir=3).
+const DEFAULT_STEP_PIN: u8 = 2;
+const DEFAULT_DIR_PIN: u8 = 3;
+
+fn pin(node: &FlowNode, key: &str, default: u8) -> u8 {
+    node.data
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|n| u8::try_from(n).ok())
+        .unwrap_or(default)
+}
+
+/// Emit C++ for a Stepper Node. `driver` is an optional target-position
+/// expression (absolute step count); `None` leaves the motor parked at zero.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let obj = format!("stepper_{token}");
+    let step_pin = pin(node, "step_pin", DEFAULT_STEP_PIN);
+    let dir_pin = pin(node, "dir_pin", DEFAULT_DIR_PIN);
+    // Runtime stores speed/acceleration as floats; default to library-sane values.
+    let speed = f64_or_default(node, "speed", 1000.0);
+    let acceleration = f64_or_default(node, "acceleration", 500.0);
+    let speed = crate::codegen::emit::cpp_double(speed);
+    let acceleration = crate::codegen::emit::cpp_double(acceleration);
+
+    let mut e = NodeEmission {
+        includes: vec!["#include <AccelStepper.h>".to_string()],
+        declarations: vec![format!(
+            "AccelStepper {obj}(AccelStepper::DRIVER, {step_pin}, {dir_pin});"
+        )],
+        setup: vec![
+            format!("{obj}.setMaxSpeed({speed});"),
+            format!("{obj}.setAcceleration({acceleration});"),
+        ],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        // Non-blocking: moveTo sets the target, run() steps at most once per call.
+        e.loop_body.push(format!("{obj}.moveTo((long)({expr}));"));
+    }
+    // The motor must keep stepping toward its target every loop, even when
+    // unconnected (no-op until a target is set), so always emit run().
+    e.loop_body.push(format!("{obj}.run();"));
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn stepper(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Stepper".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn stepper_includes_library_and_declares_motor() {
+        let e = emit(&stepper("st-1", json!({})), None);
+        assert!(e.includes.iter().any(|i| i.contains("AccelStepper.h")));
+        assert!(e.declarations.iter().any(|d| d.contains("AccelStepper stepper_st_1(AccelStepper::DRIVER, 2, 3)")));
+    }
+
+    #[test]
+    fn stepper_sets_speed_and_acceleration() {
+        let e = emit(&stepper("st-1", json!({ "speed": 800, "acceleration": 200 })), None);
+        assert!(e.setup.iter().any(|s| s.contains("setMaxSpeed(800")));
+        assert!(e.setup.iter().any(|s| s.contains("setAcceleration(200")));
+    }
+
+    #[test]
+    fn stepper_targets_value_and_runs_non_blocking() {
+        let e = emit(&stepper("st-1", json!({})), Some("sensor_x_value"));
+        assert!(e.loop_body.iter().any(|l| l.contains("moveTo") && l.contains("sensor_x_value")));
+        assert!(e.loop_body.iter().any(|l| l.contains(".run()")));
+        assert!(!e.loop_body.iter().any(|l| l.contains("delay(")), "stepper must not block");
+    }
+
+    #[test]
+    fn stepper_runs_even_when_unconnected() {
+        let e = emit(&stepper("st-1", json!({})), None);
+        assert!(e.loop_body.iter().any(|l| l.contains(".run()")));
+    }
+
+    #[test]
+    fn stepper_emits_deterministically() {
+        let n = stepper("st-1", json!({ "speed": 1000 }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/transformation/calculate.rs
+++ b/apps/web/src-tauri/src/codegen/transformation/calculate.rs
@@ -1,0 +1,111 @@
+//! Calculate emitter — mirrors `runtime/transformation/calculate.rs`.
+//!
+//! The live Calculate Node aggregates its inputs and applies an arithmetic
+//! function (`add`, `subtract`, `multiply`, `divide`, `modulo`, `max`, `min`,
+//! `pow`, `ceil`, `floor`, `round`), storing the result as its `Number` value.
+//!
+//! The generated value-passing model feeds a single driver expression into each
+//! transformation Node (the wired source with the smallest id). With a single
+//! input the runtime's fold semantics reduce to: `subtract`/`divide`/`modulo`
+//! return `inputs[0]` unchanged (the fold body is skipped), `add`/`max`/`min`
+//! return the value itself, `multiply` returns the value, `pow` returns the
+//! value (fewer than two inputs), and `ceil`/`floor`/`round` apply their unary
+//! math. We emit the matching single-input C++ so the Sketch reproduces what
+//! the Flow Author observes when one signal drives the Node.
+
+use crate::codegen::emit::{str_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `double` variable holding this Calculate Node's latest result.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("calculate_{}_value", node.id_token())
+}
+
+/// Build the C++ expression for the configured function applied to a single
+/// input value `v` (the driver expression). Mirrors the runtime's single-input
+/// fold semantics.
+fn function_expr(function: &str, v: &str) -> String {
+    match function {
+        // Unary math functions.
+        "ceil" => format!("ceil({v})"),
+        "floor" => format!("floor({v})"),
+        "round" => format!("round({v})"),
+        // Multi-input folds collapse to the first input when only one is wired.
+        // `add`/`subtract`/`multiply`/`divide`/`modulo`/`max`/`min`/`pow` all
+        // yield the input value itself for a single input.
+        _ => format!("({v})"),
+    }
+}
+
+/// Emit C++ for a Calculate Node. `driver` is the C++ numeric expression that
+/// feeds the Node, or `None` when nothing is wired in (the runtime leaves the
+/// value at its `0.0` initial state).
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let var = value_var(node);
+    let function = str_or_default(node, "function", "add");
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("double {var} = 0.0;")],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        let computed = function_expr(&function, &format!("(double)({expr})"));
+        e.loop_body.push(format!("{var} = {computed};"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn calc(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Calculate".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn declares_output_variable() {
+        let e = emit(&calc("c-1", json!({ "function": "add" })), None);
+        assert!(e.declarations.iter().any(|d| d.contains("calculate_c_1_value")));
+    }
+
+    #[test]
+    fn add_passes_single_input_through() {
+        let e = emit(&calc("c-1", json!({ "function": "add" })), Some("sensor_s_1_value"));
+        assert!(e.loop_body.iter().any(|l| l.contains("sensor_s_1_value")));
+        assert!(!e.loop_body.iter().any(|l| l.contains("ceil")));
+    }
+
+    #[test]
+    fn ceil_floor_round_emit_unary_math() {
+        for func in ["ceil", "floor", "round"] {
+            let e = emit(&calc("c-1", json!({ "function": func })), Some("x"));
+            assert!(
+                e.loop_body.iter().any(|l| l.contains(func)),
+                "expected {func} call"
+            );
+        }
+    }
+
+    #[test]
+    fn no_driver_emits_no_loop_body() {
+        let e = emit(&calc("c-1", json!({ "function": "add" })), None);
+        assert!(e.loop_body.is_empty());
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = calc("c-1", json!({ "function": "multiply" }));
+        assert_eq!(emit(&n, Some("x")), emit(&n, Some("x")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/transformation/compare.rs
+++ b/apps/web/src-tauri/src/codegen/transformation/compare.rs
@@ -1,0 +1,167 @@
+//! Compare emitter — mirrors `runtime/transformation/compare.rs`.
+//!
+//! The live Compare Node validates its input against a configured `validator`
+//! and `subValidator`, storing a `Bool` result:
+//! - `boolean` — truthiness of the input.
+//! - `number` — `greater than` / `less than` / (default) equals `number`.
+//! - `oddeven` — `odd` / (default) even, on the rounded input.
+//! - `range` — `outside` the `[min, max]` bounds / (default) strictly inside.
+//! - `text` — string predicates; not expressible against the numeric/boolean
+//!   driver expressions of the generated value model, so it emits the runtime's
+//!   `false` default for an empty match.
+//!
+//! The generated Sketch stores the boolean outcome in a `bool` variable that
+//! downstream Nodes read, reproducing the live comparison for the wired input.
+
+use crate::codegen::emit::{cpp_double, f64_or_default, str_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `bool` variable holding this Compare Node's latest outcome.
+#[must_use]
+pub fn state_var(node: &FlowNode) -> String {
+    format!("compare_{}_result", node.id_token())
+}
+
+/// Build the C++ boolean expression for the configured comparison applied to
+/// the driver expression `v`.
+fn compare_expr(node: &FlowNode, v: &str) -> String {
+    let validator = str_or_default(node, "validator", "boolean");
+    let sub = str_or_default(node, "subValidator", "true");
+    match validator.as_str() {
+        "number" => {
+            let n = cpp_double(f64_or_default(node, "number", 0.0));
+            match sub.as_str() {
+                "greater than" => format!("((double)({v}) > {n})"),
+                "less than" => format!("((double)({v}) < {n})"),
+                _ => format!("((double)({v}) == {n})"),
+            }
+        }
+        "oddeven" => {
+            // Round to nearest integer first, matching `as i64` after `round()`.
+            let rounded = format!("((long)round((double)({v})))");
+            match sub.as_str() {
+                "odd" => format!("(({rounded} % 2) != 0)"),
+                _ => format!("(({rounded} % 2) == 0)"),
+            }
+        }
+        "range" => {
+            let min = cpp_double(f64_or_default_nested(node, "min", 0.0));
+            let max = cpp_double(f64_or_default_nested(node, "max", 100.0));
+            match sub.as_str() {
+                "outside" => format!("((double)({v}) < {min} || (double)({v}) > {max})"),
+                _ => format!("((double)({v}) > {min} && (double)({v}) < {max})"),
+            }
+        }
+        "text" => "false".to_string(),
+        // `boolean` (default): truthiness of the input.
+        _ => format!("((bool)({v}))"),
+    }
+}
+
+/// Read a numeric field from the nested `range` config object, falling back to
+/// `default` (mirrors `RangeConfig` defaults: `min` 0, `max` 100).
+fn f64_or_default_nested(node: &FlowNode, key: &str, default: f64) -> f64 {
+    node.data
+        .get("range")
+        .and_then(|r| r.get(key))
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(default)
+}
+
+/// Emit C++ for a Compare Node. `driver` is the wired input expression, or
+/// `None` when nothing is connected (the runtime leaves the result at `false`).
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let var = state_var(node);
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("bool {var} = false;")],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        let computed = compare_expr(node, expr);
+        e.loop_body.push(format!("{var} = {computed};"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn cmp(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Compare".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn boolean_validator_uses_truthiness() {
+        let e = emit(&cmp("c-1", json!({ "validator": "boolean" })), Some("x"));
+        assert!(e.loop_body.iter().any(|l| l.contains("(bool)")));
+    }
+
+    #[test]
+    fn number_greater_than_emits_comparison() {
+        let e = emit(
+            &cmp("c-1", json!({ "validator": "number", "subValidator": "greater than", "number": 5.0 })),
+            Some("v"),
+        );
+        assert!(e.loop_body.iter().any(|l| l.contains("> 5.0")));
+    }
+
+    #[test]
+    fn number_less_than_and_equals() {
+        let lt = emit(
+            &cmp("c-1", json!({ "validator": "number", "subValidator": "less than", "number": 2.0 })),
+            Some("v"),
+        );
+        assert!(lt.loop_body.iter().any(|l| l.contains("< 2.0")));
+        let eq = emit(
+            &cmp("c-1", json!({ "validator": "number", "subValidator": "equal", "number": 3.0 })),
+            Some("v"),
+        );
+        assert!(eq.loop_body.iter().any(|l| l.contains("== 3.0")));
+    }
+
+    #[test]
+    fn oddeven_emits_modulo() {
+        let odd = emit(&cmp("c-1", json!({ "validator": "oddeven", "subValidator": "odd" })), Some("v"));
+        assert!(odd.loop_body.iter().any(|l| l.contains("% 2) != 0")));
+        let even = emit(&cmp("c-1", json!({ "validator": "oddeven", "subValidator": "even" })), Some("v"));
+        assert!(even.loop_body.iter().any(|l| l.contains("% 2) == 0")));
+    }
+
+    #[test]
+    fn range_inside_and_outside() {
+        let inside = emit(
+            &cmp("c-1", json!({ "validator": "range", "range": { "min": 1.0, "max": 9.0 } })),
+            Some("v"),
+        );
+        assert!(inside.loop_body.iter().any(|l| l.contains("> 1.0") && l.contains("< 9.0")));
+        let outside = emit(
+            &cmp("c-1", json!({ "validator": "range", "subValidator": "outside", "range": { "min": 1.0, "max": 9.0 } })),
+            Some("v"),
+        );
+        assert!(outside.loop_body.iter().any(|l| l.contains("||")));
+    }
+
+    #[test]
+    fn no_driver_leaves_false() {
+        let e = emit(&cmp("c-1", json!({ "validator": "boolean" })), None);
+        assert!(e.loop_body.is_empty());
+        assert!(e.declarations.iter().any(|d| d.contains("= false;")));
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = cmp("c-1", json!({ "validator": "number", "number": 1.0 }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/transformation/function.rs
+++ b/apps/web/src-tauri/src/codegen/transformation/function.rs
@@ -1,0 +1,643 @@
+//! Function emitter — translates the user-authored JS of a Function Node into
+//! C++ for the generated Sketch (Task #36), the codegen mirror of
+//! `runtime/transformation/function.rs`.
+//!
+//! The live Function Node evaluates arbitrary JavaScript via `boa_engine`. That
+//! cannot be reproduced on a bare board, so this emitter translates only a
+//! deterministic **expression subset** that maps cleanly onto C++ `double`
+//! arithmetic. Anything outside the subset is never guessed at: the Node emits
+//! a clearly-marked `// unsupported` region and leaves its value at the
+//! runtime's `0.0` initial state, so the Sketch never contains broken or
+//! silently-wrong C++.
+//!
+//! ## Supported subset
+//!
+//! The Node's `code` must be a body of zero or more simple bindings followed by
+//! a single `return`:
+//!
+//! ```js
+//! const a = input * 2;
+//! let b = a + 1;
+//! return b > 10 ? a : b;
+//! ```
+//!
+//! Within an expression the subset allows:
+//! - the `input` identifier and any identifier bound earlier in the body,
+//! - numeric literals (`5`, `2.5`), `true`/`false`,
+//! - arithmetic `+ - * / %`, unary `-`/`!`,
+//! - comparisons `> < >= <= == === != !==`,
+//! - logical `&& ||`, a ternary `?:`, and parentheses,
+//! - the unary `Math.*` helpers `floor`, `ceil`, `round`, `abs`, `sqrt` and the
+//!   binary `Math.min`, `Math.max`, `Math.pow`,
+//! - the runtime builtins `toNumber(x)` / `toBool(x)` (single-argument form).
+//!
+//! Everything else — loops, objects, strings, `{{var}}` template slots, member
+//! access other than `Math.*`, and any other call — is unsupported.
+//!
+//! Like every other emitter this is a pure function of the [`FlowNode`]:
+//! identical input always yields identical output.
+
+use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `double` variable holding this Function Node's latest result.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("function_{}_value", node.id_token())
+}
+
+/// Emit C++ for a Function Node. `driver` is the C++ numeric expression that
+/// feeds the Node's `input`, or `None` when nothing is wired in (the runtime
+/// leaves the value at its `0.0` initial state).
+///
+/// On success the Node's value variable is assigned the translated expression
+/// in `loop()`. When the source falls outside the supported subset, a
+/// clearly-marked `// unsupported` comment is emitted instead and no assignment
+/// is produced — the value stays at `0.0`.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let var = value_var(node);
+    let token = node.id_token();
+    let mut e = NodeEmission {
+        declarations: vec![format!("double {var} = 0.0;")],
+        ..NodeEmission::default()
+    };
+
+    let code = node
+        .data
+        .get("code")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+
+    // The `input` C++ expression downstream code reads. With nothing wired in,
+    // the runtime evaluates the JS with `input = 0`, so we mirror that.
+    let input_expr = driver.map_or_else(|| "0.0".to_string(), |d| format!("(double)({d})"));
+
+    match translate(code, &input_expr) {
+        Ok(cpp) => {
+            e.loop_body.push(format!("{var} = (double)({cpp});"));
+        }
+        Err(reason) => {
+            e.declarations.push(format!(
+                "// unsupported Function Node {token}: {reason} — no C++ emitted; value stays 0.0"
+            ));
+        }
+    }
+    e
+}
+
+/// Translate the Function Node's JS body into a single C++ `double` expression,
+/// or return a human-readable reason it falls outside the supported subset.
+fn translate(code: &str, input_expr: &str) -> Result<String, String> {
+    let mut env: Vec<(String, String)> = vec![("input".to_string(), input_expr.to_string())];
+    let statements = split_statements(code)?;
+    let mut return_expr: Option<String> = None;
+
+    for stmt in statements {
+        if let Some(return_body) = stmt.strip_prefix_word("return") {
+            let expr = parse_expr(&return_body, &env)?;
+            return_expr = Some(expr);
+            break; // anything after `return` is unreachable / unsupported noise
+        } else if let Some((name, value_src)) = parse_binding(&stmt) {
+            let value = parse_expr(&value_src, &env)?;
+            // Shadow or add the binding so later statements can read it.
+            env.push((name, format!("({value})")));
+        } else {
+            return Err(format!("unsupported statement `{}`", stmt.trim()));
+        }
+    }
+
+    return_expr.ok_or_else(|| "function has no `return` statement".to_string())
+}
+
+/// A single source statement with whitespace-tolerant prefix matching.
+struct Statement(String);
+
+impl Statement {
+    /// If the statement starts with `word` as a whole keyword, return the rest.
+    fn strip_prefix_word(&self, word: &str) -> Option<String> {
+        let trimmed = self.0.trim();
+        let rest = trimmed.strip_prefix(word)?;
+        // The keyword must be followed by whitespace, `(`, or end — not be a
+        // prefix of a longer identifier (`returnValue`).
+        match rest.chars().next() {
+            None => Some(String::new()),
+            Some(c) if c.is_whitespace() || c == '(' => Some(rest.to_string()),
+            _ => None,
+        }
+    }
+
+    fn trim(&self) -> &str {
+        self.0.trim()
+    }
+}
+
+/// Split the body into statements on top-level `;`, stripping `//` line
+/// comments and rejecting block comments / braces (a quick subset gate).
+fn split_statements(code: &str) -> Result<Vec<Statement>, String> {
+    let mut cleaned = String::new();
+    for line in code.lines() {
+        let without_comment = match line.find("//") {
+            Some(i) => &line[..i],
+            None => line,
+        };
+        cleaned.push_str(without_comment);
+        cleaned.push('\n');
+    }
+    if cleaned.contains("/*") {
+        return Err("block comments are not supported".to_string());
+    }
+    if cleaned.contains('{') || cleaned.contains('}') {
+        return Err("blocks, objects, and functions are not supported".to_string());
+    }
+    Ok(cleaned
+        .split(';')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| Statement(s.to_string()))
+        .collect())
+}
+
+/// Parse a `const`/`let`/`var` binding into (name, value-source). Returns
+/// `None` if the statement is not a binding.
+fn parse_binding(stmt: &Statement) -> Option<(String, String)> {
+    let trimmed = stmt.trim();
+    let rest = ["const ", "let ", "var "]
+        .iter()
+        .find_map(|kw| trimmed.strip_prefix(kw))?;
+    let (name, value) = rest.split_once('=')?;
+    let name = name.trim();
+    if name.is_empty() || !is_identifier(name) {
+        return None;
+    }
+    Some((name.to_string(), value.trim().to_string()))
+}
+
+fn is_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+// --- Expression parser (recursive-descent over a token stream) ---
+
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    Num(String),
+    Ident(String),
+    Op(String),
+    LParen,
+    RParen,
+    Comma,
+    Question,
+    Colon,
+}
+
+fn tokenize(src: &str) -> Result<Vec<Token>, String> {
+    let chars: Vec<char> = src.chars().collect();
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        if c.is_whitespace() {
+            i += 1;
+        } else if c.is_ascii_digit()
+            || (c == '.' && i + 1 < chars.len() && chars[i + 1].is_ascii_digit())
+        {
+            let start = i;
+            while i < chars.len() && (chars[i].is_ascii_digit() || chars[i] == '.') {
+                i += 1;
+            }
+            tokens.push(Token::Num(chars[start..i].iter().collect()));
+        } else if c.is_ascii_alphabetic() || c == '_' {
+            let start = i;
+            while i < chars.len()
+                && (chars[i].is_ascii_alphanumeric() || chars[i] == '_' || chars[i] == '.')
+            {
+                i += 1;
+            }
+            tokens.push(Token::Ident(chars[start..i].iter().collect()));
+        } else {
+            match c {
+                '(' => tokens.push(Token::LParen),
+                ')' => tokens.push(Token::RParen),
+                ',' => tokens.push(Token::Comma),
+                '?' => tokens.push(Token::Question),
+                ':' => tokens.push(Token::Colon),
+                '+' | '-' | '*' | '/' | '%' => tokens.push(Token::Op(c.to_string())),
+                '>' | '<' | '=' | '!' | '&' | '|' => {
+                    let mut op = c.to_string();
+                    while i + 1 < chars.len() && matches!(chars[i + 1], '=' | '&' | '|') {
+                        // Consume multi-char operators (>=, ===, !==, &&, ||).
+                        op.push(chars[i + 1]);
+                        i += 1;
+                    }
+                    tokens.push(Token::Op(op));
+                }
+                _ => return Err(format!("unsupported character `{c}` in expression")),
+            }
+            i += 1;
+        }
+    }
+    Ok(tokens)
+}
+
+struct Parser<'a> {
+    tokens: Vec<Token>,
+    pos: usize,
+    env: &'a [(String, String)],
+}
+
+impl Parser<'_> {
+    fn peek(&self) -> Option<&Token> {
+        self.tokens.get(self.pos)
+    }
+
+    fn advance(&mut self) -> Option<Token> {
+        let t = self.tokens.get(self.pos).cloned();
+        if t.is_some() {
+            self.pos += 1;
+        }
+        t
+    }
+
+    fn expect(&mut self, want: &Token) -> Result<(), String> {
+        if self.peek() == Some(want) {
+            self.pos += 1;
+            Ok(())
+        } else {
+            Err(format!("expected {want:?} in expression"))
+        }
+    }
+
+    // ternary := logic_or ('?' ternary ':' ternary)?
+    fn parse_ternary(&mut self) -> Result<String, String> {
+        let cond = self.parse_binary(0)?;
+        if self.peek() == Some(&Token::Question) {
+            self.pos += 1;
+            let then_branch = self.parse_ternary()?;
+            self.expect(&Token::Colon)?;
+            let else_branch = self.parse_ternary()?;
+            return Ok(format!("(({cond}) ? ({then_branch}) : ({else_branch}))"));
+        }
+        Ok(cond)
+    }
+
+    /// Precedence-climbing for binary operators.
+    fn parse_binary(&mut self, min_prec: u8) -> Result<String, String> {
+        let mut lhs = self.parse_unary()?;
+        while let Some(Token::Op(op)) = self.peek() {
+            let Some(prec) = binary_prec(op) else { break };
+            if prec < min_prec {
+                break;
+            }
+            let op = op.clone();
+            self.pos += 1;
+            let rhs = self.parse_binary(prec + 1)?;
+            lhs = format!("({lhs} {} {rhs})", cpp_binary_op(&op));
+        }
+        Ok(lhs)
+    }
+
+    fn parse_unary(&mut self) -> Result<String, String> {
+        if let Some(Token::Op(op)) = self.peek() {
+            if op == "-" || op == "!" {
+                let op = op.clone();
+                self.pos += 1;
+                let operand = self.parse_unary()?;
+                return Ok(format!("({op}({operand}))"));
+            }
+        }
+        self.parse_primary()
+    }
+
+    fn parse_primary(&mut self) -> Result<String, String> {
+        match self.advance() {
+            Some(Token::Num(n)) => {
+                // Ensure a C++ double literal.
+                if n.contains('.') {
+                    Ok(n)
+                } else {
+                    Ok(format!("{n}.0"))
+                }
+            }
+            Some(Token::LParen) => {
+                let inner = self.parse_ternary()?;
+                self.expect(&Token::RParen)?;
+                Ok(format!("({inner})"))
+            }
+            Some(Token::Ident(name)) => self.parse_ident(&name),
+            other => Err(format!("unexpected token {other:?} in expression")),
+        }
+    }
+
+    fn parse_ident(&mut self, name: &str) -> Result<String, String> {
+        // A call?
+        if self.peek() == Some(&Token::LParen) {
+            return self.parse_call(name);
+        }
+        match name {
+            "true" => Ok("true".to_string()),
+            "false" => Ok("false".to_string()),
+            _ => self
+                .env
+                .iter()
+                .rev()
+                .find(|(k, _)| k == name)
+                .map(|(_, v)| v.clone())
+                .ok_or_else(|| format!("unknown identifier `{name}`")),
+        }
+    }
+
+    fn parse_call(&mut self, name: &str) -> Result<String, String> {
+        self.expect(&Token::LParen)?;
+        let mut args = Vec::new();
+        if self.peek() != Some(&Token::RParen) {
+            loop {
+                args.push(self.parse_ternary()?);
+                if self.peek() == Some(&Token::Comma) {
+                    self.pos += 1;
+                } else {
+                    break;
+                }
+            }
+        }
+        self.expect(&Token::RParen)?;
+        cpp_call(name, &args)
+    }
+}
+
+/// JS binary operator → C++ operator (same spelling, but `===`/`!==` collapse).
+fn cpp_binary_op(op: &str) -> &str {
+    match op {
+        "===" | "==" => "==",
+        "!==" | "!=" => "!=",
+        other => other,
+    }
+}
+
+/// Binary operator precedence (higher binds tighter). `None` → not a supported
+/// binary operator.
+fn binary_prec(op: &str) -> Option<u8> {
+    Some(match op {
+        "||" => 1,
+        "&&" => 2,
+        "==" | "===" | "!=" | "!==" => 3,
+        ">" | "<" | ">=" | "<=" => 4,
+        "+" | "-" => 5,
+        "*" | "/" | "%" => 6,
+        _ => return None,
+    })
+}
+
+/// Translate a supported call (`Math.*`, `toNumber`, `toBool`) into C++.
+fn cpp_call(name: &str, args: &[String]) -> Result<String, String> {
+    let unary = |f: &str| -> Result<String, String> {
+        match args {
+            [a] => Ok(format!("{f}((double)({a}))")),
+            _ => Err(format!("`{name}` expects one argument")),
+        }
+    };
+    let binary = |f: &str| -> Result<String, String> {
+        match args {
+            [a, b] => Ok(format!("{f}((double)({a}), (double)({b}))")),
+            _ => Err(format!("`{name}` expects two arguments")),
+        }
+    };
+    match name {
+        "Math.floor" => unary("floor"),
+        "Math.ceil" => unary("ceil"),
+        "Math.round" => unary("round"),
+        "Math.abs" => unary("fabs"),
+        "Math.sqrt" => unary("sqrt"),
+        "Math.min" => binary("min"),
+        "Math.max" => binary("max"),
+        "Math.pow" => binary("pow"),
+        // `toNumber(x)` → numeric coercion; `toBool(x)` → truthiness.
+        "toNumber" => unary(""),
+        "toBool" => match args {
+            [a] => Ok(format!("((bool)((double)({a})))")),
+            _ => Err("`toBool` expects one argument".to_string()),
+        },
+        _ => Err(format!("unsupported call `{name}`")),
+    }
+}
+
+/// Parse a full expression string against the binding environment.
+fn parse_expr(src: &str, env: &[(String, String)]) -> Result<String, String> {
+    let trimmed = src.trim();
+    if trimmed.is_empty() {
+        return Err("empty expression".to_string());
+    }
+    if trimmed.contains("{{") {
+        return Err("`{{var}}` template slots are not supported".to_string());
+    }
+    if trimmed.contains('"') || trimmed.contains('\'') || trimmed.contains('`') {
+        return Err("string literals are not supported".to_string());
+    }
+    let tokens = tokenize(trimmed)?;
+    let mut parser = Parser {
+        tokens,
+        pos: 0,
+        env,
+    };
+    let result = parser.parse_ternary()?;
+    if parser.pos != parser.tokens.len() {
+        return Err("trailing tokens in expression".to_string());
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn func(id: &str, code: &str) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Function".to_string()),
+            data: json!({ "code": code }),
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    fn loop_line(e: &NodeEmission) -> String {
+        e.loop_body.join("\n")
+    }
+
+    fn is_unsupported(e: &NodeEmission) -> bool {
+        e.declarations.iter().any(|d| d.contains("unsupported"))
+    }
+
+    #[test]
+    fn declares_output_variable() {
+        let e = emit(&func("fn-1", "return input;"), None);
+        assert!(e
+            .declarations
+            .iter()
+            .any(|d| d == "double function_fn_1_value = 0.0;"));
+    }
+
+    #[test]
+    fn value_var_uses_sanitized_id() {
+        assert_eq!(
+            value_var(&func("fn-1", "return input;")),
+            "function_fn_1_value"
+        );
+    }
+
+    #[test]
+    fn return_input_reads_driver() {
+        let e = emit(&func("fn-1", "return input;"), Some("sensor_s_value"));
+        let body = loop_line(&e);
+        assert!(body.contains("function_fn_1_value"));
+        assert!(
+            body.contains("sensor_s_value"),
+            "must read the driver, got: {body}"
+        );
+        assert!(!is_unsupported(&e));
+    }
+
+    #[test]
+    fn arithmetic_is_translated() {
+        let e = emit(&func("fn-1", "return input * 2 + 1;"), Some("x"));
+        let body = loop_line(&e);
+        assert!(body.contains('*') && body.contains('+'), "got: {body}");
+        assert!(!is_unsupported(&e));
+    }
+
+    #[test]
+    fn bindings_chain_into_return() {
+        let code = "const a = input * 2;\nconst b = a + 3;\nreturn b;";
+        let e = emit(&func("fn-1", code), Some("x"));
+        let body = loop_line(&e);
+        // `b` resolves to `a + 3` which resolves to `input * 2`.
+        assert!(body.contains('*'), "binding a inlined: {body}");
+        assert!(body.contains('+'), "binding b inlined: {body}");
+        assert!(!is_unsupported(&e));
+    }
+
+    #[test]
+    fn default_code_passthrough_is_supported() {
+        // The Node's default body: assigns input and returns it.
+        let code = "const value = input;\nreturn value;";
+        let e = emit(&func("fn-1", code), Some("driver"));
+        assert!(loop_line(&e).contains("driver"));
+        assert!(!is_unsupported(&e));
+    }
+
+    #[test]
+    fn comparison_and_ternary_are_translated() {
+        let e = emit(&func("fn-1", "return input > 10 ? 1 : 0;"), Some("x"));
+        let body = loop_line(&e);
+        assert!(
+            body.contains('>') && body.contains('?') && body.contains(':'),
+            "got: {body}"
+        );
+        assert!(!is_unsupported(&e));
+    }
+
+    #[test]
+    fn logical_operators_are_translated() {
+        let e = emit(&func("fn-1", "return input > 0 && input < 100;"), Some("x"));
+        assert!(loop_line(&e).contains("&&"));
+    }
+
+    #[test]
+    fn strict_equality_collapses_to_cpp_equality() {
+        let e = emit(&func("fn-1", "return input === 5 ? 1 : 0;"), Some("x"));
+        let body = loop_line(&e);
+        assert!(body.contains("=="), "got: {body}");
+        assert!(!body.contains("==="), "=== must collapse to ==, got: {body}");
+    }
+
+    #[test]
+    fn math_helpers_are_translated() {
+        let e = emit(&func("fn-1", "return Math.max(input, 0);"), Some("x"));
+        assert!(loop_line(&e).contains("max("), "Math.max → max");
+    }
+
+    #[test]
+    fn unary_negation_is_translated() {
+        let e = emit(&func("fn-1", "return -input;"), Some("x"));
+        assert!(loop_line(&e).contains('-'));
+    }
+
+    // --- Scenario: Unsupported Function logic is clearly marked ---
+
+    #[test]
+    fn loop_construct_is_marked_unsupported() {
+        let code = "let s = 0;\nfor (let i = 0; i < 10; i++) { s = s + i; }\nreturn s;";
+        let e = emit(&func("fn-1", code), Some("x"));
+        assert!(
+            e.declarations
+                .iter()
+                .any(|d| d.contains("unsupported Function Node fn_1")),
+            "loops must be marked unsupported, got: {:?}",
+            e.declarations
+        );
+        // No broken/guessed C++ is emitted for it.
+        assert!(e.loop_body.is_empty(), "no assignment for unsupported code");
+    }
+
+    #[test]
+    fn string_literal_is_marked_unsupported() {
+        let e = emit(&func("fn-1", "return \"hello\";"), Some("x"));
+        assert!(is_unsupported(&e));
+        assert!(e.loop_body.is_empty());
+    }
+
+    #[test]
+    fn template_slot_is_marked_unsupported() {
+        let e = emit(&func("fn-1", "return input + {{gain}};"), Some("x"));
+        assert!(is_unsupported(&e));
+        assert!(e.loop_body.is_empty());
+    }
+
+    #[test]
+    fn unknown_call_is_marked_unsupported() {
+        let e = emit(&func("fn-1", "return parseInt(input);"), Some("x"));
+        assert!(is_unsupported(&e));
+        assert!(e.loop_body.is_empty());
+    }
+
+    #[test]
+    fn missing_return_is_marked_unsupported() {
+        let e = emit(&func("fn-1", "const a = input;"), Some("x"));
+        assert!(is_unsupported(&e));
+        assert!(e.loop_body.is_empty());
+    }
+
+    #[test]
+    fn unknown_identifier_is_marked_unsupported() {
+        let e = emit(&func("fn-1", "return undeclared + 1;"), Some("x"));
+        assert!(is_unsupported(&e));
+        assert!(e.loop_body.is_empty());
+    }
+
+    #[test]
+    fn no_driver_uses_zero_input() {
+        // With nothing wired in the runtime evaluates with input = 0.
+        let e = emit(&func("fn-1", "return input + 1;"), None);
+        let body = loop_line(&e);
+        assert!(body.contains("0.0"), "input defaults to 0.0, got: {body}");
+        assert!(!is_unsupported(&e));
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = func("fn-1", "return input * 2 + 1;");
+        assert_eq!(emit(&n, Some("x")), emit(&n, Some("x")));
+    }
+
+    #[test]
+    fn unsupported_is_deterministic() {
+        let n = func("fn-1", "for (;;) {}\nreturn 1;");
+        assert_eq!(emit(&n, Some("x")), emit(&n, Some("x")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/transformation/gate.rs
+++ b/apps/web/src-tauri/src/codegen/transformation/gate.rs
@@ -1,0 +1,102 @@
+//! Gate emitter — mirrors `runtime/transformation/gate.rs`.
+//!
+//! The live Gate Node counts the truthy inputs and applies a boolean gate
+//! (`and`, `nand`, `or`, `xor`, `nor`, `xnor`) over `true_count` vs `total`.
+//!
+//! The generated value model feeds a single boolean driver into the Node
+//! (`total == 1`), so the gates collapse to: `and`/`or`/`xor` pass the input
+//! through (`true_count == total`, `> 0`, and `== 1` all equal the single
+//! input), while `nand`/`nor`/`xnor` invert it. We emit the matching
+//! single-input pass-through / inverting logic into a `bool` variable that
+//! downstream Nodes read, reproducing the live gate for the wired signal.
+
+use crate::codegen::emit::{str_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `bool` variable holding this Gate Node's latest outcome.
+#[must_use]
+pub fn state_var(node: &FlowNode) -> String {
+    format!("gate_{}_result", node.id_token())
+}
+
+/// Build the single-input C++ boolean expression for the configured gate over
+/// the driver expression `v`.
+fn gate_expr(gate: &str, v: &str) -> String {
+    match gate {
+        // Inverting gates for a single input.
+        "nand" | "nor" | "xnor" => format!("(!((bool)({v})))"),
+        // Pass-through gates for a single input (and / or / xor).
+        _ => format!("((bool)({v}))"),
+    }
+}
+
+/// Emit C++ for a Gate Node. `driver` is the wired boolean input, or `None`
+/// when nothing is connected (the runtime leaves the result at `false` because
+/// `check` is skipped for an empty input set).
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let var = state_var(node);
+    let gate = str_or_default(node, "gate", "and");
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("bool {var} = false;")],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        let computed = gate_expr(&gate, expr);
+        e.loop_body.push(format!("{var} = {computed};"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn gate(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Gate".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn and_or_xor_pass_through() {
+        for g in ["and", "or", "xor"] {
+            let e = emit(&gate("g-1", json!({ "gate": g })), Some("x"));
+            assert!(
+                e.loop_body.iter().any(|l| l.contains("(bool)(x)") && !l.contains("!(")),
+                "gate {g} should pass through"
+            );
+        }
+    }
+
+    #[test]
+    fn nand_nor_xnor_invert() {
+        for g in ["nand", "nor", "xnor"] {
+            let e = emit(&gate("g-1", json!({ "gate": g })), Some("x"));
+            assert!(
+                e.loop_body.iter().any(|l| l.contains("!((bool)(x))")),
+                "gate {g} should invert"
+            );
+        }
+    }
+
+    #[test]
+    fn no_driver_leaves_false() {
+        let e = emit(&gate("g-1", json!({ "gate": "and" })), None);
+        assert!(e.loop_body.is_empty());
+        assert!(e.declarations.iter().any(|d| d.contains("= false;")));
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = gate("g-1", json!({ "gate": "nand" }));
+        assert_eq!(emit(&n, Some("x")), emit(&n, Some("x")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/transformation/mod.rs
+++ b/apps/web/src-tauri/src/codegen/transformation/mod.rs
@@ -1,5 +1,5 @@
 //! Transformation-Node C++ emitters (Calculate, Compare, Gate, `RangeMap`,
-//! Smooth) — the codegen mirror of `runtime/transformation`.
+//! Smooth, Function) — the codegen mirror of `runtime/transformation`.
 //!
 //! Each transformation Node is both a consumer and a producer in the generated
 //! value-passing model: it reads the C++ expression of its wired source (its
@@ -16,6 +16,7 @@
 
 pub mod calculate;
 pub mod compare;
+pub mod function;
 pub mod gate;
 pub mod range_map;
 pub mod smooth;

--- a/apps/web/src-tauri/src/codegen/transformation/mod.rs
+++ b/apps/web/src-tauri/src/codegen/transformation/mod.rs
@@ -1,0 +1,21 @@
+//! Transformation-Node C++ emitters (Calculate, Compare, Gate, `RangeMap`,
+//! Smooth) — the codegen mirror of `runtime/transformation`.
+//!
+//! Each transformation Node is both a consumer and a producer in the generated
+//! value-passing model: it reads the C++ expression of its wired source (its
+//! `driver`) and writes its result into an output variable that downstream
+//! Nodes read. The output variable name is exposed by each module's
+//! `value_var`/`state_var` accessor so [`crate::codegen`] can wire it as a
+//! driver for the Node's targets.
+//!
+//! Like the input/output emitters, every emitter is a pure function of a single
+//! [`crate::runtime::types::FlowNode`] (plus its driver) and reads the same
+//! `data` the live runtime deserializes into its `*Config`. The emitted C++
+//! reproduces the runtime semantics so that, for identical inputs, the
+//! generated Sketch yields the same output the Flow Author sees in live mode.
+
+pub mod calculate;
+pub mod compare;
+pub mod gate;
+pub mod range_map;
+pub mod smooth;

--- a/apps/web/src-tauri/src/codegen/transformation/range_map.rs
+++ b/apps/web/src-tauri/src/codegen/transformation/range_map.rs
@@ -1,0 +1,131 @@
+//! `RangeMap` emitter — mirrors `runtime/transformation/range_map.rs`.
+//!
+//! The live `RangeMap` Node linearly remaps its input from a `from` range to a
+//! `to` range:
+//!
+//! ```text
+//! mapped = (input - from.min) * (to.max - to.min) / (from.max - from.min) + to.min
+//! ```
+//!
+//! then rounds `mapped` to a precision that depends on the output span: one
+//! decimal place when `|to.max - to.min| <= 10`, otherwise to the nearest whole
+//! number. It emits the normalized result as its `to` value. The runtime does
+//! not clamp — inputs at or beyond the `from` bounds extrapolate linearly — so
+//! the generated C++ mirrors that exact behavior (including the edge values).
+//!
+//! We emit the same arithmetic into a `double` variable downstream Nodes read.
+
+use crate::codegen::emit::{cpp_double, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `double` variable holding this `RangeMap` Node's mapped output.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("range_map_{}_value", node.id_token())
+}
+
+/// Read a numeric field from a nested range object (`from`/`to`) in the Node's
+/// `data`, falling back to `default`.
+fn range_field(node: &FlowNode, range: &str, key: &str, default: f64) -> f64 {
+    node.data
+        .get(range)
+        .and_then(|r| r.get(key))
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(default)
+}
+
+/// Emit C++ for a `RangeMap` Node. `driver` is the wired numeric input, or
+/// `None` when nothing is connected (the runtime leaves the value at `0.0`).
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let var = value_var(node);
+    // Mirror `Range` defaults: from 0..1023, to 0..1023.
+    let in_min = cpp_double(range_field(node, "from", "min", 0.0));
+    let in_max = cpp_double(range_field(node, "from", "max", 1023.0));
+    let out_min = cpp_double(range_field(node, "to", "min", 0.0));
+    let out_max = cpp_double(range_field(node, "to", "max", 1023.0));
+
+    // Precision factor: one decimal place when the output span is small, else
+    // whole numbers — matching the runtime's `distance <= 10.0` rule.
+    let distance = (range_field(node, "to", "max", 1023.0) - range_field(node, "to", "min", 0.0)).abs();
+    let factor = if distance <= 10.0 { "10.0" } else { "1.0" };
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("double {var} = 0.0;")],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        let mapped = format!(
+            "(((double)({expr}) - {in_min}) * ({out_max} - {out_min}) / ({in_max} - {in_min}) + {out_min})"
+        );
+        e.loop_body
+            .push(format!("{var} = round(({mapped}) * {factor}) / {factor};"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn rm(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("RangeMap".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn declares_output_variable() {
+        let e = emit(&rm("r-1", json!({})), None);
+        assert!(e.declarations.iter().any(|d| d.contains("range_map_r_1_value")));
+    }
+
+    #[test]
+    fn emits_linear_remap_math() {
+        let e = emit(
+            &rm("r-1", json!({ "from": { "min": 0.0, "max": 1023.0 }, "to": { "min": 0.0, "max": 255.0 } })),
+            Some("sensor_s_1_value"),
+        );
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("sensor_s_1_value"));
+        assert!(body.contains("1023.0"));
+        assert!(body.contains("255.0"));
+        assert!(body.contains("round("));
+    }
+
+    #[test]
+    fn small_output_span_uses_decimal_precision() {
+        let e = emit(
+            &rm("r-1", json!({ "from": { "min": 0.0, "max": 100.0 }, "to": { "min": 0.0, "max": 5.0 } })),
+            Some("v"),
+        );
+        assert!(e.loop_body.iter().any(|l| l.contains("* 10.0") && l.contains("/ 10.0")));
+    }
+
+    #[test]
+    fn large_output_span_uses_whole_numbers() {
+        let e = emit(
+            &rm("r-1", json!({ "from": { "min": 0.0, "max": 100.0 }, "to": { "min": 0.0, "max": 255.0 } })),
+            Some("v"),
+        );
+        assert!(e.loop_body.iter().any(|l| l.contains("* 1.0") && l.contains("/ 1.0")));
+    }
+
+    #[test]
+    fn no_driver_emits_no_loop_body() {
+        let e = emit(&rm("r-1", json!({})), None);
+        assert!(e.loop_body.is_empty());
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = rm("r-1", json!({ "to": { "min": 0.0, "max": 255.0 } }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/transformation/smooth.rs
+++ b/apps/web/src-tauri/src/codegen/transformation/smooth.rs
@@ -1,0 +1,151 @@
+//! Smooth emitter — mirrors `runtime/transformation/smooth.rs`.
+//!
+//! The live Smooth Node holds state across evaluations:
+//! - `smooth` (default) — exponential smoothing:
+//!   `result = attenuation * value + (1 - attenuation) * previous`,
+//!   seeded from the Node's running value.
+//! - `movingAverage` — the mean of the last `windowSize` inputs (a rolling
+//!   window that drops the oldest sample once full).
+//!
+//! Per the Feature's stateful-Node approach, the generated Sketch keeps a
+//! module-level state variable updated each loop iteration rather than
+//! recomputing from a full history. Exponential smoothing persists a single
+//! running `double`; the moving average persists a fixed-size ring buffer plus
+//! its fill count, reproducing the same rolling mean on-device. The output
+//! `double` is read by downstream Nodes.
+
+use crate::codegen::emit::{cpp_double, f64_or_default, str_or_default, u16_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// The C++ `double` variable holding this Smooth Node's latest output.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> String {
+    format!("smooth_{}_value", node.id_token())
+}
+
+/// Emit C++ for a Smooth Node. `driver` is the wired numeric input, or `None`
+/// when nothing is connected (the runtime leaves the value at `0.0`).
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let var = value_var(node);
+    let smooth_type = str_or_default(node, "type", "smooth");
+
+    if smooth_type == "movingAverage" {
+        return moving_average(node, &token, &var, driver);
+    }
+    exponential(node, &var, driver)
+}
+
+/// Exponential smoothing: a single persistent running value.
+fn exponential(node: &FlowNode, var: &str, driver: Option<&str>) -> NodeEmission {
+    let attenuation = cpp_double(f64_or_default(node, "attenuation", 0.995));
+
+    let mut e = NodeEmission {
+        declarations: vec![format!("double {var} = 0.0;")],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        e.loop_body.push(format!(
+            "{var} = {attenuation} * (double)({expr}) + (1.0 - {attenuation}) * {var};"
+        ));
+    }
+    e
+}
+
+/// Moving average over a fixed-size ring buffer plus fill count.
+fn moving_average(node: &FlowNode, token: &str, var: &str, driver: Option<&str>) -> NodeEmission {
+    // `windowSize` defaults to 25 in the runtime; guard against 0 to avoid a
+    // zero-length buffer / divide-by-zero in the emitted C++.
+    let window = u16_or_default(node, "windowSize", 25).max(1);
+    let buf = format!("smooth_{token}_window");
+    let idx = format!("smooth_{token}_index");
+    let count = format!("smooth_{token}_count");
+
+    let mut e = NodeEmission {
+        declarations: vec![
+            format!("double {buf}[{window}] = {{0}};"),
+            format!("int {idx} = 0;"),
+            format!("int {count} = 0;"),
+            format!("double {var} = 0.0;"),
+        ],
+        ..NodeEmission::default()
+    };
+
+    if let Some(expr) = driver {
+        e.loop_body.push(format!("{buf}[{idx}] = (double)({expr});"));
+        e.loop_body.push(format!("{idx} = ({idx} + 1) % {window};"));
+        e.loop_body
+            .push(format!("if ({count} < {window}) {{ {count}++; }}"));
+        e.loop_body.push(format!("double smooth_{token}_sum = 0.0;"));
+        e.loop_body
+            .push(format!("for (int i = 0; i < {count}; i++) {{ smooth_{token}_sum += {buf}[i]; }}"));
+        e.loop_body
+            .push(format!("{var} = smooth_{token}_sum / {count};"));
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn smooth(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Smooth".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    #[test]
+    fn exponential_persists_running_value() {
+        let e = emit(&smooth("s-1", json!({ "type": "smooth", "attenuation": 0.9 })), Some("v"));
+        // Decl is a single persistent double; loop updates it from itself.
+        assert!(e.declarations.iter().any(|d| d.contains("smooth_s_1_value")));
+        assert!(e.loop_body.iter().any(|l| l.contains("0.9") && l.contains("smooth_s_1_value")));
+    }
+
+    #[test]
+    fn moving_average_uses_ring_buffer() {
+        let e = emit(
+            &smooth("s-1", json!({ "type": "movingAverage", "windowSize": 5 })),
+            Some("v"),
+        );
+        assert!(e.declarations.iter().any(|d| d.contains("smooth_s_1_window[5]")));
+        assert!(e.loop_body.iter().any(|l| l.contains("% 5")));
+        assert!(e.loop_body.iter().any(|l| l.contains("sum")));
+    }
+
+    #[test]
+    fn moving_average_guards_zero_window() {
+        let e = emit(
+            &smooth("s-1", json!({ "type": "movingAverage", "windowSize": 0 })),
+            Some("v"),
+        );
+        assert!(e.declarations.iter().any(|d| d.contains("smooth_s_1_window[1]")));
+    }
+
+    #[test]
+    fn default_type_is_exponential() {
+        let e = emit(&smooth("s-1", json!({})), Some("v"));
+        assert!(e.loop_body.iter().any(|l| l.contains("0.995")));
+    }
+
+    #[test]
+    fn no_driver_emits_no_loop_body() {
+        let e = emit(&smooth("s-1", json!({})), None);
+        assert!(e.loop_body.is_empty());
+        assert!(e.declarations.iter().any(|d| d.contains("= 0.0;")));
+    }
+
+    #[test]
+    fn emits_deterministically() {
+        let n = smooth("s-1", json!({ "type": "movingAverage", "windowSize": 3 }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/tests/codegen_parity.rs
+++ b/apps/web/src-tauri/tests/codegen_parity.rs
@@ -1,0 +1,570 @@
+//! Behaviour-parity tests — live runtime vs generated sketch (Task #40).
+//!
+//! For each representative non-Cloud Node type these tests feed the *same*
+//! inputs to (a) the live-runtime component impl and (b) a deterministic model
+//! of the C++ the codegen emitter produces, then assert the observable outputs
+//! match. This is the primary mitigation against semantic drift between the two
+//! modes: the generated Sketch must reproduce what the Flow Author sees live.
+//!
+//! ## How the comparison is meaningful without a C++ compiler
+//!
+//! The Epic explicitly puts on-hardware flashing / `arduino-cli` out of scope,
+//! so we cannot run the emitted `.ino` here. Instead — per the Task's Technical
+//! Approach — we evaluate the *exact* C++ expression the emitter writes into the
+//! sketch `loop()` against a tiny interpreter implementing the Arduino/C++
+//! numeric and boolean subset the emitters use (casts, `%`, `&&`/`||`/`!`,
+//! `ceil`/`floor`/`round`, comparison). Because the interpreter consumes the
+//! emitter's real output (extracted from [`app_lib::codegen::generate`]) and the
+//! runtime config is deserialized from the *same* Node `data`, any divergence
+//! between emitter and runtime fails the suite and names the diverging Node.
+
+use app_lib::codegen::generate;
+use app_lib::runtime::base::{Component, ComponentValue};
+use app_lib::runtime::types::{FlowEdge, FlowNode, FlowUpdate, Position};
+use app_lib::runtime::{
+    Calculate, CalculateConfig, Compare, CompareConfig, Gate, GateConfig, RangeMap, RangeMapConfig,
+};
+use serde_json::json;
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Tiny C++ expression interpreter
+// ---------------------------------------------------------------------------
+//
+// Supports the operator/function subset the codegen emitters actually produce:
+//   - numeric literals and the bound input variable(s)
+//   - unary `!`, casts `(double)`/`(bool)`/`(long)`, parentheses
+//   - `* / % + -`, comparison `> < == >= <=`, `&& ||`
+//   - calls `ceil(x)`, `floor(x)`, `round(x)`, `abs(x)`
+// Booleans are represented as `1.0` / `0.0`, matching C++ truthiness.
+
+struct Parser<'a> {
+    src: &'a [u8],
+    pos: usize,
+    vars: &'a HashMap<String, f64>,
+}
+
+impl Parser<'_> {
+    fn eval(src: &str, vars: &HashMap<String, f64>) -> f64 {
+        let mut p = Parser { src: src.as_bytes(), pos: 0, vars };
+        let v = p.parse_or();
+        p.skip_ws();
+        assert!(p.pos >= p.src.len(), "unparsed C++ tail in `{src}` at byte {}", p.pos);
+        v
+    }
+
+    fn skip_ws(&mut self) {
+        while self.pos < self.src.len() && self.src[self.pos].is_ascii_whitespace() {
+            self.pos += 1;
+        }
+    }
+
+    fn peek(&mut self) -> Option<u8> {
+        self.skip_ws();
+        self.src.get(self.pos).copied()
+    }
+
+    fn eat(&mut self, s: &str) -> bool {
+        self.skip_ws();
+        if self.src[self.pos..].starts_with(s.as_bytes()) {
+            self.pos += s.len();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn parse_or(&mut self) -> f64 {
+        let mut v = self.parse_and();
+        while self.eat("||") {
+            let r = self.parse_and();
+            v = f64::from((v != 0.0) || (r != 0.0));
+        }
+        v
+    }
+
+    fn parse_and(&mut self) -> f64 {
+        let mut v = self.parse_cmp();
+        while self.eat("&&") {
+            let r = self.parse_cmp();
+            v = f64::from((v != 0.0) && (r != 0.0));
+        }
+        v
+    }
+
+    fn parse_cmp(&mut self) -> f64 {
+        let l = self.parse_add();
+        // Two-char operators must be matched before their one-char prefixes.
+        if self.eat("==") {
+            return f64::from((l - self.parse_add()).abs() < f64::EPSILON);
+        }
+        if self.eat("!=") {
+            return f64::from((l - self.parse_add()).abs() >= f64::EPSILON);
+        }
+        if self.eat(">=") {
+            return f64::from(l >= self.parse_add());
+        }
+        if self.eat("<=") {
+            return f64::from(l <= self.parse_add());
+        }
+        if self.eat(">") {
+            return f64::from(l > self.parse_add());
+        }
+        if self.eat("<") {
+            return f64::from(l < self.parse_add());
+        }
+        l
+    }
+
+    fn parse_add(&mut self) -> f64 {
+        let mut v = self.parse_mul();
+        loop {
+            match self.peek() {
+                Some(b'+') => {
+                    self.pos += 1;
+                    v += self.parse_mul();
+                }
+                Some(b'-') => {
+                    self.pos += 1;
+                    v -= self.parse_mul();
+                }
+                _ => break,
+            }
+        }
+        v
+    }
+
+    fn parse_mul(&mut self) -> f64 {
+        let mut v = self.parse_unary();
+        loop {
+            match self.peek() {
+                Some(b'*') => {
+                    self.pos += 1;
+                    v *= self.parse_unary();
+                }
+                Some(b'/') => {
+                    self.pos += 1;
+                    v /= self.parse_unary();
+                }
+                Some(b'%') => {
+                    self.pos += 1;
+                    let r = self.parse_unary();
+                    // C++ `%` runs on the `(long)`-cast operands → integer rem.
+                    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+                    let m = ((v as i64) % (r as i64)) as f64;
+                    v = m;
+                }
+                _ => break,
+            }
+        }
+        v
+    }
+
+    fn parse_unary(&mut self) -> f64 {
+        if self.eat("!") {
+            return f64::from(self.parse_unary() == 0.0);
+        }
+        // Casts are no-ops for our f64 model; `(long)` truncation is applied by
+        // `%` and by `round`, which the emitters always wrap a cast around.
+        if self.eat("(double)") || self.eat("(bool)") || self.eat("(long)") {
+            return self.parse_unary();
+        }
+        self.parse_primary()
+    }
+
+    fn parse_primary(&mut self) -> f64 {
+        if self.peek() == Some(b'(') {
+            self.pos += 1;
+            let v = self.parse_or();
+            assert!(self.eat(")"), "missing `)` in C++ expr");
+            return v;
+        }
+        if self.peek().is_some_and(|c| c.is_ascii_alphabetic() || c == b'_') {
+            let start = self.pos;
+            while self.pos < self.src.len()
+                && (self.src[self.pos].is_ascii_alphanumeric() || self.src[self.pos] == b'_')
+            {
+                self.pos += 1;
+            }
+            let ident = std::str::from_utf8(&self.src[start..self.pos]).unwrap().to_string();
+            if self.eat("(") {
+                let arg = self.parse_or();
+                assert!(self.eat(")"), "missing `)` in call to {ident}");
+                return match ident.as_str() {
+                    "ceil" => arg.ceil(),
+                    "floor" => arg.floor(),
+                    "round" => arg.round(),
+                    "abs" => arg.abs(),
+                    other => panic!("unsupported C++ function `{other}` in emitted sketch"),
+                };
+            }
+            return *self
+                .vars
+                .get(&ident)
+                .unwrap_or_else(|| panic!("unbound C++ variable `{ident}` in emitted sketch"));
+        }
+        self.parse_number()
+    }
+
+    fn parse_number(&mut self) -> f64 {
+        self.skip_ws();
+        let start = self.pos;
+        while self.pos < self.src.len()
+            && (self.src[self.pos].is_ascii_digit() || self.src[self.pos] == b'.')
+        {
+            self.pos += 1;
+        }
+        std::str::from_utf8(&self.src[start..self.pos])
+            .unwrap()
+            .parse()
+            .unwrap_or_else(|_| panic!("bad C++ number literal near byte {start}"))
+    }
+}
+
+#[test]
+fn interpreter_models_cpp_semantics() {
+    // Guard the interpreter itself so a parity failure can be trusted to be a
+    // real emitter/runtime divergence rather than an evaluator bug.
+    let vars = HashMap::new();
+    let approx = |a: f64, b: f64| (a - b).abs() < 1e-9;
+    assert!(approx(Parser::eval("ceil(2.4)", &vars), 3.0));
+    assert!(approx(Parser::eval("floor(2.9)", &vars), 2.0));
+    assert!(approx(Parser::eval("((long)round(7.0)) % 2", &vars), 1.0));
+    assert!(approx(Parser::eval("((double)(5.0) > 3.0)", &vars), 1.0));
+    assert!(approx(Parser::eval("(!((bool)(0.0)))", &vars), 1.0));
+    assert!(approx(Parser::eval("(1.0 > 0.0) && (2.0 < 1.0)", &vars), 0.0));
+    assert!(approx(Parser::eval("((long)round(6.0)) % 2", &vars), 0.0));
+}
+
+// ---------------------------------------------------------------------------
+// Flow / sketch helpers
+// ---------------------------------------------------------------------------
+
+const SRC_VAR: &str = "constant_src_value";
+
+fn node(id: &str, kind: &str, data: serde_json::Value) -> FlowNode {
+    FlowNode {
+        id: id.to_string(),
+        node_type: Some(kind.to_string()),
+        data,
+        position: Position { x: 0.0, y: 0.0 },
+    }
+}
+
+fn edge(source: &str, target: &str) -> FlowEdge {
+    FlowEdge {
+        id: None,
+        source: source.to_string(),
+        target: target.to_string(),
+        source_handle: "out".to_string(),
+        target_handle: "in".to_string(),
+    }
+}
+
+/// Generate a sketch for `src(Constant) -> transform`, extract the single
+/// `loop()` assignment for the transform's output variable, and evaluate it
+/// with the source value bound to `input`. Returns the generated model output.
+fn emitted_output(transform: FlowNode, input: f64) -> f64 {
+    let target_id = transform.id.clone();
+    let flow = FlowUpdate {
+        // A Constant source exposes `constant_src_value` as the driver.
+        nodes: vec![node("src", "Constant", json!({ "value": 0.0 })), transform],
+        edges: vec![edge("src", &target_id)],
+    };
+    let sketch = generate(&flow).expect("generation must succeed");
+
+    // The transform's output is the only declared `double`/`bool` whose name is
+    // not the constant source's.
+    let out_var = sketch
+        .lines()
+        .filter_map(|l| {
+            let l = l.trim().trim_end_matches(';');
+            l.strip_prefix("double ")
+                .or_else(|| l.strip_prefix("bool "))
+                .and_then(|d| d.split(" = ").next())
+        })
+        .find(|name| !name.starts_with("constant_"))
+        .map_or_else(
+            || panic!("no transform output declaration in:\n{sketch}"),
+            str::to_string,
+        );
+
+    let rhs = rhs_for(&sketch, &out_var);
+    let mut vars = HashMap::new();
+    vars.insert(SRC_VAR.to_string(), input);
+    Parser::eval(&rhs, &vars)
+}
+
+/// Pull the RHS C++ expression of the `var = ...;` assignment from `loop()`.
+fn rhs_for(sketch: &str, var: &str) -> String {
+    let needle = format!("{var} = ");
+    let line = sketch
+        .lines()
+        .map(str::trim)
+        .find(|l| l.starts_with(&needle) && l.ends_with(';'))
+        .unwrap_or_else(|| panic!("no `{var} = ...;` assignment in sketch:\n{sketch}"));
+    line[needle.len()..line.len() - 1].trim().to_string()
+}
+
+fn num(v: &ComponentValue) -> f64 {
+    v.as_number().expect("expected a numeric component value")
+}
+
+fn boolean(v: &ComponentValue) -> bool {
+    match v {
+        ComponentValue::Bool(b) => *b,
+        other => panic!("expected a boolean component value, got {other:?}"),
+    }
+}
+
+fn cfg<T: serde::de::DeserializeOwned>(data: &serde_json::Value) -> T {
+    serde_json::from_value(data.clone()).expect("config must deserialize from Node data")
+}
+
+// ===========================================================================
+// Scenario: Each Node type matches live behavior
+// ===========================================================================
+
+#[test]
+fn calculate_matches_runtime() {
+    // `ceil`/`floor`/`round` apply unary math; fold functions collapse to the
+    // single input. Cover one of each class across a range of inputs.
+    for func in ["ceil", "floor", "round", "add", "multiply", "subtract", "divide", "max"] {
+        let data = json!({ "function": func });
+        for input in [-3.7, -0.5, 0.0, 2.4, 9.9] {
+            let mut rt = Calculate::new("c".into(), cfg::<CalculateConfig>(&data));
+            rt.check(&[input]);
+            let live = num(&rt.value());
+
+            let gen = emitted_output(node("c-1", "Calculate", data.clone()), input);
+
+            assert!(
+                (live - gen).abs() < 1e-9,
+                "Calculate({func}) diverged for input {input}: live={live} generated={gen}"
+            );
+        }
+    }
+}
+
+#[test]
+fn compare_matches_runtime() {
+    let datas = [
+        json!({ "validator": "number", "subValidator": "greater than", "number": 5.0 }),
+        json!({ "validator": "number", "subValidator": "less than", "number": 5.0 }),
+        json!({ "validator": "number", "subValidator": "equal", "number": 6.0 }),
+        json!({ "validator": "oddeven", "subValidator": "odd" }),
+        json!({ "validator": "oddeven", "subValidator": "even" }),
+        json!({ "validator": "range", "subValidator": "inside", "range": { "min": 10.0, "max": 20.0 } }),
+        json!({ "validator": "range", "subValidator": "outside", "range": { "min": 10.0, "max": 20.0 } }),
+        json!({ "validator": "boolean" }),
+    ];
+
+    for data in datas {
+        for input in [-4.0, -1.0, 0.0, 3.0, 6.0, 7.0, 15.0, 25.0] {
+            let mut rt = Compare::new("cmp".into(), cfg::<CompareConfig>(&data));
+            rt.check(&ComponentValue::Number(input));
+            let live = boolean(&rt.value());
+
+            let gen = emitted_output(node("cmp-1", "Compare", data.clone()), input) != 0.0;
+
+            assert_eq!(
+                live, gen,
+                "Compare({data}) diverged for input {input}: live={live} generated={gen}"
+            );
+        }
+    }
+}
+
+#[test]
+fn gate_matches_runtime() {
+    // Single boolean input: pass-through gates equal the input, inverting gates
+    // negate it. Cover one of each class against the runtime.
+    for gate_str in ["and", "or", "xor", "nand", "nor", "xnor"] {
+        let data = json!({ "gate": gate_str });
+        for input_high in [false, true] {
+            let mut rt = Gate::new("g".into(), cfg::<GateConfig>(&data));
+            rt.check(&[input_high]);
+            let live = boolean(&rt.value());
+
+            let gen = emitted_output(node("g-1", "Gate", data.clone()), f64::from(input_high)) != 0.0;
+
+            assert_eq!(live, gen, "Gate({gate_str}) diverged for input {input_high}");
+        }
+    }
+}
+
+#[test]
+fn range_map_matches_runtime() {
+    // Wide span (whole-number precision) and small span (one-decimal precision).
+    let datas = [
+        json!({ "from": { "min": 0.0, "max": 1023.0 }, "to": { "min": 0.0, "max": 255.0 } }),
+        json!({ "from": { "min": 0.0, "max": 100.0 }, "to": { "min": 0.0, "max": 5.0 } }),
+    ];
+    for data in datas {
+        for input in [0.0, 33.0, 256.0, 511.5, 1023.0] {
+            let mut rt = RangeMap::new("rm".into(), cfg::<RangeMapConfig>(&data));
+            rt.map_value(ComponentValue::Number(input));
+            // RangeMap stores [input, normalized]; the emitted value is `normalized`.
+            let live = match rt.value() {
+                ComponentValue::Array(a) => a[1].as_number().unwrap(),
+                other => panic!("expected RangeMap array, got {other:?}"),
+            };
+
+            let gen = emitted_output(node("rm-1", "RangeMap", data.clone()), input);
+
+            assert!(
+                (live - gen).abs() < 1e-6,
+                "RangeMap({data}) diverged for input {input}: live={live} generated={gen}"
+            );
+        }
+    }
+}
+
+// ===========================================================================
+// Scenario: A chained Flow reproduces live behavior on-device
+//   Sensor -> Calculate(round) -> Compare(> threshold) -> Led
+// ===========================================================================
+
+#[test]
+fn chained_flow_reproduces_live_behavior() {
+    let calc_data = json!({ "function": "round" });
+    let cmp_data = json!({ "validator": "number", "subValidator": "greater than", "number": 5.0 });
+
+    let flow = FlowUpdate {
+        nodes: vec![
+            node("sensor-1", "Sensor", json!({ "pin": "A0" })),
+            node("calc-1", "Calculate", calc_data.clone()),
+            node("cmp-1", "Compare", cmp_data.clone()),
+            node("led-1", "Led", json!({ "pin": 13 })),
+        ],
+        edges: vec![edge("sensor-1", "calc-1"), edge("calc-1", "cmp-1"), edge("cmp-1", "led-1")],
+    };
+    let sketch = generate(&flow).expect("generation must succeed");
+
+    // Structural parity: non-blocking, every chain Node emits real code.
+    assert!(!sketch.contains("delay("), "chain must stay non-blocking");
+    assert!(sketch.contains("analogRead"), "sensor read present");
+    assert!(sketch.contains("digitalWrite"), "led write present");
+
+    // Semantic parity over the whole chain: drive the same raw input through
+    // both the live components and the emitted expressions.
+    let calc_rhs = rhs_for(&sketch, "calculate_calc_1_value");
+    let cmp_rhs = rhs_for(&sketch, "compare_cmp_1_result");
+
+    for raw in [3.2, 4.6, 5.4, 5.5, 9.1] {
+        // Live: Sensor value → Calculate(round) → Compare(>5).
+        let mut calc = Calculate::new("calc".into(), cfg::<CalculateConfig>(&calc_data));
+        calc.check(&[raw]);
+        let calc_live = num(&calc.value());
+        let mut cmp = Compare::new("cmp".into(), cfg::<CompareConfig>(&cmp_data));
+        cmp.check(&ComponentValue::Number(calc_live));
+        let live = boolean(&cmp.value());
+
+        // Generated: evaluate calc RHS, feed its result into the compare RHS.
+        let mut vars = HashMap::new();
+        vars.insert("sensor_sensor_1_value".to_string(), raw);
+        let calc_gen = Parser::eval(&calc_rhs, &vars);
+        vars.insert("calculate_calc_1_value".to_string(), calc_gen);
+        let gen = Parser::eval(&cmp_rhs, &vars) != 0.0;
+
+        assert_eq!(live, gen, "chained Flow diverged for raw input {raw}");
+    }
+}
+
+// ===========================================================================
+// Scenario: Nested timing Nodes stay in parity
+//   Interval drives Delay — both timers stay non-blocking and drift-free.
+// ===========================================================================
+
+#[test]
+fn nested_timing_nodes_stay_in_parity() {
+    let flow = FlowUpdate {
+        nodes: vec![
+            node("interval-1", "Interval", json!({ "interval": 1000 })),
+            node("delay-1", "Delay", json!({ "delay": 500 })),
+        ],
+        edges: vec![edge("interval-1", "delay-1")],
+    };
+    let sketch = generate(&flow).expect("generation must succeed");
+
+    // No blocking `delay()` — both timers are millis()-based, so the loop never
+    // stalls and the two timers run concurrently without drift.
+    assert!(!sketch.contains("delay("), "timing Nodes must not block the loop");
+    assert!(sketch.contains("millis()"), "timers must be millis()-driven");
+
+    // The Interval advances its deadline by a fixed step (`previous += period`)
+    // rather than re-basing off `millis()`, which is what prevents cumulative
+    // drift. Assert that drift-free pattern is present.
+    assert!(
+        sketch.contains("interval_interval_1_previous += 1000UL"),
+        "Interval must advance by a fixed step to avoid drift, got:\n{sketch}"
+    );
+    // The Delay measures its own elapsed window independently of the Interval.
+    assert!(
+        sketch.contains("millis() - delay_delay_1_armed_at >= 500UL"),
+        "Delay must measure its own non-blocking window, got:\n{sketch}"
+    );
+
+    // Simulate the two timers on a shared clock and confirm they fire on their
+    // own schedules without one blocking the other.
+    let interval_ms = 1000u64;
+    let delay_ms = 500u64;
+    let mut interval_prev = 0u64;
+    let mut delay_pending = false;
+    let mut delay_armed = 0u64;
+    let mut interval_fires = 0u32;
+    let mut delay_fires = 0u32;
+
+    // Window covers interval pulses at 1000/2000/3000 and leaves room (+500ms)
+    // for each armed Delay to resolve before the loop ends.
+    for now in (0..=3600).step_by(50) {
+        // Interval tick (fixed-step advance, drift-free).
+        if now - interval_prev >= interval_ms {
+            interval_prev += interval_ms;
+            interval_fires += 1;
+            // The Interval pulse arms the Delay (rising edge).
+            if !delay_pending {
+                delay_pending = true;
+                delay_armed = now;
+            }
+        }
+        // Delay fires its own window later, independently.
+        if delay_pending && now - delay_armed >= delay_ms {
+            delay_pending = false;
+            delay_fires += 1;
+        }
+    }
+
+    // The 1s interval fires 3 times (at 1000/2000/3000) and each arms a 500ms
+    // delay that resolves before the next pulse — neither timer is starved or
+    // blocked by the other, and the delay tracks the interval 1:1 (no drift).
+    assert_eq!(interval_fires, 3, "interval should fire 3 times within the window");
+    assert_eq!(delay_fires, interval_fires, "every interval pulse must resolve its delay");
+}
+
+// ===========================================================================
+// Scenario: Divergence fails the suite
+// ===========================================================================
+
+#[test]
+fn divergence_is_detected() {
+    // A deliberately wrong model of the Compare Node (using `<` instead of the
+    // emitted `>`) must disagree with the runtime — proving the harness would
+    // catch a real emitter regression rather than silently passing.
+    let data = json!({ "validator": "number", "subValidator": "greater than", "number": 5.0 });
+    let mut rt = Compare::new("cmp".into(), cfg::<CompareConfig>(&data));
+    rt.check(&ComponentValue::Number(9.0));
+    let live = boolean(&rt.value()); // 9 > 5 == true
+
+    // The genuine emitted output agrees with the runtime…
+    let genuine = emitted_output(node("cmp-1", "Compare", data.clone()), 9.0) != 0.0;
+    assert_eq!(live, genuine, "sanity: genuine emitter must match runtime");
+
+    // …but a corrupted model diverges, and the harness's equality check fails.
+    let vars = HashMap::from([(SRC_VAR.to_string(), 9.0)]);
+    let corrupted = Parser::eval("((double)(constant_src_value) < 5.0)", &vars) != 0.0;
+    assert_ne!(
+        live, corrupted,
+        "a diverging Node model must be detectable by the parity comparison"
+    );
+}


### PR DESCRIPTION
## Summary

Extends sketch generation to the **full Node catalogue** (Feature #25, Epic #22). Building on the MVP core (#23: Led/Button/Sensor/Servo/Relay), every non-Cloud Node now emits faithful Arduino C++ — transformation, control/timing, the Function Node, and the remaining hardware input/output Nodes — with a behaviour-parity test harness proving the generated sketch matches live runtime semantics.

## Changes

- **Transformation Nodes (#33)** — Calculate, Compare, Gate, RangeMap, Smooth emitted to C++ expressions/state.
- **Control Nodes as non-blocking timers (#34)** — Constant, Counter, Delay, Interval, Trigger emitted using `millis()`-based scheduling (no `delay()` blocking).
- **Function Node (#36)** — user JS logic translated to C++.
- **Remaining input/output Nodes (#37)** — Switch, Motion, Proximity, Hotkey, I2cDevice (input); Rgb, Piezo, Pixel, Matrix, Stepper (output); Oscillator (generator). Catalogue aliases (Force/HallEffect/Ldr/Potentiometer/Tilt → Sensor, Vibration → Led) wired via dispatch. Library-backed Nodes emit the right includes (Adafruit_NeoPixel, LedControl, AccelStepper, Wire, Servo). Cloud Nodes still fall through to placeholders (handled by Feature #27).
- **Behaviour-parity harness (#40)** — `tests/codegen_parity.rs`: a tiny C++-expression interpreter evaluates the exact expression each emitter writes into `loop()` against the runtime impl deserialized from the same Node data, failing (and naming the Node) on any divergence. No parity bugs found.

## Test plan

- [x] Transformation Nodes emit correct C++ and match runtime values
- [x] Control Nodes schedule via `millis()` without blocking
- [x] Function Node logic translated and exercised
- [x] All remaining input/output Nodes emit faithful C++ (pins, modes, libraries)
- [x] Generated sketch behaviour matches the live runtime across per-Node, chained, and timing scenarios

Full Rust suite green (cargo test), clippy pedantic clean; web bun:test suite green; zero new type errors.

## Related

Closes #25
Closes #33
Closes #34
Closes #36
Closes #37
Closes #40
