### PR TITLE
feat(codegen): emit on-device Llm Node over an HTTP client

### DIFF
--- a/apps/web/src-tauri/src/codegen/cloud/llm.rs
+++ b/apps/web/src-tauri/src/codegen/cloud/llm.rs
@@ -1,0 +1,407 @@
+//! Llm emitter — the on-device counterpart of `runtime/external/llm.rs`.
+//!
+//! The live Llm component renders a prompt and POSTs an OpenAI-compatible
+//! `/v1/chat/completions` request to a provider, then surfaces
+//! `choices[0].message.content` downstream (see `runtime/services/llm.rs`).
+//! On a networked target (ESP32) there is no host to run that request, so the
+//! generated sketch must do it itself: ride the shared `WiFi` connection brought
+//! up by [`crate::codegen::credentials::wifi_preamble`], open an
+//! `HTTPClient` over a TLS-capable `WiFiClientSecure`, send the rendered
+//! prompt as the user message, and parse the assistant text out of the
+//! response. This mirrors the live semantics so standalone behaviour matches
+//! live mode.
+//!
+//! Unlike the Mqtt emitter — which predates the shared preamble and brings up
+//! its own `WiFi` — this emitter does **not** duplicate `WiFi` setup. Cloud
+//! Sketches already connect on boot via the preamble; the Llm Node only owns
+//! the HTTP request.
+//!
+//! ## Config (`node.data`)
+//!
+//! Read leniently, accepting the generation request shape (and mirroring the
+//! runtime `LlmConfig` field names):
+//! - `endpoint` — provider base URL; the `/v1/chat/completions` suffix is
+//!   appended (matching `OpenAiCompatibleProvider`). Falls back to `baseUrl`.
+//! - `model` — model id sent in the request body.
+//! - `prompt` — user-role prompt content.
+//! - `system` — optional system-role prompt prepended to the messages.
+//! - credentials: `wifiSsid` (the Cloud Node connection prerequisite) and
+//!   `llmApiKey` (the `Authorization: Bearer` token). When the endpoint, `WiFi`
+//!   SSID, or API key is absent the sketch emits a clearly-marked credential
+//!   placeholder and a `#warning` rather than silently failing to connect or
+//!   authenticate.
+//!
+//! Like every emitter this is a pure function of the [`FlowNode`]: identical
+//! input yields byte-identical output (determinism invariant).
+
+use crate::codegen::emit::{str_or_default, NodeEmission, NodeToken};
+use crate::runtime::types::FlowNode;
+
+/// Sentinel emitted in place of a missing credential so the sketch never
+/// silently connects or authenticates with an empty value.
+const PLACEHOLDER: &str = "REPLACE_ME";
+
+/// The HTTP + TLS + JSON includes for an on-device LLM request. De-duplicated
+/// by the assembler. `WiFi.h` is contributed by the shared preamble too;
+/// duplicates are harmless (the include block is a de-duped set).
+fn includes() -> Vec<String> {
+    vec![
+        "#include <WiFi.h>".to_string(),
+        "#include <WiFiClientSecure.h>".to_string(),
+        "#include <HTTPClient.h>".to_string(),
+        "#include <ArduinoJson.h>".to_string(),
+    ]
+}
+
+/// Escape a string for embedding inside a C++ double-quoted literal. Keeps
+/// generation safe (and deterministic) for prompts/credentials that contain a
+/// quote, backslash, or newline.
+fn cpp_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// A single config value read from `data`, with the first non-empty key
+/// winning, falling back to `default`.
+fn first_non_empty(node: &FlowNode, keys: &[&str], default: &str) -> String {
+    for key in keys {
+        let value = str_or_default(node, key, "");
+        if !value.is_empty() {
+            return value;
+        }
+    }
+    default.to_string()
+}
+
+/// Emit C++ for an Llm Cloud Node on a networked target.
+///
+/// `driver` is the C++ expression that fires the request: when it transitions
+/// truthy (its `trigger` input), the sketch renders + sends the prompt once.
+/// With no wired input the request fires once after boot. The target is
+/// assumed to offer networking — validation refuses the Node otherwise.
+#[must_use]
+#[allow(clippy::too_many_lines)]
+pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+    let token = node.id_token();
+
+    let endpoint = first_non_empty(node, &["endpoint", "baseUrl"], "");
+    let model = first_non_empty(node, &["model"], "");
+    let prompt = first_non_empty(node, &["prompt"], "");
+    let system = first_non_empty(node, &["system"], "");
+    let wifi_ssid = first_non_empty(node, &["wifiSsid"], "");
+    let api_key = first_non_empty(node, &["llmApiKey", "apiKey"], "");
+
+    // A Node is missing its essentials if it has no endpoint to call, no WiFi
+    // SSID (the connection prerequisite), or no API key to authenticate with.
+    // We still emit a requesting sketch, but with a loud placeholder + #warning
+    // so the Author is told rather than silently failing.
+    let credentials_missing = endpoint.is_empty() || wifi_ssid.is_empty() || api_key.is_empty();
+
+    let endpoint_lit = cpp_string(if endpoint.is_empty() { PLACEHOLDER } else { &endpoint });
+    let api_key_lit = cpp_string(if api_key.is_empty() { PLACEHOLDER } else { &api_key });
+    let model_lit = cpp_string(&model);
+    let prompt_lit = cpp_string(&prompt);
+    let system_lit = cpp_string(&system);
+
+    // Per-Node config names — token-scoped so multiple Llm Nodes coexist.
+    let endpoint_var = format!("llm_{token}_endpoint");
+    let api_key_var = format!("llm_{token}_api_key");
+    let model_var = format!("llm_{token}_model");
+    let prompt_var = format!("llm_{token}_prompt");
+    let system_var = format!("llm_{token}_system");
+    let value_var = format!("llm_{token}_value");
+    let sent_var = format!("llm_{token}_sent");
+    let request_fn = format!("llm_{token}_request");
+
+    let mut declarations = vec![
+        format!("const char* {endpoint_var} = {endpoint_lit};"),
+        format!("const char* {api_key_var} = {api_key_lit};"),
+        format!("const char* {model_var} = {model_lit};"),
+        format!("const char* {prompt_var} = {prompt_lit};"),
+        format!("const char* {system_var} = {system_lit};"),
+        // The latest assistant text (mirrors the live component surfacing
+        // `response.text` as its value). Empty until the first response.
+        format!("String {value_var};"),
+    ];
+    if credentials_missing {
+        // A compile-time signal plus a human-readable note. The #warning keeps
+        // the placeholder honest: the sketch builds but the Author is told.
+        declarations.insert(
+            0,
+            format!(
+                "#warning \"Llm Node {token}: missing endpoint/WiFi/API credentials — using {PLACEHOLDER} placeholder; set them before flashing\""
+            ),
+        );
+    }
+
+    // The request routine: only runs once WiFi is up (the shared preamble
+    // connects on boot, but loop() keeps ticking regardless). Builds the
+    // OpenAI-compatible body via ArduinoJson, POSTs over TLS, and parses
+    // `choices[0].message.content` into the value buffer. Mirrors
+    // `OpenAiCompatibleProvider::generate`. Non-blocking: a single attempt per
+    // call, returning immediately so the millis()-based scheduler keeps ticking.
+    let declared_fn = vec![
+        format!("void {request_fn}() {{"),
+        "  if (WiFi.status() != WL_CONNECTED) {".to_string(),
+        "    return; // WiFi not up yet; retry on the next loop tick".to_string(),
+        "  }".to_string(),
+        "  WiFiClientSecure client;".to_string(),
+        // The on-device CA bundle is out of scope here; skip verification so the
+        // request reaches HTTPS endpoints. Documented as a constraint.
+        "  client.setInsecure();".to_string(),
+        "  HTTPClient http;".to_string(),
+        format!("  String url = String({endpoint_var}) + \"/v1/chat/completions\";"),
+        "  if (!http.begin(client, url)) {".to_string(),
+        "    return; // could not start the request; retry next tick".to_string(),
+        "  }".to_string(),
+        "  http.addHeader(\"Content-Type\", \"application/json\");".to_string(),
+        format!("  http.addHeader(\"Authorization\", String(\"Bearer \") + {api_key_var});"),
+        // Build the request body: model + messages[{system?},{user}].
+        "  JsonDocument requestDoc;".to_string(),
+        format!("  requestDoc[\"model\"] = {model_var};"),
+        "  JsonArray messages = requestDoc[\"messages\"].to<JsonArray>();".to_string(),
+        format!("  if (strlen({system_var}) > 0) {{"),
+        "    JsonObject sys = messages.add<JsonObject>();".to_string(),
+        "    sys[\"role\"] = \"system\";".to_string(),
+        format!("    sys[\"content\"] = {system_var};"),
+        "  }".to_string(),
+        "  JsonObject user = messages.add<JsonObject>();".to_string(),
+        "  user[\"role\"] = \"user\";".to_string(),
+        format!("  user[\"content\"] = {prompt_var};"),
+        "  String requestBody;".to_string(),
+        "  serializeJson(requestDoc, requestBody);".to_string(),
+        "  int status = http.POST(requestBody);".to_string(),
+        "  if (status == HTTP_CODE_OK) {".to_string(),
+        "    JsonDocument responseDoc;".to_string(),
+        "    if (deserializeJson(responseDoc, http.getStream()) == DeserializationError::Ok) {".to_string(),
+        // Surface choices[0].message.content downstream (mirrors the live parse).
+        format!(
+            "      {value_var} = responseDoc[\"choices\"][0][\"message\"][\"content\"].as<String>();"
+        ),
+        "    }".to_string(),
+        "  }".to_string(),
+        "  http.end();".to_string(),
+        "}".to_string(),
+    ];
+    for line in declared_fn {
+        declarations.push(line);
+    }
+
+    // loop(): fire the request when the wired input fires (rising edge). With no
+    // wired input, fire once after boot. The `sent` latch makes the request
+    // edge-triggered rather than spamming every tick.
+    declarations.push(format!("bool {sent_var} = false;"));
+
+    let setup = vec![format!("// Llm Node {token}: request issued from loop() once connected")];
+
+    let mut loop_body = Vec::new();
+    if let Some(expr) = driver {
+        // Edge-triggered: fire on the rising edge of the wired trigger.
+        loop_body.push(format!("if (({expr}) && !{sent_var}) {{"));
+        loop_body.push(format!("  {sent_var} = true;"));
+        loop_body.push(format!("  {request_fn}();"));
+        loop_body.push("}".to_string());
+        loop_body.push(format!("if (!({expr})) {{"));
+        loop_body.push(format!("  {sent_var} = false; // re-arm for the next trigger"));
+        loop_body.push("}".to_string());
+    } else {
+        // No wired input: fire once after boot.
+        loop_body.push(format!("if (!{sent_var}) {{"));
+        loop_body.push(format!("  {sent_var} = true;"));
+        loop_body.push(format!("  {request_fn}();"));
+        loop_body.push("}".to_string());
+    }
+
+    NodeEmission {
+        includes: includes(),
+        declarations,
+        setup,
+        loop_body,
+    }
+}
+
+/// The C++ expression downstream Nodes read for an Llm Node: the latest
+/// assistant text as a C-string. Mirrors the live component surfacing
+/// `response.text` as its value.
+#[must_use]
+pub fn value_var(node: &FlowNode) -> Option<String> {
+    let token = node.id_token();
+    Some(format!("llm_{token}_value.c_str()"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::types::Position;
+    use serde_json::json;
+
+    fn llm(id: &str, data: serde_json::Value) -> FlowNode {
+        FlowNode {
+            id: id.to_string(),
+            node_type: Some("Llm".to_string()),
+            data,
+            position: Position { x: 0.0, y: 0.0 },
+        }
+    }
+
+    fn joined(lines: &[String]) -> String {
+        lines.join("\n")
+    }
+
+    fn full(id: &str) -> FlowNode {
+        llm(
+            id,
+            json!({
+                "endpoint": "https://api.example.com",
+                "model": "test-model",
+                "prompt": "Hello",
+                "wifiSsid": "net",
+                "llmApiKey": "dummy-key" // ggignore
+            }),
+        )
+    }
+
+    /// Scenario: Llm Node emits working code on a WiFi-capable target — it pulls
+    /// in the HTTP/TLS/JSON client libraries.
+    #[test]
+    fn llm_pulls_in_http_tls_and_json_libraries() {
+        let e = emit(&full("l-1"), None);
+        assert!(e.includes.iter().any(|i| i.contains("HTTPClient.h")), "missing HTTPClient include");
+        assert!(
+            e.includes.iter().any(|i| i.contains("WiFiClientSecure.h")),
+            "missing TLS client include"
+        );
+        assert!(e.includes.iter().any(|i| i.contains("ArduinoJson.h")), "missing JSON include");
+    }
+
+    /// Scenario: the request is issued over the network to the LLM endpoint and
+    /// the response is surfaced downstream.
+    #[test]
+    fn issues_request_to_endpoint_and_surfaces_response() {
+        let n = full("l-1");
+        let e = emit(&n, None);
+        let decls = joined(&e.declarations);
+        assert!(decls.contains("/v1/chat/completions"), "targets the chat-completions path");
+        assert!(decls.contains("http.POST(requestBody)"), "POSTs the request body");
+        assert!(
+            decls.contains("choices\"][0][\"message\"][\"content\"]"),
+            "parses the assistant content"
+        );
+        assert!(decls.contains("llm_l_1_value ="), "buffers the response value");
+        assert_eq!(value_var(&n).as_deref(), Some("llm_l_1_value.c_str()"));
+    }
+
+    /// Scenario: does not duplicate `WiFi` setup — relies on the shared preamble.
+    #[test]
+    fn does_not_duplicate_wifi_setup() {
+        let e = emit(&full("l-1"), None);
+        let all = format!("{}\n{}\n{}", joined(&e.declarations), joined(&e.setup), joined(&e.loop_body));
+        assert!(!all.contains("WiFi.begin"), "must not bring up WiFi itself");
+        // It still guards on the connection the preamble establishes.
+        assert!(all.contains("WiFi.status() != WL_CONNECTED"), "guards on the shared connection");
+    }
+
+    /// Scenario: a wired trigger fires the request edge-triggered.
+    #[test]
+    fn wired_trigger_fires_request_on_rising_edge() {
+        let e = emit(&full("l-1"), Some("button_b_1_state"));
+        let body = joined(&e.loop_body);
+        assert!(body.contains("button_b_1_state"), "uses the wired trigger expression");
+        assert!(body.contains("llm_l_1_request()"), "issues the request");
+        assert!(body.contains("llm_l_1_sent"), "latches so it is edge-triggered");
+    }
+
+    /// With no wired input the request fires once after boot.
+    #[test]
+    fn fires_once_when_no_wired_input() {
+        let e = emit(&full("l-1"), None);
+        let body = joined(&e.loop_body);
+        assert!(body.contains("if (!llm_l_1_sent)"), "fires once via the sent latch");
+        assert!(body.contains("llm_l_1_request()"), "issues the request");
+    }
+
+    /// Scenario: Generated Llm sketch reflects supplied credentials.
+    #[test]
+    fn reflects_supplied_credentials() {
+        let e = emit(
+            &llm(
+                "l-1",
+                json!({
+                    "endpoint": "https://api.example.com",
+                    "model": "gpt-test",
+                    "prompt": "Translate this",
+                    "system": "You are helpful",
+                    "wifiSsid": "home-net",
+                    "llmApiKey": "secret-token" // ggignore
+                }),
+            ),
+            None,
+        );
+        let decls = joined(&e.declarations);
+        assert!(decls.contains("\"https://api.example.com\""), "embeds the supplied endpoint");
+        assert!(decls.contains("\"gpt-test\""), "embeds the supplied model");
+        assert!(decls.contains("\"Translate this\""), "embeds the supplied prompt");
+        assert!(decls.contains("\"You are helpful\""), "embeds the supplied system prompt");
+        assert!(decls.contains("\"secret-token\""), "embeds the supplied API key");
+        assert!(decls.contains("Bearer"), "authenticates with a Bearer token");
+        assert!(!decls.contains("REPLACE_ME"), "no placeholder when creds supplied");
+        assert!(!decls.contains("#warning"), "no warning when creds supplied");
+    }
+
+    /// Scenario: Missing credentials produce a safe placeholder + a warning.
+    #[test]
+    fn missing_credentials_produce_safe_placeholder_and_warning() {
+        let e = emit(&llm("l-1", json!({ "model": "m", "prompt": "p" })), None);
+        let decls = joined(&e.declarations);
+        assert!(decls.contains("REPLACE_ME"), "emits a credential placeholder");
+        assert!(decls.contains("#warning"), "warns the Author at compile time");
+        // It still emits requesting code rather than silently doing nothing.
+        assert!(decls.contains("http.POST(requestBody)"), "still attempts the request");
+    }
+
+    /// A missing API key alone (endpoint + `WiFi` present) still warns.
+    #[test]
+    fn missing_api_key_alone_warns() {
+        let e = emit(
+            &llm(
+                "l-1",
+                json!({ "endpoint": "https://api.example.com", "model": "m", "prompt": "p", "wifiSsid": "net" }),
+            ),
+            None,
+        );
+        let decls = joined(&e.declarations);
+        assert!(decls.contains("#warning"), "warns when the API key is absent");
+        assert!(decls.contains("REPLACE_ME"), "placeholder for the absent key");
+    }
+
+    /// Prompt strings with a quote are escaped so generation stays valid.
+    #[test]
+    fn prompt_is_escaped() {
+        let e = emit(
+            &llm(
+                "l-1",
+                json!({ "endpoint": "https://e", "prompt": "a\"b", "wifiSsid": "net", "llmApiKey": "k" }), // ggignore
+            ),
+            None,
+        );
+        assert!(joined(&e.declarations).contains("\"a\\\"b\""), "escapes the quote in the prompt");
+    }
+
+    /// Determinism: identical Node yields byte-identical emission.
+    #[test]
+    fn emits_deterministically() {
+        let n = full("l-1");
+        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+    }
+}

--- a/apps/web/src-tauri/src/codegen/cloud/mod.rs
+++ b/apps/web/src-tauri/src/codegen/cloud/mod.rs
@@ -7,8 +7,9 @@
 //! a non-networking board, so an emitter in this module may assume the target
 //! offers [`crate::codegen::board::BoardCapability::Networking`].
 //!
-//! Only the `Mqtt` Node has an on-device emitter today (Task #38). The other
-//! Cloud Nodes still fall through to [`crate::codegen::placeholder`] until their
-//! own tasks land.
+//! The `Mqtt` (Task #38) and `Llm` (Task #44) Nodes have on-device emitters
+//! today. The remaining Cloud Nodes (Figma/Monitor) still fall through to
+//! [`crate::codegen::placeholder`] until their own tasks land.
 
+pub mod llm;
 pub mod mqtt;

--- a/apps/web/src-tauri/src/codegen/mod.rs
+++ b/apps/web/src-tauri/src/codegen/mod.rs
@@ -271,11 +271,14 @@ fn emit_node(
         Some("Trigger") => control::trigger::emit(node, driver),
         Some("Counter") => control::counter::emit(node, driver),
         Some("Constant") => control::constant::emit(node),
-        // Mqtt is the one Cloud Node with an on-device emitter (Task #38). It
-        // only reaches here on a networking target — validation refuses it
-        // otherwise. The other Cloud Nodes (Figma/Llm/Monitor) still fall
-        // through to the placeholder below.
+        // Mqtt (Task #38) and Llm (Task #44) are Cloud Nodes with on-device
+        // emitters. They only reach here on a networking target — validation
+        // refuses them otherwise. The remaining Cloud Nodes (Figma/Monitor)
+        // still fall through to the placeholder below.
         Some("Mqtt") => cloud::mqtt::emit(node, driver),
+        // The Llm Node's `driver` is its `trigger` input — when it fires, the
+        // sketch issues the LLM request over the shared WiFi connection.
+        Some("Llm") => cloud::llm::emit(node, driver),
         _ => placeholder::emit(node),
     }
 }
@@ -343,6 +346,8 @@ fn source_expression(node: &FlowNode) -> Option<String> {
         // A subscribe Mqtt Node surfaces its latest inbound message as a value;
         // a publish Mqtt Node exposes none (returns `None`).
         Some("Mqtt") => cloud::mqtt::value_var(node),
+        // An Llm Node surfaces its latest response text downstream.
+        Some("Llm") => cloud::llm::value_var(node),
         _ => None,
     }
 }
