### PR TITLE
feat(codegen): emit Figma and Monitor Nodes over the network transport

### DIFF
--- a/apps/web/src-tauri/src/codegen/cloud/figma.rs
+++ b/apps/web/src-tauri/src/codegen/cloud/figma.rs
@@ -1,0 +1,267 @@
+//! Figma emitter — the on-device counterpart of `runtime/external/figma.rs`.
+//!
+//! The live Figma component bridges Figma design variables into the Flow **over
+//! MQTT**: it subscribes to the plugin/app variable topics for inbound values
+//! (surfacing the latest as its value) and, when driven, publishes the new value
+//! back to Figma on a `.../set` topic. On a networked target (ESP32) there is no
+//! host, so the generated Sketch does this itself using the **same network
+//! transport the Mqtt Node uses** (`WiFi` + `PubSubClient`), reusing the shared
+//! [`crate::codegen::cloud::transport`] bring-up and the shared `WiFi`
+//! credentials preamble. This mirrors the live semantics so standalone behaviour
+//! matches live mode.
+//!
+//! ## Config (`node.data`)
+//!
+//! Read leniently, accepting both the live runtime shape and the generation
+//! request shape:
+//! - `broker` / `brokerId` — broker host.
+//! - `port` — broker TCP port (default `1883`).
+//! - `uniqueId` — the microflow instance id used to build the topics.
+//! - `variableId` — the Figma `VariableID:123:456`, normalised to `123-456`.
+//! - `wifiSsid`, `brokerUsername`, `brokerPassword` — credentials. When
+//!   `wifiSsid`/`broker` are absent the Sketch emits a clearly-marked credential
+//!   placeholder and a `#warning` rather than silently failing to connect.
+//!
+//! Topics mirror the live component exactly:
+//! - inbound: `microflow/<uniqueId>/figma/variable/<shortVarId>` and
+//!   `microflow/<uniqueId>/app/variable/<shortVarId>`
+//! - outbound (set): `microflow/<uniqueId>/app/variable/<shortVarId>/set`
+//!
+//! Like every emitter this is a pure function of the [`FlowNode`]: identical
+//! input yields byte-identical output (determinism invariant).
+
+use crate::codegen::cloud::transport::{cpp_string, Subscription, Transport, DEFAULT_PORT};
+use crate::codegen::emit::{str_or_default, u16_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// A single config value read from `data`, first non-empty key winning.
+fn first_non_empty(node: &FlowNode, keys: &[&str], default: &str) -> String {
+    for key in keys {
+        let value = str_or_default(node, key, "");
+        if !value.is_empty() {
+            return value;
+        }
+    }
+    default.to_string()
+}
+
+/// Convert `VariableID:123:456` → `123-456`, mirroring
+/// `runtime/external/figma.rs::short_var_id`.
+fn short_var_id(variable_id: &str) -> String {
+    variable_id.replace("VariableID:", "").replace(':', "-")
+}
+
+/// Emit C++ for a Figma Cloud Node on a networked target.
+///
+/// `driver` is the C++ expression that, each time it changes, is published back
+/// to Figma (the new variable value). When unwired, the Node is subscribe-only.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let prefix = format!("figma_{token}");
+
+    let broker = first_non_empty(node, &["broker", "brokerId"], "");
+    let port = u16_or_default(node, "port", DEFAULT_PORT);
+    let unique_id = first_non_empty(node, &["uniqueId"], "");
+    let variable_id = first_non_empty(node, &["variableId"], "");
+    let wifi_ssid = first_non_empty(node, &["wifiSsid"], "");
+    let broker_user = first_non_empty(node, &["brokerUsername"], "");
+    let broker_pass = first_non_empty(node, &["brokerPassword"], "");
+
+    let short = short_var_id(&variable_id);
+    let plugin_topic = format!("microflow/{unique_id}/figma/variable/{short}");
+    let app_topic = format!("microflow/{unique_id}/app/variable/{short}");
+    let set_topic = format!("microflow/{unique_id}/app/variable/{short}/set");
+
+    // Missing essential connection details → loud placeholder + #warning.
+    let credentials_missing = wifi_ssid.is_empty() || broker.is_empty();
+
+    // Per-Node symbols.
+    let plugin_topic_var = format!("{prefix}_plugin_topic");
+    let app_topic_var = format!("{prefix}_app_topic");
+    let set_topic_var = format!("{prefix}_set_topic");
+    let value_var = format!("{prefix}_value");
+    let callback = format!("{prefix}_on_message");
+    let last_var = driver.map(|_| format!("{prefix}_last_published"));
+
+    let subscriptions = vec![
+        Subscription { topic_var: plugin_topic_var.clone() },
+        Subscription { topic_var: app_topic_var.clone() },
+    ];
+
+    let transport = Transport {
+        prefix: &prefix,
+        broker: &broker,
+        port,
+        broker_user: &broker_user,
+        broker_pass: &broker_pass,
+        subscriptions: &subscriptions,
+        on_message: Some(&callback),
+        kind: "Figma",
+        credentials_missing,
+    };
+
+    // Node-specific declarations: topic strings, the inbound value buffer, and
+    // the inbound-message callback that surfaces the latest value (mirrors the
+    // live component emitting a "change" downstream when a value arrives).
+    let mut extra_decls = vec![
+        format!("const char* {plugin_topic_var} = {};", cpp_string(&plugin_topic)),
+        format!("const char* {app_topic_var} = {};", cpp_string(&app_topic)),
+        format!("const char* {set_topic_var} = {};", cpp_string(&set_topic)),
+        format!("String {value_var};"),
+    ];
+    if let Some(last) = &last_var {
+        extra_decls.push(format!("String {last};"));
+    }
+    extra_decls.push(format!(
+        "void {callback}(char* topic, byte* payload, unsigned int length) {{"
+    ));
+    extra_decls.push(format!("  {value_var} = String();"));
+    extra_decls.push("  for (unsigned int i = 0; i < length; i++) {".to_string());
+    extra_decls.push(format!("    {value_var} += (char)payload[i];"));
+    extra_decls.push("  }".to_string());
+    extra_decls.push("}".to_string());
+
+    // loop() tail: when driven, publish the new value back to Figma on the set
+    // topic — but only when it changed, mirroring the live debounced dispatch
+    // (no host event loop here, so de-dupe on value change instead of time).
+    let mut loop_tail = Vec::new();
+    if let (Some(expr), Some(last)) = (driver, &last_var) {
+        let mqtt_client = transport.mqtt_client();
+        loop_tail.push(format!("if ({mqtt_client}.connected()) {{"));
+        loop_tail.push(format!("  String {prefix}_next = String({expr});"));
+        loop_tail.push(format!("  if ({prefix}_next != {last}) {{"));
+        loop_tail.push(format!("    {mqtt_client}.publish({set_topic_var}, {prefix}_next.c_str());"));
+        loop_tail.push(format!("    {last} = {prefix}_next;"));
+        loop_tail.push("  }".to_string());
+        loop_tail.push("}".to_string());
+    } else {
+        loop_tail.push(format!(
+            "// Figma Node {token} has no wired input — subscribe-only, nothing to publish"
+        ));
+    }
+
+    transport.emission(extra_decls, loop_tail)
+}
+
+/// The C++ expression downstream Nodes read for a Figma Node: the latest inbound
+/// variable value as a number (`toFloat`), mirroring the live component
+/// surfacing the arrived value.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> Option<String> {
+    let token = node.id_token();
+    Some(format!("figma_{token}_value.toFloat()"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn figma(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Figma".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    fn joined(lines: &[String]) -> String {
+        lines.join("\n")
+    }
+
+    /// Scenario: Figma Node emits working code on a `WiFi`-capable target — pulls
+    /// in the `WiFi` + MQTT client libraries (the network transport).
+    #[test]
+    fn figma_pulls_in_wifi_and_mqtt_client_libraries() {
+        let e = emit(
+            &figma("f-1", json!({ "broker": "b", "uniqueId": "u", "variableId": "VariableID:1:2", "wifiSsid": "net" })),
+            None,
+        );
+        assert!(e.includes.iter().any(|i| i.contains("WiFi.h")), "missing WiFi include");
+        assert!(e.includes.iter().any(|i| i.contains("PubSubClient.h")), "missing MQTT client include");
+    }
+
+    /// Scenario: the Sketch connects to the network/broker on boot and drives the
+    /// Figma Node over the network transport (subscribes to its variable topics).
+    #[test]
+    fn connects_and_subscribes_to_figma_variable_topics() {
+        let e = emit(
+            &figma(
+                "f-1",
+                json!({ "broker": "broker.example.com", "uniqueId": "abc", "variableId": "VariableID:123:456", "wifiSsid": "net" }),
+            ),
+            None,
+        );
+        let decls = joined(&e.declarations);
+        let setup = joined(&e.setup);
+        assert!(setup.contains("ensure_connected()"), "connects on boot");
+        assert!(decls.contains("setServer(figma_f_1_broker"), "points at the broker");
+        // Topics mirror the live component (short var id 123-456).
+        assert!(decls.contains("microflow/abc/figma/variable/123-456"), "plugin topic");
+        assert!(decls.contains("microflow/abc/app/variable/123-456"), "app topic");
+        assert!(decls.contains("subscribe(figma_f_1_plugin_topic)"), "subscribes plugin topic");
+        assert!(decls.contains("subscribe(figma_f_1_app_topic)"), "subscribes app topic");
+    }
+
+    /// A subscribe-only Figma Node surfaces inbound values for downstream Nodes.
+    #[test]
+    fn surfaces_inbound_variable_value() {
+        let n = figma("f-1", json!({ "broker": "b", "uniqueId": "u", "variableId": "VariableID:1:2", "wifiSsid": "net" }));
+        let e = emit(&n, None);
+        let decls = joined(&e.declarations);
+        assert!(decls.contains("figma_f_1_value"), "buffers the inbound value");
+        assert!(decls.contains("setCallback") || joined(&e.setup).contains("setCallback"));
+        assert_eq!(value_var(&n).as_deref(), Some("figma_f_1_value.toFloat()"));
+    }
+
+    /// A driven Figma Node publishes the new value back to Figma on the set
+    /// topic — over the same network transport.
+    #[test]
+    fn driven_node_publishes_value_back_to_figma() {
+        let e = emit(
+            &figma("f-1", json!({ "broker": "b", "uniqueId": "u", "variableId": "VariableID:1:2", "wifiSsid": "net" })),
+            Some("sensor_s_1_value"),
+        );
+        let body = joined(&e.loop_body);
+        let decls = joined(&e.declarations);
+        assert!(decls.contains("microflow/u/app/variable/1-2/set"), "set topic mirrors live");
+        assert!(body.contains("publish(figma_f_1_set_topic"), "publishes to the set topic");
+        assert!(body.contains("sensor_s_1_value"), "publishes the driven value");
+    }
+
+    /// Scenario: the loop maintains the connection (reconnect on drop).
+    #[test]
+    fn loop_maintains_connection_and_pumps_client() {
+        let e = emit(&figma("f-1", json!({ "broker": "b", "uniqueId": "u", "variableId": "VariableID:1:2", "wifiSsid": "net" })), None);
+        let body = joined(&e.loop_body);
+        assert!(body.contains("ensure_connected()"), "reconnects in loop");
+        assert!(body.contains("figma_f_1_client.loop()"), "pumps the MQTT client");
+    }
+
+    /// Scenario: Missing credentials produce a safe placeholder + a warning.
+    #[test]
+    fn missing_credentials_produce_safe_placeholder_and_warning() {
+        let e = emit(&figma("f-1", json!({ "uniqueId": "u", "variableId": "VariableID:1:2" })), Some("v"));
+        let decls = joined(&e.declarations);
+        assert!(decls.contains("REPLACE_ME"), "emits a credential placeholder");
+        assert!(decls.contains("#warning"), "warns the Author at compile time");
+        assert!(joined(&e.setup).contains("ensure_connected()"), "still attempts to connect");
+    }
+
+    /// Determinism: identical Node yields byte-identical emission.
+    #[test]
+    fn emits_deterministically() {
+        let n = figma("f-1", json!({ "broker": "b", "uniqueId": "u", "variableId": "VariableID:1:2", "wifiSsid": "net" }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+
+    /// Topic strings are escaped so generation stays valid.
+    #[test]
+    fn topics_are_escaped() {
+        let e = emit(&figma("f-1", json!({ "broker": "b", "uniqueId": "a\"b", "variableId": "VariableID:1:2", "wifiSsid": "net" })), None);
+        assert!(joined(&e.declarations).contains("a\\\"b"), "escapes the quote in the topic");
+    }
+}

--- a/apps/web/src-tauri/src/codegen/cloud/mod.rs
+++ b/apps/web/src-tauri/src/codegen/cloud/mod.rs
@@ -7,8 +7,17 @@
 //! a non-networking board, so an emitter in this module may assume the target
 //! offers [`crate::codegen::board::BoardCapability::Networking`].
 //!
-//! Only the `Mqtt` Node has an on-device emitter today (Task #38). The other
-//! Cloud Nodes still fall through to [`crate::codegen::placeholder`] until their
-//! own tasks land.
+//! `Mqtt` (Task #38), `Figma` and `Monitor` (Task #42) have on-device emitters.
+//! The remaining Cloud Node (`Llm`) still falls through to
+//! [`crate::codegen::placeholder`] until its own task lands.
+//!
+//! `Figma` and `Monitor` both bridge over the **same network transport the Mqtt
+//! Node uses** — `WiFi` + an MQTT client (`PubSubClient`). The shared
+//! [`transport`] helper owns that broker bring-up so neither emitter duplicates
+//! the connect logic; the `WiFi` setup itself is reused from
+//! [`crate::codegen::credentials`] rather than re-emitted here.
 
+pub mod figma;
+pub mod monitor;
 pub mod mqtt;
+pub mod transport;

--- a/apps/web/src-tauri/src/codegen/cloud/monitor.rs
+++ b/apps/web/src-tauri/src/codegen/cloud/monitor.rs
@@ -1,0 +1,189 @@
+//! Monitor emitter — the on-device counterpart of `runtime/output/monitor.rs`.
+//!
+//! The live Monitor component is a display-only sink: it receives values on its
+//! `value` port and stores them for visualisation in the host frontend. There is
+//! no hardware interaction. On a networked target (ESP32) there is no host to
+//! store into, so the standalone analogue is to **send each received value over
+//! the same network transport the Mqtt Node uses** (`WiFi` + `PubSubClient`) on a
+//! deterministic monitor topic, so a host can still visualise the device's
+//! values. This mirrors the live "receive a value → surface it" semantics,
+//! redirected onto the network since no host event loop is present.
+//!
+//! The transport bring-up and `WiFi` credential reuse are shared via
+//! [`crate::codegen::cloud::transport`] / [`crate::codegen::credentials`].
+//!
+//! ## Config (`node.data`)
+//!
+//! Read leniently, accepting both the live runtime shape and the generation
+//! request shape:
+//! - `broker` / `brokerId` — broker host.
+//! - `port` — broker TCP port (default `1883`).
+//! - `uniqueId` — the microflow instance id used to build the topic.
+//! - `wifiSsid`, `brokerUsername`, `brokerPassword` — credentials. When
+//!   `wifiSsid`/`broker` are absent the Sketch emits a clearly-marked credential
+//!   placeholder and a `#warning` rather than silently failing to connect.
+//!
+//! Topic: `microflow/<uniqueId>/monitor/<token>` — Node-scoped so multiple
+//! Monitor Nodes publish to distinct topics.
+//!
+//! Like every emitter this is a pure function of the [`FlowNode`]: identical
+//! input yields byte-identical output (determinism invariant).
+
+use crate::codegen::cloud::transport::{cpp_string, Transport, DEFAULT_PORT};
+use crate::codegen::emit::{str_or_default, u16_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// A single config value read from `data`, first non-empty key winning.
+fn first_non_empty(node: &FlowNode, keys: &[&str], default: &str) -> String {
+    for key in keys {
+        let value = str_or_default(node, key, "");
+        if !value.is_empty() {
+            return value;
+        }
+    }
+    default.to_string()
+}
+
+/// Emit C++ for a Monitor Cloud Node on a networked target.
+///
+/// `driver` is the C++ expression for the value flowing into the Monitor; each
+/// time it changes the Sketch publishes it on the monitor topic. An unwired
+/// Monitor has nothing to display, so it only maintains its connection.
+#[must_use]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+    let prefix = format!("monitor_{token}");
+
+    let broker = first_non_empty(node, &["broker", "brokerId"], "");
+    let port = u16_or_default(node, "port", DEFAULT_PORT);
+    let unique_id = first_non_empty(node, &["uniqueId"], "");
+    let wifi_ssid = first_non_empty(node, &["wifiSsid"], "");
+    let broker_user = first_non_empty(node, &["brokerUsername"], "");
+    let broker_pass = first_non_empty(node, &["brokerPassword"], "");
+
+    let topic = format!("microflow/{unique_id}/monitor/{token}");
+    let credentials_missing = wifi_ssid.is_empty() || broker.is_empty();
+
+    let topic_var = format!("{prefix}_topic");
+    let last_var = driver.map(|_| format!("{prefix}_last_published"));
+
+    // Monitor is publish-only — it never subscribes.
+    let transport = Transport {
+        prefix: &prefix,
+        broker: &broker,
+        port,
+        broker_user: &broker_user,
+        broker_pass: &broker_pass,
+        subscriptions: &[],
+        on_message: None,
+        kind: "Monitor",
+        credentials_missing,
+    };
+
+    let mut extra_decls = vec![format!("const char* {topic_var} = {};", cpp_string(&topic))];
+    if let Some(last) = &last_var {
+        extra_decls.push(format!("String {last};"));
+    }
+
+    // loop() tail: publish each received value on change (mirrors the live sink
+    // surfacing the latest value; de-dupe on change since there is no host loop).
+    let mut loop_tail = Vec::new();
+    if let (Some(expr), Some(last)) = (driver, &last_var) {
+        let mqtt_client = transport.mqtt_client();
+        loop_tail.push(format!("if ({mqtt_client}.connected()) {{"));
+        loop_tail.push(format!("  String {prefix}_next = String({expr});"));
+        loop_tail.push(format!("  if ({prefix}_next != {last}) {{"));
+        loop_tail.push(format!("    {mqtt_client}.publish({topic_var}, {prefix}_next.c_str());"));
+        loop_tail.push(format!("    {last} = {prefix}_next;"));
+        loop_tail.push("  }".to_string());
+        loop_tail.push("}".to_string());
+    } else {
+        loop_tail.push(format!(
+            "// Monitor Node {token} has no wired input — nothing to display/publish"
+        ));
+    }
+
+    transport.emission(extra_decls, loop_tail)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn monitor(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Monitor".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    fn joined(lines: &[String]) -> String {
+        lines.join("\n")
+    }
+
+    /// Scenario: Monitor Node emits working code on a `WiFi`-capable target —
+    /// pulls in the `WiFi` + MQTT client libraries (the network transport).
+    #[test]
+    fn monitor_pulls_in_wifi_and_mqtt_client_libraries() {
+        let e = emit(&monitor("mon-1", json!({ "broker": "b", "uniqueId": "u", "wifiSsid": "net" })), Some("v"));
+        assert!(e.includes.iter().any(|i| i.contains("WiFi.h")), "missing WiFi include");
+        assert!(e.includes.iter().any(|i| i.contains("PubSubClient.h")), "missing MQTT client include");
+    }
+
+    /// Scenario: connects on boot and drives the Monitor over the network
+    /// transport (publishes received values on its monitor topic).
+    #[test]
+    fn connects_and_publishes_received_values_over_transport() {
+        let e = emit(
+            &monitor("mon-1", json!({ "broker": "broker.example.com", "uniqueId": "abc", "wifiSsid": "net" })),
+            Some("sensor_s_1_value"),
+        );
+        let decls = joined(&e.declarations);
+        let setup = joined(&e.setup);
+        let body = joined(&e.loop_body);
+        assert!(setup.contains("ensure_connected()"), "connects on boot");
+        assert!(decls.contains("setServer(monitor_mon_1_broker"), "points at the broker");
+        assert!(decls.contains("microflow/abc/monitor/mon_1"), "monitor topic is node-scoped");
+        assert!(body.contains("publish(monitor_mon_1_topic"), "publishes on its topic");
+        assert!(body.contains("sensor_s_1_value"), "publishes the received value");
+    }
+
+    /// Scenario: the loop maintains the connection (reconnect on drop).
+    #[test]
+    fn loop_maintains_connection_and_pumps_client() {
+        let e = emit(&monitor("mon-1", json!({ "broker": "b", "uniqueId": "u", "wifiSsid": "net" })), Some("v"));
+        let body = joined(&e.loop_body);
+        assert!(body.contains("ensure_connected()"), "reconnects in loop");
+        assert!(body.contains("monitor_mon_1_client.loop()"), "pumps the MQTT client");
+    }
+
+    /// An unwired Monitor still connects but has nothing to publish.
+    #[test]
+    fn unwired_monitor_has_nothing_to_publish() {
+        let e = emit(&monitor("mon-1", json!({ "broker": "b", "uniqueId": "u", "wifiSsid": "net" })), None);
+        let body = joined(&e.loop_body);
+        assert!(body.contains("nothing to display"), "no publish without a wired input");
+        assert!(!body.contains("publish(monitor_mon_1_topic"), "does not publish when unwired");
+    }
+
+    /// Scenario: Missing credentials produce a safe placeholder + a warning.
+    #[test]
+    fn missing_credentials_produce_safe_placeholder_and_warning() {
+        let e = emit(&monitor("mon-1", json!({ "uniqueId": "u" })), Some("v"));
+        let decls = joined(&e.declarations);
+        assert!(decls.contains("REPLACE_ME"), "emits a credential placeholder");
+        assert!(decls.contains("#warning"), "warns the Author at compile time");
+        assert!(joined(&e.setup).contains("ensure_connected()"), "still attempts to connect");
+    }
+
+    /// Determinism: identical Node yields byte-identical emission.
+    #[test]
+    fn emits_deterministically() {
+        let n = monitor("mon-1", json!({ "broker": "b", "uniqueId": "u", "wifiSsid": "net" }));
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/cloud/transport.rs
+++ b/apps/web/src-tauri/src/codegen/cloud/transport.rs
@@ -1,0 +1,311 @@
+//! Shared on-device network transport for Cloud Nodes that bridge over MQTT.
+//!
+//! `Figma` and `Monitor` both talk to the host/plugin over the **same network
+//! transport the Mqtt Node uses**: `WiFi` (ESP32 core) plus an MQTT client
+//! (`PubSubClient`). Rather than each emitter re-implementing the `WiFi`/broker
+//! bring-up, they share this helper, which builds a token-scoped, non-blocking
+//! (re)connect routine mirroring `cloud::mqtt`'s `ensure_connected` shape.
+//!
+//! The `WiFi` SSID/password themselves come from the shared credentials surface
+//! ([`crate::codegen::credentials::wifi_preamble`]), which the assembler injects
+//! once per Sketch — this helper therefore only owns the *broker* connection and
+//! the per-Node MQTT client, never a second copy of the `WiFi` setup.
+//!
+//! Like every emitter, the produced fragments are a pure function of their
+//! inputs: identical configuration yields byte-identical text (determinism).
+
+use crate::codegen::emit::NodeEmission;
+
+/// Default broker port — standard unencrypted MQTT, matching `cloud::mqtt`.
+pub const DEFAULT_PORT: u16 = 1883;
+/// Sentinel emitted in place of a missing credential so the Sketch never
+/// silently connects with an empty value. Matches `cloud::mqtt::PLACEHOLDER`.
+pub const PLACEHOLDER: &str = "REPLACE_ME";
+
+/// Escape a string for embedding inside a C++ double-quoted literal so a stray
+/// quote/backslash/newline can never break the generated Sketch.
+#[must_use]
+pub fn cpp_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// The `WiFi` + MQTT client includes shared by every MQTT-bridging Cloud Node.
+/// De-duplicated by the assembler against the credentials preamble's `WiFi.h`.
+#[must_use]
+pub fn includes() -> Vec<String> {
+    vec![
+        "#include <WiFi.h>".to_string(),
+        "#include <PubSubClient.h>".to_string(),
+    ]
+}
+
+/// A topic this Node subscribes to on every (re)connect, mapped to nothing —
+/// subscriptions are emitted into the connect routine.
+#[derive(Debug, Clone)]
+pub struct Subscription {
+    /// The C++ expression naming the topic to subscribe to (a `const char*`).
+    pub topic_var: String,
+}
+
+/// Configuration for the shared MQTT transport of one Cloud Node.
+pub struct Transport<'a> {
+    /// Per-Node prefix (e.g. `figma_f_1`) keeping every symbol Node-scoped so
+    /// multiple Cloud Nodes coexist in one Sketch.
+    pub prefix: &'a str,
+    /// Broker host (already resolved; empty → placeholder + warning).
+    pub broker: &'a str,
+    /// Broker TCP port.
+    pub port: u16,
+    /// Optional broker username (empty → anonymous connect).
+    pub broker_user: &'a str,
+    /// Optional broker password (only used when `broker_user` is set).
+    pub broker_pass: &'a str,
+    /// Topics to (re)subscribe on every connect.
+    pub subscriptions: &'a [Subscription],
+    /// Optional inbound-message callback name. When set, the connect routine
+    /// installs it via `setCallback` and the caller is expected to declare it.
+    pub on_message: Option<&'a str>,
+    /// Human-readable Node kind for the missing-credentials `#warning`.
+    pub kind: &'a str,
+    /// True when essential connection details are absent (emits placeholder +
+    /// `#warning` so the Author is told rather than silently failing).
+    pub credentials_missing: bool,
+}
+
+impl Transport<'_> {
+    /// The per-Node `WiFiClient` symbol.
+    fn wifi_client(&self) -> String {
+        format!("{}_wifi_client", self.prefix)
+    }
+
+    /// The per-Node `PubSubClient` symbol downstream code publishes through.
+    #[must_use]
+    pub fn mqtt_client(&self) -> String {
+        format!("{}_client", self.prefix)
+    }
+
+    /// The per-Node broker host symbol.
+    fn broker_var(&self) -> String {
+        format!("{}_broker", self.prefix)
+    }
+
+    /// The per-Node broker port symbol.
+    fn port_var(&self) -> String {
+        format!("{}_port", self.prefix)
+    }
+
+    /// The per-Node MQTT client-id symbol.
+    fn client_id_var(&self) -> String {
+        format!("{}_client_id", self.prefix)
+    }
+
+    /// The per-Node `ensure_connected` routine name.
+    #[must_use]
+    pub fn ensure_fn(&self) -> String {
+        format!("{}_ensure_connected", self.prefix)
+    }
+
+    /// Global declarations: broker config, the MQTT client, the (re)connect
+    /// routine, and — when credentials are missing — a `#warning`.
+    ///
+    /// `extra_decls` are the caller's Node-specific declarations (e.g. topic
+    /// strings and value buffers), emitted before the connect routine so it can
+    /// reference them.
+    #[must_use]
+    pub fn declarations(&self, extra_decls: Vec<String>) -> Vec<String> {
+        let broker_lit = cpp_string(if self.broker.is_empty() { PLACEHOLDER } else { self.broker });
+        let client_id_lit = cpp_string(&format!("microflow-{}", self.prefix));
+
+        let mut decls = Vec::new();
+        if self.credentials_missing {
+            decls.push(format!(
+                "#warning \"{} Node {}: missing network credentials — using {PLACEHOLDER} placeholder; set WiFi SSID and broker before flashing\"",
+                self.kind, self.prefix
+            ));
+        }
+        decls.push(format!("const char* {} = {broker_lit};", self.broker_var()));
+        decls.push(format!("const uint16_t {} = {};", self.port_var(), self.port));
+        decls.push(format!("const char* {} = {client_id_lit};", self.client_id_var()));
+        decls.push(format!("WiFiClient {};", self.wifi_client()));
+        decls.push(format!("PubSubClient {}({});", self.mqtt_client(), self.wifi_client()));
+
+        decls.extend(extra_decls);
+
+        // Connect/auth arguments differ when a broker username is configured.
+        let connect_call = if self.broker_user.is_empty() {
+            format!("{}.connect({})", self.mqtt_client(), self.client_id_var())
+        } else {
+            format!(
+                "{}.connect({}, {}, {})",
+                self.mqtt_client(),
+                self.client_id_var(),
+                cpp_string(self.broker_user),
+                cpp_string(if self.broker_pass.is_empty() { PLACEHOLDER } else { self.broker_pass })
+            )
+        };
+
+        // Non-blocking (re)connect: ensure WiFi is up, then the broker. Returns
+        // immediately so the `millis()`-based scheduler keeps ticking. The WiFi
+        // bring-up itself is owned by the shared credentials preamble; here we
+        // only wait for it to be connected before touching the broker.
+        decls.push(format!("void {}() {{", self.ensure_fn()));
+        decls.push("  if (WiFi.status() != WL_CONNECTED) {".to_string());
+        decls.push("    return; // WiFi not up yet; retry on the next loop tick".to_string());
+        decls.push("  }".to_string());
+        decls.push(format!("  if (!{}.connected()) {{", self.mqtt_client()));
+        decls.push(format!("    {}.setServer({}, {});", self.mqtt_client(), self.broker_var(), self.port_var()));
+        decls.push(format!("    if ({connect_call}) {{"));
+        if self.subscriptions.is_empty() {
+            decls.push("      // no inbound topics to subscribe".to_string());
+        } else {
+            for sub in self.subscriptions {
+                decls.push(format!("      {}.subscribe({});", self.mqtt_client(), sub.topic_var));
+            }
+        }
+        decls.push("    }".to_string());
+        decls.push("  }".to_string());
+        decls.push("}".to_string());
+
+        decls
+    }
+
+    /// `setup()` statements: point the client at the broker, install the inbound
+    /// callback (if any), and kick off the first connect attempt. `WiFi.mode` /
+    /// `WiFi.begin` are owned by the shared credentials preamble.
+    #[must_use]
+    pub fn setup(&self) -> Vec<String> {
+        let mut setup = vec![format!(
+            "{}.setServer({}, {});",
+            self.mqtt_client(),
+            self.broker_var(),
+            self.port_var()
+        )];
+        if let Some(cb) = self.on_message {
+            setup.push(format!("{}.setCallback({cb});", self.mqtt_client()));
+        }
+        setup.push(format!("{}();", self.ensure_fn()));
+        setup
+    }
+
+    /// `loop()` statements every MQTT-bridging Node shares: maintain the
+    /// connection (reconnect on drop) and pump the client. The caller appends
+    /// its own publish logic after these.
+    #[must_use]
+    pub fn loop_prelude(&self) -> Vec<String> {
+        vec![
+            format!("{}();", self.ensure_fn()),
+            format!("{}.loop();", self.mqtt_client()),
+        ]
+    }
+
+    /// Assemble a full [`NodeEmission`] from the shared fragments plus the
+    /// caller's Node-specific declarations and loop body.
+    #[must_use]
+    pub fn emission(&self, extra_decls: Vec<String>, loop_tail: Vec<String>) -> NodeEmission {
+        let mut loop_body = self.loop_prelude();
+        loop_body.extend(loop_tail);
+        NodeEmission {
+            includes: includes(),
+            declarations: self.declarations(extra_decls),
+            setup: self.setup(),
+            loop_body,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base<'a>(prefix: &'a str, subs: &'a [Subscription]) -> Transport<'a> {
+        Transport {
+            prefix,
+            broker: "broker.example.com",
+            port: DEFAULT_PORT,
+            broker_user: "",
+            broker_pass: "",
+            subscriptions: subs,
+            on_message: None,
+            kind: "Test",
+            credentials_missing: false,
+        }
+    }
+
+    #[test]
+    fn includes_pull_in_wifi_and_mqtt_client() {
+        let inc = includes();
+        assert!(inc.iter().any(|i| i.contains("WiFi.h")));
+        assert!(inc.iter().any(|i| i.contains("PubSubClient.h")));
+    }
+
+    #[test]
+    fn connect_routine_waits_for_wifi_then_broker() {
+        let t = base("x_1", &[]);
+        let decls = t.declarations(vec![]).join("\n");
+        assert!(decls.contains("WiFi.status() != WL_CONNECTED"), "waits for WiFi");
+        assert!(decls.contains("x_1_client.setServer(x_1_broker, x_1_port)"), "points at broker");
+        assert!(decls.contains("x_1_client.connect(x_1_client_id)"), "anonymous connect");
+        // The WiFi bring-up is owned by the credentials preamble, not here.
+        assert!(!decls.contains("WiFi.begin"), "does not duplicate WiFi setup");
+    }
+
+    #[test]
+    fn subscriptions_are_emitted_into_the_connect_routine() {
+        let subs = [Subscription { topic_var: "x_1_topic".to_string() }];
+        let t = base("x_1", &subs);
+        assert!(t.declarations(vec![]).join("\n").contains("subscribe(x_1_topic)"));
+    }
+
+    #[test]
+    fn broker_auth_used_when_username_present() {
+        let mut t = base("x_1", &[]);
+        t.broker_user = "user";
+        t.broker_pass = "pass"; // ggignore
+        assert!(t
+            .declarations(vec![])
+            .join("\n")
+            .contains("connect(x_1_client_id, \"user\", \"pass\")"));
+    }
+
+    #[test]
+    fn missing_credentials_emit_warning_and_placeholder() {
+        let mut t = base("x_1", &[]);
+        t.broker = "";
+        t.credentials_missing = true;
+        let decls = t.declarations(vec![]).join("\n");
+        assert!(decls.contains("#warning"), "warns the Author");
+        assert!(decls.contains("REPLACE_ME"), "emits a placeholder broker");
+    }
+
+    #[test]
+    fn loop_prelude_reconnects_and_pumps() {
+        let t = base("x_1", &[]);
+        let body = t.loop_prelude().join("\n");
+        assert!(body.contains("x_1_ensure_connected()"), "reconnects in loop");
+        assert!(body.contains("x_1_client.loop()"), "pumps the client");
+    }
+
+    #[test]
+    fn setup_installs_callback_when_present() {
+        let mut t = base("x_1", &[]);
+        t.on_message = Some("x_1_on_message");
+        assert!(t.setup().join("\n").contains("setCallback(x_1_on_message)"));
+    }
+
+    #[test]
+    fn cpp_string_escapes_quotes_and_backslashes() {
+        assert_eq!(cpp_string("a\"b\\c"), "\"a\\\"b\\\\c\"");
+    }
+}

--- a/apps/web/src-tauri/src/codegen/mod.rs
+++ b/apps/web/src-tauri/src/codegen/mod.rs
@@ -271,11 +271,13 @@ fn emit_node(
         Some("Trigger") => control::trigger::emit(node, driver),
         Some("Counter") => control::counter::emit(node, driver),
         Some("Constant") => control::constant::emit(node),
-        // Mqtt is the one Cloud Node with an on-device emitter (Task #38). It
-        // only reaches here on a networking target — validation refuses it
-        // otherwise. The other Cloud Nodes (Figma/Llm/Monitor) still fall
-        // through to the placeholder below.
+        // Cloud Nodes with an on-device emitter only reach here on a networking
+        // target — validation refuses them otherwise. Mqtt (Task #38), Figma and
+        // Monitor (Task #42) bridge over the network transport; the remaining
+        // Cloud Node (Llm) still falls through to the placeholder below.
         Some("Mqtt") => cloud::mqtt::emit(node, driver),
+        Some("Figma") => cloud::figma::emit(node, driver),
+        Some("Monitor") => cloud::monitor::emit(node, driver),
         _ => placeholder::emit(node),
     }
 }
@@ -343,6 +345,9 @@ fn source_expression(node: &FlowNode) -> Option<String> {
         // A subscribe Mqtt Node surfaces its latest inbound message as a value;
         // a publish Mqtt Node exposes none (returns `None`).
         Some("Mqtt") => cloud::mqtt::value_var(node),
+        // A Figma Node surfaces the latest inbound variable value downstream.
+        // Monitor is a display-only sink and exposes no readable value.
+        Some("Figma") => cloud::figma::value_var(node),
         _ => None,
     }
 }
@@ -773,14 +778,14 @@ mod tests {
 
     /// Scenario: An unsupported Node becomes a placeholder comment.
     ///
-    /// A Cloud Node (Figma — still without an on-device emitter) alongside a
+    /// A Cloud Node (Llm — still without an on-device emitter) alongside a
     /// core Led: the Cloud Node gets a clear placeholder comment, the Led still
     /// emits real code, and generation does not crash or blank the sketch.
     #[test]
     fn cloud_node_becomes_placeholder_while_core_node_still_emits() {
         let flow = FlowUpdate {
             nodes: vec![
-                node("figma-1", "Figma"),
+                node("llm-1", "Llm"),
                 node_data("led-1", "Led", json!({ "pin": 13 })),
             ],
             edges: vec![],
@@ -792,8 +797,8 @@ mod tests {
 
         // Placeholder for the Cloud Node, identifying it and the networked need.
         assert!(
-            sketch.contains("// unsupported Node figma_1 (Figma)"),
-            "missing Figma placeholder, got:\n{sketch}"
+            sketch.contains("// unsupported Node llm_1 (Llm)"),
+            "missing Llm placeholder, got:\n{sketch}"
         );
         assert!(sketch.contains("networked target"), "Cloud message missing");
         // The Led still produces real code.
@@ -827,20 +832,16 @@ mod tests {
 
     /// Scenario: A Flow of only unsupported Nodes still yields a valid sketch.
     ///
-    /// Mqtt now has an on-device emitter (Task #38), so the remaining
-    /// still-unsupported Cloud Nodes are Figma/Llm/Monitor.
+    /// Mqtt (Task #38), Figma and Monitor (Task #42) now have on-device
+    /// emitters, so the only still-unsupported Cloud Node is Llm.
     #[test]
     fn all_unsupported_flow_yields_valid_sketch() {
         let flow = FlowUpdate {
-            nodes: vec![
-                node("figma-1", "Figma"),
-                node("llm-1", "Llm"),
-                node("monitor-1", "Monitor"),
-            ],
+            nodes: vec![node("llm-1", "Llm"), node("gizmo-1", "Gizmo")],
             edges: vec![],
         };
 
-        // All Cloud Nodes — runnable only on a networking board (ESP32).
+        // Llm is a Cloud Node — runnable only on a networking board (ESP32).
         let sketch = sketch_for(&flow, &networking_target());
 
         // A structurally valid sketch is still produced.
@@ -849,7 +850,7 @@ mod tests {
         // A placeholder for every unsupported Node.
         assert_eq!(
             sketch.matches("// unsupported Node ").count(),
-            3,
+            2,
             "expected one placeholder per unsupported node, got:\n{sketch}"
         );
     }
@@ -1645,9 +1646,9 @@ mod tests {
         assert!(!sketch.contains("// unsupported Node osc"), "oscillator must not be a placeholder");
     }
 
-    /// Scenario: No remaining non-Cloud Node is a placeholder. Mqtt now emits
-    /// real on-device code (Task #38); the remaining Cloud Nodes (Figma/Llm/
-    /// Monitor) still fall through to placeholders (Feature #27 territory).
+    /// Scenario: No remaining non-Cloud Node is a placeholder. Mqtt (Task #38),
+    /// Figma and Monitor (Task #42) now emit real on-device code; only the Llm
+    /// Cloud Node still falls through to a placeholder (Feature #27 territory).
     #[test]
     fn no_remaining_non_cloud_node_is_a_placeholder() {
         let flow = FlowUpdate {
@@ -1669,12 +1670,12 @@ mod tests {
                 node_data("st-1", "Stepper", json!({})),
                 node_data("vb-1", "Vibration", json!({})),
                 node_data("osc-1", "Oscillator", json!({})),
-                // Mqtt now emits real on-device code (Task #38).
+                // Mqtt, Figma and Monitor now emit real on-device code.
                 node_data("mqtt-1", "Mqtt", json!({ "broker": "b", "topic": "t", "wifiSsid": "net" })),
-                // The remaining Cloud Nodes still fall through (Feature #27).
-                node("figma-1", "Figma"),
+                node_data("figma-1", "Figma", json!({ "broker": "b", "uniqueId": "u", "variableId": "VariableID:1:2", "wifiSsid": "net" })),
+                node_data("monitor-1", "Monitor", json!({ "broker": "b", "uniqueId": "u", "wifiSsid": "net" })),
+                // Only the Llm Cloud Node still falls through (Feature #27).
                 node("llm-1", "Llm"),
-                node("monitor-1", "Monitor"),
             ],
             edges: vec![],
         };
@@ -1683,15 +1684,19 @@ mod tests {
         // on the Uno they would be refused before emission.
         let sketch = sketch_for(&flow, &networking_target());
 
-        // Exactly the three still-unsupported Cloud Nodes are placeholders.
+        // Only the Llm Cloud Node is still a placeholder.
         assert_eq!(
             sketch.matches("// unsupported Node ").count(),
-            3,
-            "only the three remaining Cloud Nodes may be placeholders, got:\n{sketch}"
+            1,
+            "only the Llm Cloud Node may be a placeholder, got:\n{sketch}"
         );
-        // Mqtt is no longer a placeholder; it emits a real MQTT client.
+        // Mqtt/Figma/Monitor are no longer placeholders; they emit real clients.
         assert!(!sketch.contains("// unsupported Node mqtt_1"), "Mqtt must emit real code");
+        assert!(!sketch.contains("// unsupported Node figma_1"), "Figma must emit real code");
+        assert!(!sketch.contains("// unsupported Node monitor_1"), "Monitor must emit real code");
         assert!(sketch.contains("PubSubClient mqtt_mqtt_1_client"), "Mqtt client declared");
+        assert!(sketch.contains("PubSubClient figma_figma_1_client"), "Figma client declared");
+        assert!(sketch.contains("PubSubClient monitor_monitor_1_client"), "Monitor client declared");
         // Spot-check that representative remaining Nodes emit real artefacts.
         assert!(sketch.contains("switch_sw_1_state"));
         assert!(sketch.contains("oscillator_osc_1_value"));


### PR DESCRIPTION
## Summary

The Figma and Monitor Cloud Nodes previously fell through to placeholder comments during sketch generation, so a Flow Author who used them and selected a WiFi-capable board (ESP32) got no standalone behavior. This task gives both Nodes a real on-device emission over the network transport, so the flashed device participates on its own — mirroring the live (host-driven) semantics. Serves Feature #27 (generate sketches for Cloud Nodes on a networked board) under Epic #22 (untether the board).

## Changes

- **Shared MQTT transport helper** (`codegen/cloud/transport.rs`): the `WiFi` + `PubSubClient` broker bring-up shared by Figma and Monitor — a non-blocking `ensure_connected` (reconnect each `loop()` tick), per-Node-scoped symbols, subscriptions, and a publish client. `WiFi` setup itself is reused from the existing `codegen/credentials.rs` preamble rather than duplicated.
- **Figma emitter** (`codegen/cloud/figma.rs`): mirrors `runtime/external/figma.rs` — subscribes to `microflow/<uniqueId>/figma|app/variable/<shortVarId>` for inbound values (surfaced downstream via `value_var`), and publishes driven values back to Figma on the `.../set` topic.
- **Monitor emitter** (`codegen/cloud/monitor.rs`): the live Monitor is a display sink; standalone it publishes each received value on `microflow/<uniqueId>/monitor/<token>` over the same transport so a host can still visualise the device.
- **Dispatch wiring** (`codegen/mod.rs`, `codegen/cloud/mod.rs`): `Figma`/`Monitor` wired into `emit_node`; `Figma` into `source_expression`. Llm and any other Cloud Node still placeholder. Placeholder integration tests updated so `Llm` is now the sole placeholdered Cloud Node.
- Missing credentials emit a `REPLACE_ME` placeholder + `#warning` rather than silently failing to connect.

## Test plan

- [x] Figma Node emits working code on a WiFi-capable target (WiFi+MQTT includes, connects on boot, subscribes to its variable topics, publishes driven values to the set topic)
- [x] Monitor Node emits working code on a WiFi-capable target (WiFi+MQTT includes, connects on boot, publishes received values on its monitor topic)
- [x] Missing credentials produce a safe placeholder (`REPLACE_ME` + `#warning`, still emits connecting code) — covered for Figma, Monitor, and the shared transport
- [x] `loop()` maintains the connection (reconnect on drop) without a host event loop
- [x] Deterministic, byte-identical emission for a given Node
- [x] `cargo clippy --all-targets -- -W clippy::pedantic -D warnings` clean; `bun run check-types` zero new errors

> Note: one pre-existing codegen test (`cloud_sketch_connects_to_wifi_on_boot_with_supplied_credentials`) fails identically on the base feature branch — it asserts on the untouched Mqtt emitter's declaration-region `WiFi.begin` and is outside this task's scope.

## Related

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
