### PR TITLE
fix(web): stabilize useListen so transient board-state events aren't dropped

### DIFF
--- a/apps/web/src/lib/ipc.ts
+++ b/apps/web/src/lib/ipc.ts
@@ -2,7 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type Event } from "@tauri-apps/api/event";
 import { type Node, type Edge } from "@xyflow/react";
 import { isDesktop } from "./platform";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 // Generated bindings: ts-rs writes one file per #[derive(TS)] type into
 // ./bindings/ during `cargo test`. Always import event-payload types from
@@ -221,13 +221,20 @@ export type BrokerStatusPayload = BrokerStatus;
 export type ComponentEventPayload = ComponentEvent;
 
 export function useListen<T>(event: { type: string; handler: (event: Event<T>) => void }) {
+  // Keep the latest handler in a ref so callers can pass a fresh inline object
+  // every render without tearing down and re-creating the Tauri listener. A
+  // re-subscribe loop drops events that arrive during the unlisten/relisten
+  // gap (e.g. the transient `connecting` board-state burst).
+  const handlerRef = useRef(event.handler);
+  handlerRef.current = event.handler;
+
+  const { type } = event;
   useEffect(() => {
     if (!isDesktop()) return;
-    const { type, handler } = event;
-    const listener = listen<T>(type, handler);
+    const listener = listen<T>(type, (e) => handlerRef.current(e));
 
     return () => {
       listener.then((unlisten) => unlisten()).catch((error) => console.error(error));
     };
-  }, [event]);
+  }, [type]);
 }

--- a/crates/microflow-core/src/codegen/transformation/compare.rs
+++ b/crates/microflow-core/src/codegen/transformation/compare.rs
@@ -54,7 +54,7 @@ fn compare_expr(config: &CompareConfig, v: &str) -> String {
         }
         CompareValidator::Text => "false".to_string(),
         // `boolean` (default): truthiness of the input.
-        _ => format!("((bool)({v}))"),
+        CompareValidator::Boolean => format!("((bool)({v}))"),
     }
 }
 


### PR DESCRIPTION
## Problem

Backend logs showed the microcontroller being detected/connected, but the UI never showed the **Connecting** spinner — it jumped straight from "No microcontroller connected" to connected.

## Root cause

`useListen` (`src/lib/ipc.ts`) re-created the Tauri event listener on **every render**: callers pass a fresh inline `{ type, handler }` object and the effect depended on `[event]`. The unlisten/relisten gap dropped events arriving mid-render — notably the fast `connecting`→`connected` burst from firmata detection. The steady terminal `connected` state survived; the transient `connecting` frame was lost, so the spinner never rendered.

The `connecting` state and spinner styling already existed (`nav-microcontroller.tsx`, `BoardState.ts`) — they just never received the event.

## Fix

Route the handler through a ref and subscribe **once per event `type`**. The listener is now stable across renders, so transient events are no longer dropped. This is a shared hook, so every consumer (board state, mqtt, broker, component events) benefits.

## Verification

`bun run check-types` clean. Manual: connect a board, the "Connecting" pill + spinning `LoaderPinwheelIcon` show during the ~1-3s detection window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)