### PR TITLE
feat(codegen): emit on-device Mqtt Node for a networked target

### DIFF
--- a/apps/web/src-tauri/src/codegen/cloud/mod.rs
+++ b/apps/web/src-tauri/src/codegen/cloud/mod.rs
@@ -1,0 +1,14 @@
+//! Cloud-Node C++ emitters — the networked counterpart to the hardware-IO
+//! emitters.
+//!
+//! Cloud Nodes (`Mqtt`, `Figma`, `Llm`, `Monitor`) cross the hardware boundary:
+//! they talk to networked services and therefore only run on a `WiFi`-capable
+//! target (e.g. the ESP32). Validation (#26/#35) already refuses a Cloud Node on
+//! a non-networking board, so an emitter in this module may assume the target
+//! offers [`crate::codegen::board::BoardCapability::Networking`].
+//!
+//! Only the `Mqtt` Node has an on-device emitter today (Task #38). The other
+//! Cloud Nodes still fall through to [`crate::codegen::placeholder`] until their
+//! own tasks land.
+
+pub mod mqtt;

--- a/apps/web/src-tauri/src/codegen/cloud/mqtt.rs
+++ b/apps/web/src-tauri/src/codegen/cloud/mqtt.rs
@@ -292,7 +292,7 @@ mod tests {
         let e = emit(
             &mqtt(
                 "m-1",
-                json!({ "broker": "broker.example.com", "port": 1883, "topic": "t", "wifiSsid": "net", "wifiPassword": "pw" }),
+                json!({ "broker": "broker.example.com", "port": 1883, "topic": "t", "wifiSsid": "net", "wifiPassword": "pw" }), // ggignore
             ),
             None,
         );
@@ -356,9 +356,9 @@ mod tests {
                     "port": 8883,
                     "topic": "microflow/sensor",
                     "wifiSsid": "home-net",
-                    "wifiPassword": "s3cret",
+                    "wifiPassword": "s3cret", // ggignore
                     "brokerUsername": "user",
-                    "brokerPassword": "pass",
+                    "brokerPassword": "pass", // ggignore
                     "direction": "publish"
                 }),
             ),

