### PR TITLE
fix(hotkey): fire release ("false") event, not just press

### DIFF
--- a/apps/web/src-tauri/src/lib.rs
+++ b/apps/web/src-tauri/src/lib.rs
@@ -207,8 +207,8 @@ pub fn run() {
                 .start_monitoring(app.handle().clone(), board_link, observer);
 
             // Hotkeys: the webview emits "key_event" { key, pressed }; Rust owns
-            // hotkey→component routing. Forward key-down to the actor, which
-            // dispatches to the registered Hotkey components.
+            // hotkey→component routing. Forward both key-down and key-up to the
+            // actor, which dispatches to the registered Hotkey components.
             let actor_keys = actor_tx.clone();
             app.handle().listen("key_event", move |event| {
                 if let Ok(data) = serde_json::from_str::<serde_json::Value>(event.payload()) {
@@ -221,11 +221,11 @@ pub fn run() {
                         .get("pressed")
                         .and_then(serde_json::Value::as_bool)
                         .unwrap_or(false);
-                    if key.is_empty() || !pressed {
+                    if key.is_empty() {
                         return;
                     }
-                    log::info!("[HOTKEY] key_event: {key}");
-                    let _ = actor_keys.send(host::ActorMsg::Key { accelerator: key });
+                    log::info!("[HOTKEY] key_event: {key} pressed={pressed}");
+                    let _ = actor_keys.send(host::ActorMsg::Key { accelerator: key, pressed });
                 }
             });
 

--- a/apps/web/src-tauri/src/runtime/host.rs
+++ b/apps/web/src-tauri/src/runtime/host.rs
@@ -64,8 +64,9 @@ pub enum ActorMsg {
         method: String,
         value: ComponentValue,
     },
-    /// A hotkey press (`key_event`), matched against registered hotkey listeners.
-    Key { accelerator: String },
+    /// A hotkey press/release (`key_event`), matched against registered hotkey
+    /// listeners. `pressed` distinguishes key-down (`true`) from key-up (`false`).
+    Key { accelerator: String, pressed: bool },
     /// An inbound MQTT / Figma broker payload routed to a subscribe component.
     Deliver {
         id: String,
@@ -288,9 +289,9 @@ impl Actor {
                 let effects = self.rt.dispatch(&id, &method, value);
                 self.apply(effects);
             }
-            ActorMsg::Key { accelerator } => {
+            ActorMsg::Key { accelerator, pressed } => {
                 self.set_now();
-                let effects = self.rt.dispatch_key_event(&accelerator);
+                let effects = self.rt.dispatch_key_event(&accelerator, pressed);
                 self.apply(effects);
             }
             ActorMsg::Deliver { id, topic, payload } => {

--- a/crates/microflow-core/src/runtime/mod.rs
+++ b/crates/microflow-core/src/runtime/mod.rs
@@ -483,9 +483,10 @@ impl FlowRuntime {
         self.finish("inject", Vec::new(), ScheduleRequests::default())
     }
 
-    /// Deliver a hotkey press to every component listening on `accelerator`
-    /// (matched lowercased), then drain the cascade.
-    pub fn dispatch_key_event(&mut self, accelerator: &str) -> Effects {
+    /// Deliver a hotkey press (`pressed = true`) or release (`pressed = false`)
+    /// to every component listening on `accelerator` (matched lowercased), then
+    /// drain the cascade.
+    pub fn dispatch_key_event(&mut self, accelerator: &str, pressed: bool) -> Effects {
         let ids = self
             .key_listeners
             .get(&accelerator.to_lowercase())
@@ -494,7 +495,7 @@ impl FlowRuntime {
         let mut out = Vec::new();
         let mut reqs = ScheduleRequests::default();
         for id in ids {
-            self.dispatch_to(id.as_ref(), "key_event", ComponentValue::Bool(true), &mut out, &mut reqs);
+            self.dispatch_to(id.as_ref(), "key_event", ComponentValue::Bool(pressed), &mut out, &mut reqs);
         }
         self.finish("key", out, reqs)
     }


### PR DESCRIPTION
## Problem
Hotkey nodes only ever emitted the **"true"** event, never **"false"**. Reported: "the hotkey button only fires the true event, not the false event."

## Root cause
Node logic was correct (`pressed → true`, else `false`). The release (keyup) never reached the runtime — it was dropped/hardcoded across 3 host layers:

1. `lib.rs` — host dropped keyup: `if key.is_empty() || !pressed { return; }`
2. `ActorMsg::Key` — carried only `accelerator`, no `pressed`
3. `dispatch_key_event` — hardcoded `ComponentValue::Bool(true)`

## Fix
Thread `pressed` through all three layers; forward keyup instead of dropping it. Frontend already emitted both keydown/keyup correctly — no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)