@@ -827,14 +832,13 @@ mod tests {
 
     /// Scenario: A Flow of only unsupported Nodes still yields a valid sketch.
     ///
-    /// Mqtt now has an on-device emitter (Task #38), so the remaining
-    /// still-unsupported Cloud Nodes are Figma/Llm/Monitor.
+    /// Mqtt (Task #38) and Llm (Task #44) now have on-device emitters, so the
+    /// remaining still-unsupported Cloud Nodes are Figma/Monitor.
     #[test]
     fn all_unsupported_flow_yields_valid_sketch() {
         let flow = FlowUpdate {
             nodes: vec![
                 node("figma-1", "Figma"),
-                node("llm-1", "Llm"),
                 node("monitor-1", "Monitor"),
             ],
             edges: vec![],
@@ -849,7 +853,7 @@ mod tests {
         // A placeholder for every unsupported Node.
         assert_eq!(
             sketch.matches("// unsupported Node ").count(),
-            3,
+            2,
             "expected one placeholder per unsupported node, got:\n{sketch}"
         );
     }
@@ -988,6 +992,155 @@ mod tests {
                 "mqtt-1",
                 "Mqtt",
                 json!({ "broker": "b", "topic": "t", "wifiSsid": "net", "direction": "publish" }),
+            )],
+            edges: vec![],
+        };
+        let esp32 = networking_target();
+        assert_eq!(sketch_for(&flow, &esp32), sketch_for(&flow, &esp32));
+    }
+
+    // --- Task #44: emit the Llm Node for a networked target ---
+
+    /// Scenario: Llm Node emits working code on a WiFi-capable target.
+    ///
+    /// A Flow with an Llm Cloud Node generated for the ESP32 connects to the
+    /// network on boot (shared preamble) and issues the LLM request over the
+    /// network, surfacing the response — not a placeholder.
+    #[test]
+    fn llm_node_emits_working_code_on_a_wifi_capable_target() {
+        let flow = FlowUpdate {
+            nodes: vec![node_data(
+                "llm-1",
+                "Llm",
+                json!({
+                    "endpoint": "https://api.example.com",
+                    "model": "test-model",
+                    "prompt": "Hello",
+                    "wifiSsid": "net",
+                    "llmApiKey": "dummy-key" // ggignore
+                }),
+            )],
+            edges: vec![],
+        };
+
+        let sketch = sketch_for(&flow, &networking_target());
+
+        // Not a placeholder.
+        assert!(!sketch.contains("// unsupported Node llm_1"), "Llm must emit real code, got:\n{sketch}");
+        // HTTP/TLS/JSON client libraries pulled in.
+        assert!(sketch.contains("#include <HTTPClient.h>"), "missing HTTPClient include");
+        assert!(sketch.contains("#include <WiFiClientSecure.h>"), "missing TLS client include");
+        // Connects to the network on boot via the shared WiFi preamble.
+        assert!(sketch.contains("WiFi.begin(wifi_ssid, wifi_password)"), "connects via shared preamble");
+        // Issues the request over the network to the LLM endpoint.
+        assert!(sketch.contains("/v1/chat/completions"), "issues the LLM request");
+        assert!(sketch.contains("http.POST"), "POSTs the request");
+        // Surfaces the response to downstream Nodes.
+        assert!(sketch.contains("llm_llm_1_value ="), "buffers the response value");
+        // Stays non-blocking (no blocking delay).
+        assert!(!sketch.contains("delay("), "stays non-blocking");
+    }
+
+    /// Scenario: an Llm Node's response drives a downstream wired Node.
+    #[test]
+    fn llm_response_drives_a_downstream_node() {
+        // Wire a Button trigger into the Llm Node so the request is edge-fired.
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("button-1", "Button", json!({ "pin": 2 })),
+                node_data(
+                    "llm-1",
+                    "Llm",
+                    json!({
+                        "endpoint": "https://api.example.com",
+                        "model": "m",
+                        "prompt": "p",
+                        "wifiSsid": "net",
+                        "llmApiKey": "dummy-key" // ggignore
+                    }),
+                ),
+            ],
+            edges: vec![edge("button-1", "llm-1")],
+        };
+
+        let sketch = sketch_for(&flow, &networking_target());
+
+        assert!(sketch.contains("button_button_1_state"), "fires on the wired Button trigger");
+        assert!(sketch.contains("llm_llm_1_request()"), "issues the request when triggered");
+    }
+
+    /// Scenario: Generated Llm sketch reflects supplied credentials.
+    ///
+    /// The endpoint/model/prompt/API key carried on the Node are embedded, and
+    /// the `WiFi` SSID supplied through the credentials surface flows into the
+    /// shared connect preamble.
+    #[test]
+    fn generated_llm_sketch_reflects_supplied_credentials() {
+        let flow = FlowUpdate {
+            nodes: vec![node_data(
+                "llm-1",
+                "Llm",
+                json!({
+                    "endpoint": "https://api.example.com",
+                    "model": "gpt-test",
+                    "prompt": "Translate this",
+                    "wifiSsid": "home-net",
+                    "llmApiKey": "secret-token" // ggignore
+                }),
+            )],
+            edges: vec![],
+        };
+
+        let creds = crate::codegen::credentials::Credentials {
+            wifi_ssid: "home-net".to_string(),
+            wifi_password: "wifi-pass".to_string(), // ggignore
+            llm_endpoint: "https://api.example.com".to_string(),
+            llm_api_key: "secret-token".to_string(), // ggignore
+            ..Default::default()
+        };
+        let sketch = match generate_with_credentials(&flow, &networking_target(), Some(&creds))
+            .expect("generation should succeed")
+        {
+            GenerationOutcome::Sketch(s) => s,
+            GenerationOutcome::Problems(p) => panic!("expected a sketch, got: {p:?}"),
+        };
+
+        assert!(sketch.contains("\"https://api.example.com\""), "uses the supplied endpoint");
+        assert!(sketch.contains("\"gpt-test\""), "uses the supplied model");
+        assert!(sketch.contains("\"secret-token\""), "authenticates with the supplied API key");
+        assert!(sketch.contains("Bearer"), "uses a Bearer token");
+        // The WiFi SSID supplied via the credentials surface reaches the preamble.
+        assert!(sketch.contains("\"home-net\""), "uses the supplied WiFi SSID");
+        assert!(!sketch.contains("REPLACE_ME"), "no placeholder when creds supplied");
+    }
+
+    /// Scenario: Missing credentials produce a safe placeholder.
+    #[test]
+    fn missing_llm_credentials_produce_a_safe_placeholder() {
+        let flow = FlowUpdate {
+            // No endpoint, WiFi SSID, or API key supplied.
+            nodes: vec![node_data("llm-1", "Llm", json!({ "model": "m", "prompt": "p" }))],
+            edges: vec![],
+        };
+
+        let sketch = sketch_for(&flow, &networking_target());
+
+        // A loud, compile-time warning rather than silent failure.
+        assert!(sketch.contains("#warning"), "warns the Author");
+        // A clearly-marked placeholder rather than an empty connection value.
+        assert!(sketch.contains("REPLACE_ME"), "emits a credential placeholder");
+        // It still emits requesting code (does not silently do nothing).
+        assert!(sketch.contains("http.POST"), "still attempts the request");
+    }
+
+    /// Llm emission is deterministic at the sketch level.
+    #[test]
+    fn llm_sketch_is_deterministic() {
+        let flow = FlowUpdate {
+            nodes: vec![node_data(
+                "llm-1",
+                "Llm",
+                json!({ "endpoint": "https://e", "model": "m", "prompt": "p", "wifiSsid": "net", "llmApiKey": "k" }), // ggignore
             )],
             edges: vec![],
         };
@@ -1669,11 +1822,15 @@ mod tests {
                 node_data("st-1", "Stepper", json!({})),
                 node_data("vb-1", "Vibration", json!({})),
                 node_data("osc-1", "Oscillator", json!({})),
-                // Mqtt now emits real on-device code (Task #38).
+                // Mqtt (Task #38) and Llm (Task #44) now emit real on-device code.
                 node_data("mqtt-1", "Mqtt", json!({ "broker": "b", "topic": "t", "wifiSsid": "net" })),
+                node_data(
+                    "llm-1",
+                    "Llm",
+                    json!({ "endpoint": "https://e", "model": "m", "prompt": "p", "wifiSsid": "net", "llmApiKey": "k" }), // ggignore
+                ),
                 // The remaining Cloud Nodes still fall through (Feature #27).
                 node("figma-1", "Figma"),
-                node("llm-1", "Llm"),
                 node("monitor-1", "Monitor"),
             ],
             edges: vec![],
@@ -1683,11 +1840,11 @@ mod tests {
         // on the Uno they would be refused before emission.
         let sketch = sketch_for(&flow, &networking_target());
 
-        // Exactly the three still-unsupported Cloud Nodes are placeholders.
+        // Exactly the two still-unsupported Cloud Nodes are placeholders.
         assert_eq!(
             sketch.matches("// unsupported Node ").count(),
-            3,
-            "only the three remaining Cloud Nodes may be placeholders, got:\n{sketch}"
+            2,
+            "only the two remaining Cloud Nodes may be placeholders, got:\n{sketch}"
         );
         // Mqtt is no longer a placeholder; it emits a real MQTT client.
         assert!(!sketch.contains("// unsupported Node mqtt_1"), "Mqtt must emit real code");


### PR DESCRIPTION
## Summary

A Flow Author who places an Llm Cloud Node and selects a WiFi-capable board target (ESP32) should get a Sketch that, once flashed, makes the LLM request on its own and surfaces the response downstream — no host computer. Until now the Llm Node fell through to a placeholder comment in codegen. This change makes codegen emit a real on-device Llm implementation, mirroring the live `runtime/external/llm.rs` semantics, in service of Feature #27 (generate sketches for Cloud Nodes on a networked board).

## Changes

- Adds a `cloud::llm` emitter (`codegen/cloud/llm.rs`) following the `cloud::mqtt` layout. It rides the shared WiFi connect preamble (no duplicated WiFi setup), opens an `HTTPClient` over a TLS-capable `WiFiClientSecure`, builds an OpenAI-compatible `/v1/chat/completions` body via ArduinoJson, POSTs it with a `Bearer` API key, and parses `choices[0].message.content` into a token-scoped `String` surfaced to downstream Nodes.
- The request is edge-triggered from its wired `trigger` input (or fires once after boot when unwired), and stays non-blocking so the `millis()` scheduler keeps ticking.
- Missing endpoint / WiFi SSID / API key emit a clearly-marked `REPLACE_ME` placeholder plus a `#warning` rather than silently failing.
- Wires `"Llm"` into the `emit_node` and `source_expression` dispatch in `codegen/mod.rs`, replacing its placeholder. Figma/Monitor/Mqtt behavior is unchanged; two existing placeholder-count assertions were updated to reflect that Llm now emits real code.

## Test plan

- [x] Llm Node emits working code on a WiFi-capable target (connects on boot via the shared preamble, issues the request, surfaces the response, stays non-blocking)
- [x] Generated Llm sketch reflects supplied credentials (endpoint/model/prompt/API key embedded; WiFi SSID flows through the credentials surface into the preamble)
- [x] Missing credentials produce a safe placeholder (`#warning` + `REPLACE_ME`, still emits requesting code)
- [x] `cargo test --lib` green (one unrelated pre-existing failure: `cloud_sketch_connects_to_wifi_on_boot_with_supplied_credentials`)
- [x] `cargo clippy --all-targets -- -W clippy::pedantic -D warnings` clean

## Related

Closes #44