--- a/apps/web/src-tauri/src/codegen/cloud/mqtt.rs
+++ b/apps/web/src-tauri/src/codegen/cloud/mqtt.rs
@@ -1,0 +1,410 @@
+//! Mqtt emitter — the on-device counterpart of `runtime/external/mqtt.rs`.
+//!
+//! The live Mqtt component publishes to / subscribes from a broker through a
+//! host-driven adapter. On a networked target (ESP32) there is no host, so the
+//! generated sketch must do it itself: bring up `WiFi`, connect to the broker,
+//! and — depending on the Node's `direction` — publish on `trigger` or
+//! subscribe and surface inbound messages. This mirrors the live semantics so
+//! standalone behaviour matches live mode.
+//!
+//! The emission uses the ubiquitous Arduino MQTT stack: `WiFi.h` (ESP32 core)
+//! plus `PubSubClient`. `WiFi` bring-up and reconnect live in shared helpers so
+//! later Cloud Nodes (Figma/Llm/Monitor) can reuse the same bootstrap.
+//!
+//! ## Config (`node.data`)
+//!
+//! Read leniently, accepting both the live runtime shape and the generation
+//! request shape:
+//! - `broker` — broker host (the request shape); falls back to `brokerId`.
+//! - `port` — broker TCP port (default `1883`).
+//! - `topic` — topic to publish on / subscribe to.
+//! - `direction` — `"publish"` or `"subscribe"` (default `"subscribe"`,
+//!   matching `MqttConfig::default`).
+//! - credentials: `wifiSsid`, `wifiPassword`, `brokerUsername`,
+//!   `brokerPassword`. When `wifiSsid`/`broker` are absent the sketch emits a
+//!   clearly-marked credential placeholder and a `#warning` rather than
+//!   silently failing to connect.
+//!
+//! Like every emitter this is a pure function of the [`FlowNode`]: identical
+//! input yields byte-identical output (determinism invariant).
+
+use crate::codegen::emit::{str_or_default, u16_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Default broker port — standard unencrypted MQTT.
+const DEFAULT_PORT: u16 = 1883;
+/// Default direction matches `runtime/external/mqtt.rs::MqttConfig::default`.
+const DEFAULT_DIRECTION: &str = "subscribe";
+/// Sentinel emitted in place of a missing credential so the sketch never
+/// silently connects with an empty value.
+const PLACEHOLDER: &str = "REPLACE_ME";
+
+/// The `WiFi` + MQTT client includes. De-duplicated by the assembler.
+fn includes() -> Vec<String> {
+    vec![
+        "#include <WiFi.h>".to_string(),
+        "#include <PubSubClient.h>".to_string(),
+    ]
+}
+
+/// Escape a string for embedding inside a C++ double-quoted literal. Keeps
+/// generation safe (and deterministic) for topics/credentials that contain a
+/// quote or backslash.
+fn cpp_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// A single config value read from `data`, with the first non-empty key
+/// winning, falling back to `default`.
+fn first_non_empty(node: &FlowNode, keys: &[&str], default: &str) -> String {
+    for key in keys {
+        let value = str_or_default(node, key, "");
+        if !value.is_empty() {
+            return value;
+        }
+    }
+    default.to_string()
+}
+
+/// Emit C++ for an Mqtt Cloud Node on a networked target.
+///
+/// `driver` is the C++ expression a publish Node sends each time its input
+/// fires (the payload). A subscribe Node ignores it. The target is assumed to
+/// offer networking — validation refuses the Node otherwise.
+#[must_use]
+#[allow(clippy::too_many_lines)]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let direction = {
+        let d = str_or_default(node, "direction", DEFAULT_DIRECTION);
+        if d.is_empty() { DEFAULT_DIRECTION.to_string() } else { d }
+    };
+    let is_publish = direction == "publish";
+
+    let topic = first_non_empty(node, &["topic"], "");
+    let broker = first_non_empty(node, &["broker", "brokerId"], "");
+    let port = u16_or_default(node, "port", DEFAULT_PORT);
+    let wifi_ssid = first_non_empty(node, &["wifiSsid"], "");
+    let wifi_password = first_non_empty(node, &["wifiPassword"], "");
+    let broker_user = first_non_empty(node, &["brokerUsername"], "");
+    let broker_pass = first_non_empty(node, &["brokerPassword"], "");
+
+    // A Node is missing its essential connection details if it has no WiFi SSID
+    // or no broker host. We still emit a connecting sketch, but with a loud
+    // placeholder + #warning so the Author is told rather than silently failing.
+    let credentials_missing = wifi_ssid.is_empty() || broker.is_empty();
+
+    let ssid_lit = cpp_string(if wifi_ssid.is_empty() { PLACEHOLDER } else { &wifi_ssid });
+    let wifi_pass_lit = cpp_string(if wifi_password.is_empty() { PLACEHOLDER } else { &wifi_password });
+    let broker_lit = cpp_string(if broker.is_empty() { PLACEHOLDER } else { &broker });
+    let topic_lit = cpp_string(&topic);
+
+    // Per-Node config names — token-scoped so multiple Mqtt Nodes coexist.
+    let ssid_var = format!("mqtt_{token}_wifi_ssid");
+    let wifi_pass_var = format!("mqtt_{token}_wifi_password");
+    let broker_var = format!("mqtt_{token}_broker");
+    let port_var = format!("mqtt_{token}_port");
+    let topic_var = format!("mqtt_{token}_topic");
+    let client_id_var = format!("mqtt_{token}_client_id");
+    let wifi_client = format!("mqtt_{token}_wifi_client");
+    let mqtt_client = format!("mqtt_{token}_client");
+
+    let mut declarations = vec![
+        format!("const char* {ssid_var} = {ssid_lit};"),
+        format!("const char* {wifi_pass_var} = {wifi_pass_lit};"),
+        format!("const char* {broker_var} = {broker_lit};"),
+        format!("const uint16_t {port_var} = {port};"),
+        format!("const char* {topic_var} = {topic_lit};"),
+        format!("const char* {client_id_var} = {};", cpp_string(&format!("microflow-{token}"))),
+        format!("WiFiClient {wifi_client};"),
+        format!("PubSubClient {mqtt_client}({wifi_client});"),
+    ];
+    if credentials_missing {
+        // A compile-time signal plus a human-readable note. The #warning keeps
+        // the placeholder honest: the sketch builds but the Author is told.
+        declarations.insert(
+            0,
+            format!(
+                "#warning \"MQTT Node {token}: missing network credentials — using {PLACEHOLDER} placeholder; set WiFi SSID and broker before flashing\""
+            ),
+        );
+    }
+
+    // Connect/auth arguments differ when a broker username is configured.
+    let connect_call = if broker_user.is_empty() {
+        format!("{mqtt_client}.connect({client_id_var})")
+    } else {
+        format!(
+            "{mqtt_client}.connect({client_id_var}, {}, {})",
+            cpp_string(&broker_user),
+            cpp_string(if broker_pass.is_empty() { PLACEHOLDER } else { &broker_pass })
+        )
+    };
+
+    // The (re)connect routine: ensure WiFi is up, then the broker. Mirrors the
+    // live component maintaining its connection; here it runs in loop() with no
+    // host event loop. It is *non-blocking* — it kicks off `WiFi.begin` and
+    // attempts the broker connect once per call, returning immediately so the
+    // sketch's `millis()`-based scheduler keeps ticking (no blocking `delay`).
+    // Subscribe Nodes (re)subscribe on every (re)connect.
+    let mut ensure_fn = vec![
+        format!("void mqtt_{token}_ensure_connected() {{"),
+        "  if (WiFi.status() != WL_CONNECTED) {".to_string(),
+        format!("    WiFi.begin({ssid_var}, {wifi_pass_var});"),
+        "    return; // WiFi not up yet; retry on the next loop tick".to_string(),
+        "  }".to_string(),
+        format!("  if (!{mqtt_client}.connected()) {{"),
+        format!("    {mqtt_client}.setServer({broker_var}, {port_var});"),
+        format!("    if ({connect_call}) {{"),
+    ];
+    if is_publish {
+        ensure_fn.push("      // publish-only Node: nothing to subscribe".to_string());
+    } else {
+        ensure_fn.push(format!("      {mqtt_client}.subscribe({topic_var});"));
+    }
+    ensure_fn.push("    }".to_string());
+    ensure_fn.push("  }".to_string());
+    ensure_fn.push("}".to_string());
+
+    // Inbound message handling for subscribe Nodes: copy the latest payload into
+    // a Node-scoped buffer so downstream Nodes can read it (mirrors the live
+    // component surfacing the message as its value).
+    if !is_publish {
+        let callback = format!("mqtt_{token}_on_message");
+        let value_var = format!("mqtt_{token}_value");
+        declarations.push(format!("String {value_var};"));
+        declarations.push(format!(
+            "void {callback}(char* topic, byte* payload, unsigned int length) {{"
+        ));
+        declarations.push(format!("  {value_var} = String();"));
+        declarations.push("  for (unsigned int i = 0; i < length; i++) {".to_string());
+        declarations.push(format!("    {value_var} += (char)payload[i];"));
+        declarations.push("  }".to_string());
+        declarations.push("}".to_string());
+    }
+    // The ensure-connected helper is appended after the message callback it may
+    // reference (subscribe uses the callback name only in setup, so order is
+    // not strictly required, but keep declarations readable).
+    for line in ensure_fn {
+        declarations.push(line);
+    }
+
+    let mut setup = vec![
+        "WiFi.mode(WIFI_STA);".to_string(),
+        format!("{mqtt_client}.setServer({broker_var}, {port_var});"),
+    ];
+    if !is_publish {
+        setup.push(format!("{mqtt_client}.setCallback(mqtt_{token}_on_message);"));
+    }
+    setup.push(format!("mqtt_{token}_ensure_connected();"));
+
+    // loop(): keep the connection alive (reconnect on drop), pump the client,
+    // and — for publish Nodes — send the driven payload when its input fires.
+    let mut loop_body = vec![
+        format!("mqtt_{token}_ensure_connected();"),
+        format!("{mqtt_client}.loop();"),
+    ];
+    if is_publish {
+        if let Some(expr) = driver {
+            loop_body.push(format!("if ({mqtt_client}.connected()) {{"));
+            loop_body.push(format!(
+                "  {mqtt_client}.publish({topic_var}, String({expr}).c_str());"
+            ));
+            loop_body.push("}".to_string());
+        } else {
+            loop_body.push(format!(
+                "// publish Node {token} has no wired input — nothing to publish"
+            ));
+        }
+    }
+
+    NodeEmission {
+        includes: includes(),
+        declarations,
+        setup,
+        loop_body,
+    }
+}
+
+/// The C++ expression downstream Nodes read for a subscribe Mqtt Node: the
+/// latest inbound message as a numeric value (`toFloat`). Publish Nodes expose
+/// no readable value. Mirrors the live component surfacing the message as its
+/// value.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> Option<String> {
+    let direction = str_or_default(node, "direction", DEFAULT_DIRECTION);
+    if direction == "publish" {
+        return None;
+    }
+    let token = node.id_token();
+    Some(format!("mqtt_{token}_value.toFloat()"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn mqtt(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Mqtt".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    fn joined(lines: &[String]) -> String {
+        lines.join("\n")
+    }
+
+    /// Scenario: Mqtt Node emits working code on a `WiFi`-capable target — it
+    /// pulls in the `WiFi` + MQTT client libraries.
+    #[test]
+    fn mqtt_pulls_in_wifi_and_mqtt_client_libraries() {
+        let e = emit(
+            &mqtt("m-1", json!({ "broker": "broker.example.com", "topic": "t", "wifiSsid": "net" })),
+            None,
+        );
+        assert!(e.includes.iter().any(|i| i.contains("WiFi.h")), "missing WiFi include");
+        assert!(
+            e.includes.iter().any(|i| i.contains("PubSubClient.h")),
+            "missing MQTT client include"
+        );
+    }
+
+    /// Scenario: connects to the network and the broker on boot.
+    #[test]
+    fn connects_to_network_and_broker_on_boot() {
+        let e = emit(
+            &mqtt(
+                "m-1",
+                json!({ "broker": "broker.example.com", "port": 1883, "topic": "t", "wifiSsid": "net", "wifiPassword": "pw" }),
+            ),
+            None,
+        );
+        let setup = joined(&e.setup);
+        let decls = joined(&e.declarations);
+        assert!(setup.contains("WiFi.mode(WIFI_STA)"), "boots WiFi in setup");
+        assert!(setup.contains("ensure_connected()"), "connects on boot");
+        assert!(decls.contains("WiFi.begin(mqtt_m_1_wifi_ssid"), "uses WiFi.begin with creds");
+        assert!(decls.contains("setServer(mqtt_m_1_broker"), "points at the broker host/port");
+    }
+
+    /// Scenario: a subscribe Node subscribes on its configured topic and
+    /// surfaces inbound messages.
+    #[test]
+    fn subscribe_node_subscribes_and_surfaces_messages() {
+        let n = mqtt(
+            "m-1",
+            json!({ "broker": "b", "topic": "microflow/sensor", "wifiSsid": "net", "direction": "subscribe" }),
+        );
+        let e = emit(&n, None);
+        let decls = joined(&e.declarations);
+        assert!(decls.contains("subscribe(mqtt_m_1_topic)"), "subscribes to its topic");
+        assert!(decls.contains("setCallback") || joined(&e.setup).contains("setCallback"));
+        assert!(decls.contains("mqtt_m_1_value"), "buffers the inbound message");
+        assert_eq!(value_var(&n).as_deref(), Some("mqtt_m_1_value.toFloat()"));
+    }
+
+    /// Scenario: a publish Node publishes its driven payload on its topic.
+    #[test]
+    fn publish_node_publishes_driven_payload() {
+        let n = mqtt(
+            "m-1",
+            json!({ "broker": "b", "topic": "microflow/sensor", "wifiSsid": "net", "direction": "publish" }),
+        );
+        let e = emit(&n, Some("sensor_s_1_value"));
+        let body = joined(&e.loop_body);
+        assert!(body.contains("publish(mqtt_m_1_topic"), "publishes on its topic");
+        assert!(body.contains("sensor_s_1_value"), "publishes the driven payload");
+        // Publish Nodes expose no readable value.
+        assert_eq!(value_var(&n), None);
+    }
+
+    /// Scenario: the loop maintains the connection (reconnect on drop) without
+    /// a host event loop.
+    #[test]
+    fn loop_maintains_connection_and_pumps_client() {
+        let e = emit(&mqtt("m-1", json!({ "broker": "b", "topic": "t", "wifiSsid": "net" })), None);
+        let body = joined(&e.loop_body);
+        assert!(body.contains("ensure_connected()"), "reconnects in loop");
+        assert!(body.contains("mqtt_m_1_client.loop()"), "pumps the MQTT client");
+    }
+
+    /// Scenario: Generated Mqtt sketch reflects supplied credentials.
+    #[test]
+    fn reflects_supplied_credentials() {
+        let e = emit(
+            &mqtt(
+                "m-1",
+                json!({
+                    "broker": "broker.example.com",
+                    "port": 8883,
+                    "topic": "microflow/sensor",
+                    "wifiSsid": "home-net",
+                    "wifiPassword": "s3cret",
+                    "brokerUsername": "user",
+                    "brokerPassword": "pass",
+                    "direction": "publish"
+                }),
+            ),
+            Some("v"),
+        );
+        let decls = joined(&e.declarations);
+        assert!(decls.contains("\"home-net\""), "embeds the supplied SSID");
+        assert!(decls.contains("\"s3cret\""), "embeds the supplied WiFi password");
+        assert!(decls.contains("\"broker.example.com\""), "embeds the broker host");
+        assert!(decls.contains("8883"), "embeds the supplied port");
+        assert!(decls.contains("connect(mqtt_m_1_client_id, \"user\", \"pass\")"), "uses broker auth");
+        assert!(!decls.contains("REPLACE_ME"), "no placeholder when creds supplied");
+        assert!(!decls.contains("#warning"), "no warning when creds supplied");
+    }
+
+    /// Scenario: Missing credentials produce a safe placeholder + a warning.
+    #[test]
+    fn missing_credentials_produce_safe_placeholder_and_warning() {
+        let e = emit(&mqtt("m-1", json!({ "topic": "microflow/sensor", "direction": "publish" })), Some("v"));
+        let decls = joined(&e.declarations);
+        assert!(decls.contains("REPLACE_ME"), "emits a credential placeholder");
+        assert!(decls.contains("#warning"), "warns the Author at compile time");
+        // It still emits connecting code rather than silently doing nothing.
+        assert!(joined(&e.setup).contains("ensure_connected()"), "still attempts to connect");
+    }
+
+    /// Direction defaults to subscribe when absent (matches runtime default).
+    #[test]
+    fn direction_defaults_to_subscribe() {
+        let n = mqtt("m-1", json!({ "broker": "b", "topic": "t", "wifiSsid": "net" }));
+        let e = emit(&n, None);
+        assert!(joined(&e.declarations).contains("subscribe(mqtt_m_1_topic)"), "defaults to subscribe");
+        assert!(value_var(&n).is_some(), "subscribe Node exposes a value");
+    }
+
+    /// Topic strings with a quote are escaped so generation stays valid.
+    #[test]
+    fn topic_is_escaped() {
+        let e = emit(&mqtt("m-1", json!({ "broker": "b", "topic": "a\"b", "wifiSsid": "net" })), None);
+        assert!(joined(&e.declarations).contains("\"a\\\"b\""), "escapes the quote in the topic");
+    }
+
+    /// Determinism: identical Node yields byte-identical emission.
+    #[test]
+    fn emits_deterministically() {
+        let n = mqtt("m-1", json!({ "broker": "b", "topic": "t", "wifiSsid": "net", "direction": "publish" }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/mod.rs
+++ b/apps/web/src-tauri/src/codegen/mod.rs
@@ -22,6 +22,7 @@
 //!   compiles even when the Flow is empty.
 
 pub mod board;
+pub mod cloud;
 pub mod control;
 pub mod emit;
 pub mod generator;
@@ -232,6 +233,11 @@ fn emit_node(
         Some("Trigger") => control::trigger::emit(node, driver),
         Some("Counter") => control::counter::emit(node, driver),
         Some("Constant") => control::constant::emit(node),
+        // Mqtt is the one Cloud Node with an on-device emitter (Task #38). It
+        // only reaches here on a networking target — validation refuses it
+        // otherwise. The other Cloud Nodes (Figma/Llm/Monitor) still fall
+        // through to the placeholder below.
+        Some("Mqtt") => cloud::mqtt::emit(node, driver),
         _ => placeholder::emit(node),
     }
 }
@@ -296,6 +302,9 @@ fn source_expression(node: &FlowNode) -> Option<String> {
         Some("Trigger") => Some(control::trigger::state_var(node)),
         Some("Counter") => Some(control::counter::value_var(node)),
         Some("Constant") => Some(control::constant::value_var(node)),
+        // A subscribe Mqtt Node surfaces its latest inbound message as a value;
+        // a publish Mqtt Node exposes none (returns `None`).
+        Some("Mqtt") => cloud::mqtt::value_var(node),
         _ => None,
     }
 }
@@ -620,14 +629,14 @@ mod tests {
 
     /// Scenario: An unsupported Node becomes a placeholder comment.
     ///
-    /// A Cloud Node (Mqtt) alongside a core Led: the Cloud Node gets a clear
-    /// placeholder comment, the Led still emits real code, and generation does
-    /// not crash or blank the sketch.
+    /// A Cloud Node (Figma — still without an on-device emitter) alongside a
+    /// core Led: the Cloud Node gets a clear placeholder comment, the Led still
+    /// emits real code, and generation does not crash or blank the sketch.
     #[test]
     fn cloud_node_becomes_placeholder_while_core_node_still_emits() {
         let flow = FlowUpdate {
             nodes: vec![
-                node("mqtt-1", "Mqtt"),
+                node("figma-1", "Figma"),
                 node_data("led-1", "Led", json!({ "pin": 13 })),
             ],
             edges: vec![],
@@ -639,8 +648,8 @@ mod tests {
 
         // Placeholder for the Cloud Node, identifying it and the networked need.
         assert!(
-            sketch.contains("// unsupported Node mqtt_1 (Mqtt)"),
-            "missing Mqtt placeholder, got:\n{sketch}"
+            sketch.contains("// unsupported Node figma_1 (Figma)"),
+            "missing Figma placeholder, got:\n{sketch}"
         );
         assert!(sketch.contains("networked target"), "Cloud message missing");
         // The Led still produces real code.
@@ -673,11 +682,13 @@ mod tests {
     }
 
     /// Scenario: A Flow of only unsupported Nodes still yields a valid sketch.
+    ///
+    /// Mqtt now has an on-device emitter (Task #38), so the remaining
+    /// still-unsupported Cloud Nodes are Figma/Llm/Monitor.
     #[test]
     fn all_unsupported_flow_yields_valid_sketch() {
         let flow = FlowUpdate {
             nodes: vec![
-                node("mqtt-1", "Mqtt"),
                 node("figma-1", "Figma"),
                 node("llm-1", "Llm"),
                 node("monitor-1", "Monitor"),
@@ -694,7 +705,7 @@ mod tests {
         // A placeholder for every unsupported Node.
         assert_eq!(
             sketch.matches("// unsupported Node ").count(),
-            4,
+            3,
             "expected one placeholder per unsupported node, got:\n{sketch}"
         );
     }
@@ -703,7 +714,7 @@ mod tests {
     #[test]
     fn placeholder_comments_are_deterministic_at_sketch_level() {
         let flow = FlowUpdate {
-            nodes: vec![node("mqtt-1", "Mqtt"), node("gizmo-1", "Gizmo")],
+            nodes: vec![node("figma-1", "Figma"), node("gizmo-1", "Gizmo")],
             edges: vec![],
         };
 
@@ -715,6 +726,129 @@ mod tests {
             first, second,
             "repeated generation must yield identical placeholder comments"
         );
+    }
+
+    // --- Task #38: emit the Mqtt Node for a networked target ---
+
+    /// Scenario: Mqtt Node emits working code on a WiFi-capable target.
+    ///
+    /// A Flow with an Mqtt Cloud Node generated for the ESP32 connects to the
+    /// network and broker on boot and publishes/subscribes on its topic — not a
+    /// placeholder.
+    #[test]
+    fn mqtt_node_emits_working_code_on_a_wifi_capable_target() {
+        let flow = FlowUpdate {
+            nodes: vec![node_data(
+                "mqtt-1",
+                "Mqtt",
+                json!({ "broker": "broker.example.com", "port": 1883, "topic": "microflow/sensor", "direction": "subscribe", "wifiSsid": "net" }),
+            )],
+            edges: vec![],
+        };
+
+        let sketch = sketch_for(&flow, &networking_target());
+
+        // Not a placeholder.
+        assert!(!sketch.contains("// unsupported Node mqtt_1"), "Mqtt must emit real code, got:\n{sketch}");
+        // WiFi + MQTT client libraries pulled in.
+        assert!(sketch.contains("#include <WiFi.h>"), "missing WiFi include");
+        assert!(sketch.contains("#include <PubSubClient.h>"), "missing MQTT client include");
+        // Connects to network and broker on boot.
+        assert!(sketch.contains("WiFi.mode(WIFI_STA)"), "boots WiFi in setup");
+        assert!(sketch.contains("mqtt_mqtt_1_ensure_connected()"), "connects on boot + loop");
+        assert!(sketch.contains("setServer(mqtt_mqtt_1_broker"), "points at the broker");
+        // Subscribes on the configured topic.
+        assert!(sketch.contains("subscribe(mqtt_mqtt_1_topic)"), "subscribes to its topic");
+        // Maintains the connection in loop() without a host event loop.
+        assert!(sketch.contains("mqtt_mqtt_1_client.loop()"), "pumps client in loop");
+        // Stays non-blocking (no blocking delay).
+        assert!(!sketch.contains("delay("), "stays non-blocking");
+    }
+
+    /// Scenario: a publish Mqtt Node publishes its wired input on its topic.
+    #[test]
+    fn mqtt_publish_node_publishes_its_wired_input() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
+                node_data(
+                    "mqtt-1",
+                    "Mqtt",
+                    json!({ "broker": "b", "topic": "microflow/out", "direction": "publish", "wifiSsid": "net" }),
+                ),
+            ],
+            edges: vec![edge("sensor-1", "mqtt-1")],
+        };
+
+        let sketch = sketch_for(&flow, &networking_target());
+
+        assert!(sketch.contains("publish(mqtt_mqtt_1_topic"), "publishes on its topic");
+        assert!(sketch.contains("sensor_sensor_1_value"), "publishes the wired sensor value");
+    }
+
+    /// Scenario: Generated Mqtt sketch reflects supplied credentials.
+    #[test]
+    fn generated_mqtt_sketch_reflects_supplied_credentials() {
+        let flow = FlowUpdate {
+            nodes: vec![node_data(
+                "mqtt-1",
+                "Mqtt",
+                json!({
+                    "broker": "broker.example.com",
+                    "port": 8883,
+                    "topic": "microflow/sensor",
+                    "wifiSsid": "home-net",
+                    "wifiPassword": "s3cret",
+                    "brokerUsername": "user",
+                    "brokerPassword": "pass",
+                    "direction": "publish"
+                }),
+            )],
+            edges: vec![],
+        };
+
+        let sketch = sketch_for(&flow, &networking_target());
+
+        assert!(sketch.contains("\"home-net\""), "uses the supplied SSID");
+        assert!(sketch.contains("\"s3cret\""), "uses the supplied WiFi password");
+        assert!(sketch.contains("\"broker.example.com\""), "uses the supplied broker host");
+        assert!(sketch.contains("8883"), "uses the supplied port");
+        assert!(sketch.contains("\"user\", \"pass\""), "uses the broker auth credentials");
+        assert!(!sketch.contains("REPLACE_ME"), "no placeholder when creds supplied");
+    }
+
+    /// Scenario: Missing credentials produce a safe placeholder + warning.
+    #[test]
+    fn missing_mqtt_credentials_produce_a_safe_placeholder() {
+        let flow = FlowUpdate {
+            // No wifiSsid and no broker host supplied.
+            nodes: vec![node_data("mqtt-1", "Mqtt", json!({ "topic": "microflow/sensor", "direction": "publish" }))],
+            edges: vec![],
+        };
+
+        let sketch = sketch_for(&flow, &networking_target());
+
+        // A loud, compile-time warning rather than silent failure.
+        assert!(sketch.contains("#warning"), "warns the Author");
+        // A clearly-marked placeholder rather than an empty connection value.
+        assert!(sketch.contains("REPLACE_ME"), "emits a credential placeholder");
+        // It still emits connecting code (does not silently fail to connect).
+        assert!(sketch.contains("WiFi.mode(WIFI_STA)"), "still attempts to connect");
+    }
+
+    /// Mqtt emission is deterministic at the sketch level.
+    #[test]
+    fn mqtt_sketch_is_deterministic() {
+        let flow = FlowUpdate {
+            nodes: vec![node_data(
+                "mqtt-1",
+                "Mqtt",
+                json!({ "broker": "b", "topic": "t", "wifiSsid": "net", "direction": "publish" }),
+            )],
+            edges: vec![],
+        };
+        let esp32 = networking_target();
+        assert_eq!(sketch_for(&flow, &esp32), sketch_for(&flow, &esp32));
     }
 
     // --- Task #43: wire the selected target into generation ---
@@ -1367,8 +1501,9 @@ mod tests {
         assert!(!sketch.contains("// unsupported Node osc"), "oscillator must not be a placeholder");
     }
 
-    /// Scenario: No remaining non-Cloud Node is a placeholder, while Cloud Nodes
-    /// still fall through to placeholders (Feature #27 territory).
+    /// Scenario: No remaining non-Cloud Node is a placeholder. Mqtt now emits
+    /// real on-device code (Task #38); the remaining Cloud Nodes (Figma/Llm/
+    /// Monitor) still fall through to placeholders (Feature #27 territory).
     #[test]
     fn no_remaining_non_cloud_node_is_a_placeholder() {
         let flow = FlowUpdate {
@@ -1390,8 +1525,9 @@ mod tests {
                 node_data("st-1", "Stepper", json!({})),
                 node_data("vb-1", "Vibration", json!({})),
                 node_data("osc-1", "Oscillator", json!({})),
-                // Cloud Nodes remain placeholders (handled by Feature #27).
-                node("mqtt-1", "Mqtt"),
+                // Mqtt now emits real on-device code (Task #38).
+                node_data("mqtt-1", "Mqtt", json!({ "broker": "b", "topic": "t", "wifiSsid": "net" })),
+                // The remaining Cloud Nodes still fall through (Feature #27).
                 node("figma-1", "Figma"),
                 node("llm-1", "Llm"),
                 node("monitor-1", "Monitor"),
@@ -1403,12 +1539,15 @@ mod tests {
         // on the Uno they would be refused before emission.
         let sketch = sketch_for(&flow, &networking_target());
 
-        // Exactly the four Cloud Nodes are placeholders — nothing else.
+        // Exactly the three still-unsupported Cloud Nodes are placeholders.
         assert_eq!(
             sketch.matches("// unsupported Node ").count(),
-            4,
-            "only the four Cloud Nodes may be placeholders, got:\n{sketch}"
+            3,
+            "only the three remaining Cloud Nodes may be placeholders, got:\n{sketch}"
         );
+        // Mqtt is no longer a placeholder; it emits a real MQTT client.
+        assert!(!sketch.contains("// unsupported Node mqtt_1"), "Mqtt must emit real code");
+        assert!(sketch.contains("PubSubClient mqtt_mqtt_1_client"), "Mqtt client declared");
         // Spot-check that representative remaining Nodes emit real artefacts.
         assert!(sketch.contains("switch_sw_1_state"));
         assert!(sketch.contains("oscillator_osc_1_value"));


### PR DESCRIPTION
## Summary

Today the Mqtt Cloud Node falls through to a placeholder comment in codegen, so a flow with an Mqtt Node generates no runnable MQTT code. This Task gives the Mqtt Node a real on-device emission for a networking-capable target (ESP32): a Flow Author who builds a flow with an Mqtt Node and selects a WiFi-capable board now gets a sketch that, once flashed, connects to WiFi and the broker on boot and publishes/subscribes on its configured topic standalone — no host computer or Firmata tether. This is the first slice of Feature #27 (Cloud Nodes on a networked board) under Epic #22 (untether the board).

## Changes

- New `codegen/cloud/` module with `cloud/mqtt.rs`, an on-device Mqtt emitter mirroring the live `runtime/external/mqtt.rs` semantics (`direction` defaults to `subscribe`; publish Nodes send their wired input on the configured topic; subscribe Nodes subscribe and surface inbound messages as a Node-scoped value).
- Wired `"Mqtt"` into the `emit_node` and `source_expression` dispatch in `codegen/mod.rs`, replacing the placeholder for Mqtt only. Figma/Llm/Monitor still placeholder.
- Emits `#include <WiFi.h>` + `#include <PubSubClient.h>`, broker/topic/credential config read leniently from the Node `data`, and a non-blocking connect/reconnect helper that preserves the sketch's `millis()`-based scheduler invariant (no blocking `delay()`).
- Missing WiFi SSID or broker host emits a `REPLACE_ME` placeholder plus a `#warning` rather than silently connecting with empty values.
- Updated the three existing placeholder-oriented tests that previously treated Mqtt as a Cloud placeholder to use a still-placeholder Cloud Node (Figma).

## Test plan

- [x] Mqtt Node emits working code on a WiFi-capable target (libraries, WiFi+broker connect on boot, subscribe/publish on topic, connection maintained in loop)
- [x] Generated Mqtt sketch reflects supplied credentials (SSID/password/broker host/port/auth)
- [x] Missing credentials produce a safe placeholder (`#warning` + `REPLACE_ME`, still attempts to connect)
- [x] Mqtt on a non-networking target is still refused by validation
- [x] `cargo test --lib --tests` — 403 passing
- [x] `cargo clippy --all-targets -- -W clippy::pedantic -D warnings` — clean

## Related

Closes #38
