### PR TITLE
feat(codegen): handle-aware typed wiring, dataflow order, port-complete emitters

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -157,6 +157,18 @@ Two kinds:
 
 Distinct from the **Component Catalog**: catalog is metadata for _registration_ (what UI shows, how to construct); Wiring is per-impl _behavior_ applied after construction.
 
+## Sketch Wiring
+
+The static twin of the **FlowRouter** inside Sketch Generation (`crates/microflow-core/src/codegen/wire.rs`, [ADR-0013](docs/adr/0013-handle-aware-sketch-wiring.md)). Every edge is resolved by its real handles: `output_expression(node, source_handle)` (in `codegen/mod.rs`) maps each **Emit** to a typed C++ expression, and a **`NodeInputs`** groups the resolved sources per **Port** (`target_handle`) for the target's emitter. Emitters bind their actual ports — `emit(node, &NodeInputs)` — instead of receiving one anonymous driver expression.
+
+Three shapes matter:
+
+- **`CppExpr`** — a typed expression (`Bool | Double | Str`). Consumers coerce via `as_bool`/`as_double(_or)`/`as_u8_or`/`as_string`, transcriptions of `ComponentValue`'s conversions, so a `String` source into a numeric port compiles to the runtime's fallback rather than invalid C++.
+- **`SourceExpr`** — one emit handle's exposure: the value expression plus either an explicit `fired` flag (event handles: Delay/Interval `event`, Trigger `bang` — true only on the emitting loop iteration) or a `Detector` (`Change` for `value`-style handles, which the runtime emits on every update; `RisingEdge` for `true`/`false` state handles).
+- **`bind_pulses`** — the shared edge/change-detector primitive pulse ports consume firings through (one action per source firing; a sustained level counts once).
+
+`loop()` fragments concatenate in **dataflow (topological) order** — producers run before consumers within a tick; cycles append in id order. Aggregating Nodes (Calculate, Gate) fold over *all* wired sources, mirroring snapshot delivery. Edges the sketch cannot honor (missing source, valueless source handle, unmodelled port, surplus sources on a single-source port) surface as `// note:` comments in the sketch; node ids whose sanitized C++ tokens collide are refused by validation before emission. The `codegen/parity.rs` guards pin every Calculate/Gate variant and Counter port to its emitted C++.
+
 ## Runtime Services
 
 > ⚠ **Reconciled (2026-06 · post-re-host).** ADR-0002 Phase 4 designed a

--- a/crates/microflow-core/examples/generate_sketch.rs
+++ b/crates/microflow-core/examples/generate_sketch.rs
@@ -1,0 +1,54 @@
+//! Generate a representative Arduino sketch to stdout — a quick way to
+//! eyeball (or compile-check) the Sketch Generation output end-to-end:
+//!
+//! ```sh
+//! cargo run -p microflow-core --example generate_sketch > /tmp/sketch/sketch.ino
+//! ```
+
+use microflow_core::codegen::{board, generate, GenerationOutcome};
+use microflow_core::flow::FlowUpdate;
+
+fn main() {
+    let flow: FlowUpdate = serde_json::from_str(
+        r#"{
+        "nodes": [
+            {"id": "button-1", "type": "Button", "data": {"pin": 6}, "position": {"x": 0, "y": 0}},
+            {"id": "sensor-1", "type": "Sensor", "data": {"pin": "A0"}, "position": {"x": 0, "y": 0}},
+            {"id": "smooth-1", "type": "Smooth", "data": {"type": "movingAverage", "windowSize": 8}, "position": {"x": 0, "y": 0}},
+            {"id": "map-1", "type": "RangeMap", "data": {"from": {"min": 0, "max": 1023}, "to": {"min": 0, "max": 255}}, "position": {"x": 0, "y": 0}},
+            {"id": "led-1", "type": "Led", "data": {"pin": 9}, "position": {"x": 0, "y": 0}},
+            {"id": "led-2", "type": "Led", "data": {"pin": 13}, "position": {"x": 0, "y": 0}},
+            {"id": "counter-1", "type": "Counter", "data": {}, "position": {"x": 0, "y": 0}},
+            {"id": "compare-1", "type": "Compare", "data": {"validator": "number", "subValidator": "greater than", "number": 3}, "position": {"x": 0, "y": 0}},
+            {"id": "servo-1", "type": "Servo", "data": {"pin": 10, "range": {"min": 0, "max": 180}}, "position": {"x": 0, "y": 0}},
+            {"id": "calc-1", "type": "Calculate", "data": {"function": "add"}, "position": {"x": 0, "y": 0}},
+            {"id": "const-1", "type": "Constant", "data": {"value": 100}, "position": {"x": 0, "y": 0}}
+        ],
+        "edges": [
+            {"source": "sensor-1", "sourceHandle": "value", "target": "smooth-1", "targetHandle": "value"},
+            {"source": "smooth-1", "sourceHandle": "value", "target": "map-1", "targetHandle": "value"},
+            {"source": "map-1", "sourceHandle": "to", "target": "led-1", "targetHandle": "value"},
+            {"source": "button-1", "sourceHandle": "true", "target": "led-2", "targetHandle": "toggle"},
+            {"source": "button-1", "sourceHandle": "true", "target": "counter-1", "targetHandle": "increment"},
+            {"source": "counter-1", "sourceHandle": "value", "target": "compare-1", "targetHandle": "value"},
+            {"source": "compare-1", "sourceHandle": "true", "target": "counter-1", "targetHandle": "reset"},
+            {"source": "map-1", "sourceHandle": "to", "target": "calc-1", "targetHandle": "value"},
+            {"source": "const-1", "sourceHandle": "value", "target": "calc-1", "targetHandle": "value"},
+            {"source": "calc-1", "sourceHandle": "value", "target": "servo-1", "targetHandle": "value"}
+        ]
+    }"#,
+    )
+    .expect("flow json parses");
+
+    let target = board::target_by_id("uno").expect("uno target");
+    match generate(&flow, &target).expect("generation never errors") {
+        GenerationOutcome::Sketch(sketch) => print!("{sketch}"),
+        GenerationOutcome::Problems(problems) => {
+            eprintln!("flow is not runnable on {}:", target.name);
+            for p in problems {
+                eprintln!("  - {}", p.message);
+            }
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/microflow-core/src/codegen/cloud/figma.rs
+++ b/crates/microflow-core/src/codegen/cloud/figma.rs
@@ -32,6 +32,7 @@
 
 use crate::codegen::cloud::transport::{cpp_string, Subscription, Transport, DEFAULT_PORT};
 use crate::codegen::emit::{str_or_default, u16_or_default, NodeEmission, NodeToken};
+use crate::codegen::wire::{CppExpr, NodeInputs, SourceExpr};
 use crate::flow::FlowNode;
 
 /// A single config value read from `data`, first non-empty key winning.
@@ -53,10 +54,16 @@ fn short_var_id(variable_id: &str) -> String {
 
 /// Emit C++ for a Figma Cloud Node on a networked target.
 ///
-/// `driver` is the C++ expression that, each time it changes, is published back
-/// to Figma (the new variable value). When unwired, the Node is subscribe-only.
+/// The `set` port publishes each new sample of its first wired source back to
+/// Figma on the set topic (the on-device twin of the live set dispatch). The
+/// runtime's other mutation ports (`true`/`false`/`toggle`, the numeric
+/// `increment`/`decrement`/`reset`, and the color channels) manipulate typed
+/// Figma variables the generated sketch does not model; wiring them emits an
+/// explicit note. When unwired, the Node is subscribe-only.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
+    let driver_source = inputs.first("set");
+    let driver = driver_source.map(|s| s.value.as_string());
     let token = node.id_token();
     let prefix = format!("figma_{token}");
 
@@ -82,7 +89,7 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
     let set_topic_var = format!("{prefix}_set_topic");
     let value_var = format!("{prefix}_value");
     let callback = format!("{prefix}_on_message");
-    let last_var = driver.map(|_| format!("{prefix}_last_published"));
+    let last_var = driver.as_ref().map(|_| format!("{prefix}_last_published"));
 
     let subscriptions = vec![
         Subscription { topic_var: plugin_topic_var.clone() },
@@ -122,14 +129,33 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
     extra_decls.push("  }".to_string());
     extra_decls.push("}".to_string());
 
+    // Extra sources on `set` and the unmodelled mutation ports are surfaced as
+    // notes rather than silently dropped.
+    if inputs.on("set").len() > 1 {
+        extra_decls.push(format!(
+            "// note: {} additional source(s) wired into 'set' are ignored — generated code follows the first source only",
+            inputs.on("set").len() - 1
+        ));
+    }
+    for port in [
+        "true", "false", "toggle", "increment", "decrement", "reset", "red", "green", "blue",
+        "opacity",
+    ] {
+        if !inputs.on(port).is_empty() {
+            extra_decls.push(format!(
+                "// note: input '{port}' mutates a typed Figma variable codegen does not model — edge ignored"
+            ));
+        }
+    }
+
     // loop() tail: when driven, publish the new value back to Figma on the set
     // topic — but only when it changed, mirroring the live debounced dispatch
     // (no host event loop here, so de-dupe on value change instead of time).
     let mut loop_tail = Vec::new();
-    if let (Some(expr), Some(last)) = (driver, &last_var) {
+    if let (Some(expr), Some(last)) = (&driver, &last_var) {
         let mqtt_client = transport.mqtt_client();
         loop_tail.push(format!("if ({mqtt_client}.connected()) {{"));
-        loop_tail.push(format!("  String {prefix}_next = String({expr});"));
+        loop_tail.push(format!("  String {prefix}_next = {expr};"));
         loop_tail.push(format!("  if ({prefix}_next != {last}) {{"));
         loop_tail.push(format!("    {mqtt_client}.publish({set_topic_var}, {prefix}_next.c_str());"));
         loop_tail.push(format!("    {last} = {prefix}_next;"));
@@ -144,13 +170,15 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
     transport.emission(extra_decls, loop_tail)
 }
 
-/// The C++ expression downstream Nodes read for a Figma Node: the latest inbound
-/// variable value as a number (`toFloat`), mirroring the live component
-/// surfacing the arrived value.
+/// What downstream Nodes read from a Figma Node: the latest inbound variable
+/// value parsed as a number (`toFloat`), mirroring the live component's parse
+/// of FLOAT variables — the common case for hardware-driving design tokens.
 #[must_use]
-pub fn value_var(node: &FlowNode) -> Option<String> {
+pub fn output(node: &FlowNode) -> Option<SourceExpr> {
     let token = node.id_token();
-    Some(format!("figma_{token}_value.toFloat()"))
+    Some(SourceExpr::level(CppExpr::number(format!(
+        "figma_{token}_value.toFloat()"
+    ))))
 }
 
 #[cfg(test)]
@@ -172,13 +200,20 @@ mod tests {
         lines.join("\n")
     }
 
+    /// A single numeric source wired into the `set` port.
+    fn set_input(expr: &str) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add("set", SourceExpr::level(CppExpr::number(expr)));
+        inputs
+    }
+
     /// Scenario: Figma Node emits working code on a `WiFi`-capable target — pulls
     /// in the `WiFi` + MQTT client libraries (the network transport).
     #[test]
     fn figma_pulls_in_wifi_and_mqtt_client_libraries() {
         let e = emit(
             &figma("f-1", json!({ "broker": "b", "uniqueId": "u", "variableId": "VariableID:1:2", "wifiSsid": "net" })),
-            None,
+            &NodeInputs::default(),
         );
         assert!(e.includes.iter().any(|i| i.contains("WiFi.h")), "missing WiFi include");
         assert!(e.includes.iter().any(|i| i.contains("PubSubClient.h")), "missing MQTT client include");
@@ -193,7 +228,7 @@ mod tests {
                 "f-1",
                 json!({ "broker": "broker.example.com", "uniqueId": "abc", "variableId": "VariableID:123:456", "wifiSsid": "net" }),
             ),
-            None,
+            &NodeInputs::default(),
         );
         let decls = joined(&e.declarations);
         let setup = joined(&e.setup);
@@ -210,20 +245,23 @@ mod tests {
     #[test]
     fn surfaces_inbound_variable_value() {
         let n = figma("f-1", json!({ "broker": "b", "uniqueId": "u", "variableId": "VariableID:1:2", "wifiSsid": "net" }));
-        let e = emit(&n, None);
+        let e = emit(&n, &NodeInputs::default());
         let decls = joined(&e.declarations);
         assert!(decls.contains("figma_f_1_value"), "buffers the inbound value");
         assert!(decls.contains("setCallback") || joined(&e.setup).contains("setCallback"));
-        assert_eq!(value_var(&n).as_deref(), Some("figma_f_1_value.toFloat()"));
+        assert_eq!(
+            output(&n).map(|s| s.value.code),
+            Some("figma_f_1_value.toFloat()".to_string())
+        );
     }
 
-    /// A driven Figma Node publishes the new value back to Figma on the set
-    /// topic — over the same network transport.
+    /// A Figma Node with a wired `set` port publishes the new value back to
+    /// Figma on the set topic — over the same network transport.
     #[test]
-    fn driven_node_publishes_value_back_to_figma() {
+    fn set_port_publishes_value_back_to_figma() {
         let e = emit(
             &figma("f-1", json!({ "broker": "b", "uniqueId": "u", "variableId": "VariableID:1:2", "wifiSsid": "net" })),
-            Some("sensor_s_1_value"),
+            &set_input("sensor_s_1_value"),
         );
         let body = joined(&e.loop_body);
         let decls = joined(&e.declarations);
@@ -232,10 +270,25 @@ mod tests {
         assert!(body.contains("sensor_s_1_value"), "publishes the driven value");
     }
 
+    /// Unmodelled mutation ports are noted instead of silently dropped.
+    #[test]
+    fn unmodelled_mutation_ports_are_noted() {
+        let mut inputs = NodeInputs::default();
+        inputs.add("toggle", SourceExpr::level(CppExpr::boolean("btn")));
+        let e = emit(
+            &figma("f-1", json!({ "broker": "b", "uniqueId": "u", "variableId": "VariableID:1:2", "wifiSsid": "net" })),
+            &inputs,
+        );
+        assert!(
+            joined(&e.declarations).contains("input 'toggle' mutates a typed Figma variable"),
+            "wired toggle is noted"
+        );
+    }
+
     /// Scenario: the loop maintains the connection (reconnect on drop).
     #[test]
     fn loop_maintains_connection_and_pumps_client() {
-        let e = emit(&figma("f-1", json!({ "broker": "b", "uniqueId": "u", "variableId": "VariableID:1:2", "wifiSsid": "net" })), None);
+        let e = emit(&figma("f-1", json!({ "broker": "b", "uniqueId": "u", "variableId": "VariableID:1:2", "wifiSsid": "net" })), &NodeInputs::default());
         let body = joined(&e.loop_body);
         assert!(body.contains("ensure_connected()"), "reconnects in loop");
         assert!(body.contains("figma_f_1_client.loop()"), "pumps the MQTT client");
@@ -244,7 +297,7 @@ mod tests {
     /// Scenario: Missing credentials produce a safe placeholder + a warning.
     #[test]
     fn missing_credentials_produce_safe_placeholder_and_warning() {
-        let e = emit(&figma("f-1", json!({ "uniqueId": "u", "variableId": "VariableID:1:2" })), Some("v"));
+        let e = emit(&figma("f-1", json!({ "uniqueId": "u", "variableId": "VariableID:1:2" })), &set_input("v"));
         let decls = joined(&e.declarations);
         assert!(decls.contains("REPLACE_ME"), "emits a credential placeholder");
         assert!(decls.contains("#warning"), "warns the Author at compile time");
@@ -255,13 +308,13 @@ mod tests {
     #[test]
     fn emits_deterministically() {
         let n = figma("f-1", json!({ "broker": "b", "uniqueId": "u", "variableId": "VariableID:1:2", "wifiSsid": "net" }));
-        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+        assert_eq!(emit(&n, &set_input("v")), emit(&n, &set_input("v")));
     }
 
     /// Topic strings are escaped so generation stays valid.
     #[test]
     fn topics_are_escaped() {
-        let e = emit(&figma("f-1", json!({ "broker": "b", "uniqueId": "a\"b", "variableId": "VariableID:1:2", "wifiSsid": "net" })), None);
+        let e = emit(&figma("f-1", json!({ "broker": "b", "uniqueId": "a\"b", "variableId": "VariableID:1:2", "wifiSsid": "net" })), &NodeInputs::default());
         assert!(joined(&e.declarations).contains("a\\\"b"), "escapes the quote in the topic");
     }
 }

--- a/crates/microflow-core/src/codegen/cloud/llm.rs
+++ b/crates/microflow-core/src/codegen/cloud/llm.rs
@@ -35,6 +35,7 @@
 //! input yields byte-identical output (determinism invariant).
 
 use crate::codegen::emit::{str_or_default, NodeEmission, NodeToken};
+use crate::codegen::wire::{bind_pulses, CppExpr, NodeInputs, SourceExpr};
 use crate::flow::FlowNode;
 
 /// Sentinel emitted in place of a missing credential so the sketch never
@@ -86,13 +87,13 @@ fn first_non_empty(node: &FlowNode, keys: &[&str], default: &str) -> String {
 
 /// Emit C++ for an Llm Cloud Node on a networked target.
 ///
-/// `driver` is the C++ expression that fires the request: when it transitions
-/// truthy (its `trigger` input), the sketch renders + sends the prompt once.
-/// With no wired input the request fires once after boot. The target is
-/// assumed to offer networking — validation refuses the Node otherwise.
+/// A pulse on the `trigger` port fires the request (one request per firing
+/// source, mirroring one dispatch == one generate). With no wired input the
+/// request fires once after boot. The target is assumed to offer networking —
+/// validation refuses the Node otherwise.
 #[must_use]
 #[allow(clippy::too_many_lines)]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let token = node.id_token();
 
     let endpoint = first_non_empty(node, &["endpoint", "baseUrl"], "");
@@ -198,25 +199,21 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
         declarations.push(line);
     }
 
-    // loop(): fire the request when the wired input fires (rising edge). With no
-    // wired input, fire once after boot. The `sent` latch makes the request
-    // edge-triggered rather than spamming every tick.
-    declarations.push(format!("bool {sent_var} = false;"));
-
+    // loop(): fire one request per pulse on the `trigger` port. With no wired
+    // input, fire once after boot (the `sent` latch).
     let setup = vec![format!("// Llm Node {token}: request issued from loop() once connected")];
 
     let mut loop_body = Vec::new();
-    if let Some(expr) = driver {
-        // Edge-triggered: fire on the rising edge of the wired trigger.
-        loop_body.push(format!("if (({expr}) && !{sent_var}) {{"));
-        loop_body.push(format!("  {sent_var} = true;"));
+    let binding = bind_pulses(&format!("llm_{token}_trigger"), inputs.on("trigger"));
+    declarations.extend(binding.declarations.iter().cloned());
+    loop_body.extend(binding.loop_lines.iter().cloned());
+    if let Some(any) = binding.any_fired() {
+        loop_body.push(format!("if ({any}) {{"));
         loop_body.push(format!("  {request_fn}();"));
-        loop_body.push("}".to_string());
-        loop_body.push(format!("if (!({expr})) {{"));
-        loop_body.push(format!("  {sent_var} = false; // re-arm for the next trigger"));
         loop_body.push("}".to_string());
     } else {
         // No wired input: fire once after boot.
+        declarations.push(format!("bool {sent_var} = false;"));
         loop_body.push(format!("if (!{sent_var}) {{"));
         loop_body.push(format!("  {sent_var} = true;"));
         loop_body.push(format!("  {request_fn}();"));
@@ -231,13 +228,14 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
     }
 }
 
-/// The C++ expression downstream Nodes read for an Llm Node: the latest
-/// assistant text as a C-string. Mirrors the live component surfacing
-/// `response.text` as its value.
+/// What downstream Nodes read from an Llm Node: the latest assistant text as
+/// an Arduino `String`. Mirrors the live component surfacing `response.text`
+/// as its value; the typed coercions turn it into whatever the consuming port
+/// needs.
 #[must_use]
-pub fn value_var(node: &FlowNode) -> Option<String> {
+pub fn output(node: &FlowNode) -> Option<SourceExpr> {
     let token = node.id_token();
-    Some(format!("llm_{token}_value.c_str()"))
+    Some(SourceExpr::level(CppExpr::text(format!("llm_{token}_value"))))
 }
 
 #[cfg(test)]
@@ -259,6 +257,13 @@ mod tests {
         lines.join("\n")
     }
 
+    /// A single boolean source wired into the `trigger` port.
+    fn trigger_input(expr: &str) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add("trigger", SourceExpr::level(CppExpr::boolean(expr)));
+        inputs
+    }
+
     fn full(id: &str) -> FlowNode {
         llm(
             id,
@@ -276,7 +281,7 @@ mod tests {
     /// in the HTTP/TLS/JSON client libraries.
     #[test]
     fn llm_pulls_in_http_tls_and_json_libraries() {
-        let e = emit(&full("l-1"), None);
+        let e = emit(&full("l-1"), &NodeInputs::default());
         assert!(e.includes.iter().any(|i| i.contains("HTTPClient.h")), "missing HTTPClient include");
         assert!(
             e.includes.iter().any(|i| i.contains("WiFiClientSecure.h")),
@@ -290,7 +295,7 @@ mod tests {
     #[test]
     fn issues_request_to_endpoint_and_surfaces_response() {
         let n = full("l-1");
-        let e = emit(&n, None);
+        let e = emit(&n, &NodeInputs::default());
         let decls = joined(&e.declarations);
         assert!(decls.contains("/v1/chat/completions"), "targets the chat-completions path");
         assert!(decls.contains("http.POST(requestBody)"), "POSTs the request body");
@@ -299,13 +304,13 @@ mod tests {
             "parses the assistant content"
         );
         assert!(decls.contains("llm_l_1_value ="), "buffers the response value");
-        assert_eq!(value_var(&n).as_deref(), Some("llm_l_1_value.c_str()"));
+        assert_eq!(output(&n).map(|s| s.value.code), Some("llm_l_1_value".to_string()));
     }
 
     /// Scenario: does not duplicate `WiFi` setup — relies on the shared preamble.
     #[test]
     fn does_not_duplicate_wifi_setup() {
-        let e = emit(&full("l-1"), None);
+        let e = emit(&full("l-1"), &NodeInputs::default());
         let all = format!("{}\n{}\n{}", joined(&e.declarations), joined(&e.setup), joined(&e.loop_body));
         assert!(!all.contains("WiFi.begin"), "must not bring up WiFi itself");
         // It still guards on the connection the preamble establishes.
@@ -315,17 +320,20 @@ mod tests {
     /// Scenario: a wired trigger fires the request edge-triggered.
     #[test]
     fn wired_trigger_fires_request_on_rising_edge() {
-        let e = emit(&full("l-1"), Some("button_b_1_state"));
+        let e = emit(&full("l-1"), &trigger_input("button_b_1_state"));
         let body = joined(&e.loop_body);
         assert!(body.contains("button_b_1_state"), "uses the wired trigger expression");
         assert!(body.contains("llm_l_1_request()"), "issues the request");
-        assert!(body.contains("llm_l_1_sent"), "latches so it is edge-triggered");
+        assert!(
+            body.contains("!= llm_l_1_trigger_prev0"),
+            "fires once per source change, not every truthy tick: {body}"
+        );
     }
 
     /// With no wired input the request fires once after boot.
     #[test]
     fn fires_once_when_no_wired_input() {
-        let e = emit(&full("l-1"), None);
+        let e = emit(&full("l-1"), &NodeInputs::default());
         let body = joined(&e.loop_body);
         assert!(body.contains("if (!llm_l_1_sent)"), "fires once via the sent latch");
         assert!(body.contains("llm_l_1_request()"), "issues the request");
@@ -346,7 +354,7 @@ mod tests {
                     "llmApiKey": "secret-token" // ggignore
                 }),
             ),
-            None,
+            &NodeInputs::default(),
         );
         let decls = joined(&e.declarations);
         assert!(decls.contains("\"https://api.example.com\""), "embeds the supplied endpoint");
@@ -362,7 +370,7 @@ mod tests {
     /// Scenario: Missing credentials produce a safe placeholder + a warning.
     #[test]
     fn missing_credentials_produce_safe_placeholder_and_warning() {
-        let e = emit(&llm("l-1", json!({ "model": "m", "prompt": "p" })), None);
+        let e = emit(&llm("l-1", json!({ "model": "m", "prompt": "p" })), &NodeInputs::default());
         let decls = joined(&e.declarations);
         assert!(decls.contains("REPLACE_ME"), "emits a credential placeholder");
         assert!(decls.contains("#warning"), "warns the Author at compile time");
@@ -378,7 +386,7 @@ mod tests {
                 "l-1",
                 json!({ "endpoint": "https://api.example.com", "model": "m", "prompt": "p", "wifiSsid": "net" }),
             ),
-            None,
+            &NodeInputs::default(),
         );
         let decls = joined(&e.declarations);
         assert!(decls.contains("#warning"), "warns when the API key is absent");
@@ -393,7 +401,7 @@ mod tests {
                 "l-1",
                 json!({ "endpoint": "https://e", "prompt": "a\"b", "wifiSsid": "net", "llmApiKey": "k" }), // ggignore
             ),
-            None,
+            &NodeInputs::default(),
         );
         assert!(joined(&e.declarations).contains("\"a\\\"b\""), "escapes the quote in the prompt");
     }
@@ -402,6 +410,6 @@ mod tests {
     #[test]
     fn emits_deterministically() {
         let n = full("l-1");
-        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+        assert_eq!(emit(&n, &trigger_input("v")), emit(&n, &trigger_input("v")));
     }
 }

--- a/crates/microflow-core/src/codegen/cloud/monitor.rs
+++ b/crates/microflow-core/src/codegen/cloud/monitor.rs
@@ -31,6 +31,7 @@
 
 use crate::codegen::cloud::transport::{cpp_string, Transport, DEFAULT_PORT};
 use crate::codegen::emit::{str_or_default, u16_or_default, NodeEmission, NodeToken};
+use crate::codegen::wire::{extra_sources_note, NodeInputs};
 use crate::flow::FlowNode;
 
 /// A single config value read from `data`, first non-empty key winning.
@@ -46,11 +47,13 @@ fn first_non_empty(node: &FlowNode, keys: &[&str], default: &str) -> String {
 
 /// Emit C++ for a Monitor Cloud Node on a networked target.
 ///
-/// `driver` is the C++ expression for the value flowing into the Monitor; each
+/// The first source wired into the `value` port is the displayed value; each
 /// time it changes the Sketch publishes it on the monitor topic. An unwired
 /// Monitor has nothing to display, so it only maintains its connection.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
+    let sources = inputs.on("value");
+    let driver = sources.first().map(|s| s.value.as_string());
     let token = node.id_token();
     let prefix = format!("monitor_{token}");
 
@@ -65,7 +68,7 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
     let credentials_missing = wifi_ssid.is_empty() || broker.is_empty();
 
     let topic_var = format!("{prefix}_topic");
-    let last_var = driver.map(|_| format!("{prefix}_last_published"));
+    let last_var = driver.as_ref().map(|_| format!("{prefix}_last_published"));
 
     // Monitor is publish-only — it never subscribes.
     let transport = Transport {
@@ -81,6 +84,9 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
     };
 
     let mut extra_decls = vec![format!("const char* {topic_var} = {};", cpp_string(&topic))];
+    if let Some(note) = extra_sources_note("value", sources) {
+        extra_decls.push(note);
+    }
     if let Some(last) = &last_var {
         extra_decls.push(format!("String {last};"));
     }
@@ -88,10 +94,10 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
     // loop() tail: publish each received value on change (mirrors the live sink
     // surfacing the latest value; de-dupe on change since there is no host loop).
     let mut loop_tail = Vec::new();
-    if let (Some(expr), Some(last)) = (driver, &last_var) {
+    if let (Some(expr), Some(last)) = (&driver, &last_var) {
         let mqtt_client = transport.mqtt_client();
         loop_tail.push(format!("if ({mqtt_client}.connected()) {{"));
-        loop_tail.push(format!("  String {prefix}_next = String({expr});"));
+        loop_tail.push(format!("  String {prefix}_next = {expr};"));
         loop_tail.push(format!("  if ({prefix}_next != {last}) {{"));
         loop_tail.push(format!("    {mqtt_client}.publish({topic_var}, {prefix}_next.c_str());"));
         loop_tail.push(format!("    {last} = {prefix}_next;"));
@@ -125,11 +131,19 @@ mod tests {
         lines.join("\n")
     }
 
+    /// A single numeric source wired into the `value` port.
+    fn value_input(expr: &str) -> NodeInputs {
+        use crate::codegen::wire::{CppExpr, SourceExpr};
+        let mut inputs = NodeInputs::default();
+        inputs.add("value", SourceExpr::level(CppExpr::number(expr)));
+        inputs
+    }
+
     /// Scenario: Monitor Node emits working code on a `WiFi`-capable target —
     /// pulls in the `WiFi` + MQTT client libraries (the network transport).
     #[test]
     fn monitor_pulls_in_wifi_and_mqtt_client_libraries() {
-        let e = emit(&monitor("mon-1", json!({ "broker": "b", "uniqueId": "u", "wifiSsid": "net" })), Some("v"));
+        let e = emit(&monitor("mon-1", json!({ "broker": "b", "uniqueId": "u", "wifiSsid": "net" })), &value_input("v"));
         assert!(e.includes.iter().any(|i| i.contains("WiFi.h")), "missing WiFi include");
         assert!(e.includes.iter().any(|i| i.contains("PubSubClient.h")), "missing MQTT client include");
     }
@@ -140,7 +154,7 @@ mod tests {
     fn connects_and_publishes_received_values_over_transport() {
         let e = emit(
             &monitor("mon-1", json!({ "broker": "broker.example.com", "uniqueId": "abc", "wifiSsid": "net" })),
-            Some("sensor_s_1_value"),
+            &value_input("sensor_s_1_value"),
         );
         let decls = joined(&e.declarations);
         let setup = joined(&e.setup);
@@ -155,7 +169,7 @@ mod tests {
     /// Scenario: the loop maintains the connection (reconnect on drop).
     #[test]
     fn loop_maintains_connection_and_pumps_client() {
-        let e = emit(&monitor("mon-1", json!({ "broker": "b", "uniqueId": "u", "wifiSsid": "net" })), Some("v"));
+        let e = emit(&monitor("mon-1", json!({ "broker": "b", "uniqueId": "u", "wifiSsid": "net" })), &value_input("v"));
         let body = joined(&e.loop_body);
         assert!(body.contains("ensure_connected()"), "reconnects in loop");
         assert!(body.contains("monitor_mon_1_client.loop()"), "pumps the MQTT client");
@@ -164,7 +178,7 @@ mod tests {
     /// An unwired Monitor still connects but has nothing to publish.
     #[test]
     fn unwired_monitor_has_nothing_to_publish() {
-        let e = emit(&monitor("mon-1", json!({ "broker": "b", "uniqueId": "u", "wifiSsid": "net" })), None);
+        let e = emit(&monitor("mon-1", json!({ "broker": "b", "uniqueId": "u", "wifiSsid": "net" })), &NodeInputs::default());
         let body = joined(&e.loop_body);
         assert!(body.contains("nothing to display"), "no publish without a wired input");
         assert!(!body.contains("publish(monitor_mon_1_topic"), "does not publish when unwired");
@@ -173,7 +187,7 @@ mod tests {
     /// Scenario: Missing credentials produce a safe placeholder + a warning.
     #[test]
     fn missing_credentials_produce_safe_placeholder_and_warning() {
-        let e = emit(&monitor("mon-1", json!({ "uniqueId": "u" })), Some("v"));
+        let e = emit(&monitor("mon-1", json!({ "uniqueId": "u" })), &value_input("v"));
         let decls = joined(&e.declarations);
         assert!(decls.contains("REPLACE_ME"), "emits a credential placeholder");
         assert!(decls.contains("#warning"), "warns the Author at compile time");
@@ -184,6 +198,6 @@ mod tests {
     #[test]
     fn emits_deterministically() {
         let n = monitor("mon-1", json!({ "broker": "b", "uniqueId": "u", "wifiSsid": "net" }));
-        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+        assert_eq!(emit(&n, &value_input("v")), emit(&n, &value_input("v")));
     }
 }

--- a/crates/microflow-core/src/codegen/cloud/mqtt.rs
+++ b/crates/microflow-core/src/codegen/cloud/mqtt.rs
@@ -33,6 +33,7 @@
 //! input yields byte-identical output (determinism invariant).
 
 use crate::codegen::emit::{str_or_default, u16_or_default, NodeEmission, NodeToken};
+use crate::codegen::wire::{bind_pulses, CppExpr, NodeInputs, SourceExpr};
 use crate::flow::FlowNode;
 
 /// Default broker port — standard unencrypted MQTT.
@@ -84,12 +85,14 @@ fn first_non_empty(node: &FlowNode, keys: &[&str], default: &str) -> String {
 
 /// Emit C++ for an Mqtt Cloud Node on a networked target.
 ///
-/// `driver` is the C++ expression a publish Node sends each time its input
-/// fires (the payload). A subscribe Node ignores it. The target is assumed to
-/// offer networking — validation refuses the Node otherwise.
+/// A publish Node sends one message per pulse arriving on its `trigger` port
+/// (the firing source's value is the payload), the on-device twin of one
+/// dispatch == one publish. A subscribe Node ignores trigger wiring. The
+/// target is assumed to offer networking — validation refuses the Node
+/// otherwise.
 #[must_use]
 #[allow(clippy::too_many_lines)]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let token = node.id_token();
     let direction = {
         let d = str_or_default(node, "direction", DEFAULT_DIRECTION);
@@ -212,22 +215,29 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
     setup.push(format!("mqtt_{token}_ensure_connected();"));
 
     // loop(): keep the connection alive (reconnect on drop), pump the client,
-    // and — for publish Nodes — send the driven payload when its input fires.
+    // and — for publish Nodes — send one message per pulse on the `trigger`
+    // port, the firing source's value as the payload.
     let mut loop_body = vec![
         format!("mqtt_{token}_ensure_connected();"),
         format!("{mqtt_client}.loop();"),
     ];
     if is_publish {
-        if let Some(expr) = driver {
-            loop_body.push(format!("if ({mqtt_client}.connected()) {{"));
-            loop_body.push(format!(
-                "  {mqtt_client}.publish({topic_var}, String({expr}).c_str());"
-            ));
-            loop_body.push("}".to_string());
-        } else {
+        let sources = inputs.on("trigger");
+        let binding = bind_pulses(&format!("mqtt_{token}_trigger"), sources);
+        declarations.extend(binding.declarations.iter().cloned());
+        loop_body.extend(binding.loop_lines.iter().cloned());
+        if binding.fired.is_empty() {
             loop_body.push(format!(
                 "// publish Node {token} has no wired input — nothing to publish"
             ));
+        }
+        for (fired, source) in binding.fired.iter().zip(sources) {
+            loop_body.push(format!("if ({fired} && {mqtt_client}.connected()) {{"));
+            loop_body.push(format!(
+                "  {mqtt_client}.publish({topic_var}, ({}).c_str());",
+                source.value.as_string()
+            ));
+            loop_body.push("}".to_string());
         }
     }
 
@@ -239,18 +249,20 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
     }
 }
 
-/// The C++ expression downstream Nodes read for a subscribe Mqtt Node: the
-/// latest inbound message as a numeric value (`toFloat`). Publish Nodes expose
-/// no readable value. Mirrors the live component surfacing the message as its
-/// value.
+/// What downstream Nodes read from a subscribe Mqtt Node: the latest inbound
+/// message parsed as a number (`toFloat`), mirroring the live component's
+/// numeric payload parse — the common case for sensor data over MQTT. Publish
+/// Nodes expose no readable value.
 #[must_use]
-pub fn value_var(node: &FlowNode) -> Option<String> {
+pub fn output(node: &FlowNode) -> Option<SourceExpr> {
     let direction = str_or_default(node, "direction", DEFAULT_DIRECTION);
     if direction == "publish" {
         return None;
     }
     let token = node.id_token();
-    Some(format!("mqtt_{token}_value.toFloat()"))
+    Some(SourceExpr::level(CppExpr::number(format!(
+        "mqtt_{token}_value.toFloat()"
+    ))))
 }
 
 #[cfg(test)]
@@ -272,13 +284,20 @@ mod tests {
         lines.join("\n")
     }
 
+    /// A single numeric source wired into the `trigger` port.
+    fn trigger_input(expr: &str) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add("trigger", SourceExpr::level(CppExpr::number(expr)));
+        inputs
+    }
+
     /// Scenario: Mqtt Node emits working code on a `WiFi`-capable target — it
     /// pulls in the `WiFi` + MQTT client libraries.
     #[test]
     fn mqtt_pulls_in_wifi_and_mqtt_client_libraries() {
         let e = emit(
             &mqtt("m-1", json!({ "broker": "broker.example.com", "topic": "t", "wifiSsid": "net" })),
-            None,
+            &NodeInputs::default(),
         );
         assert!(e.includes.iter().any(|i| i.contains("WiFi.h")), "missing WiFi include");
         assert!(
@@ -297,7 +316,7 @@ mod tests {
                 "m-1",
                 json!({ "broker": "broker.example.com", "port": 1883, "topic": "t", "wifiSsid": "net", "wifiPassword": "pw" }), // ggignore
             ),
-            None,
+            &NodeInputs::default(),
         );
         let setup = joined(&e.setup);
         let decls = joined(&e.declarations);
@@ -317,34 +336,41 @@ mod tests {
             "m-1",
             json!({ "broker": "b", "topic": "microflow/sensor", "wifiSsid": "net", "direction": "subscribe" }),
         );
-        let e = emit(&n, None);
+        let e = emit(&n, &NodeInputs::default());
         let decls = joined(&e.declarations);
         assert!(decls.contains("subscribe(mqtt_m_1_topic)"), "subscribes to its topic");
         assert!(decls.contains("setCallback") || joined(&e.setup).contains("setCallback"));
         assert!(decls.contains("mqtt_m_1_value"), "buffers the inbound message");
-        assert_eq!(value_var(&n).as_deref(), Some("mqtt_m_1_value.toFloat()"));
+        assert_eq!(
+            output(&n).map(|s| s.value.code),
+            Some("mqtt_m_1_value.toFloat()".to_string())
+        );
     }
 
-    /// Scenario: a publish Node publishes its driven payload on its topic.
+    /// Scenario: a publish Node publishes one message per trigger pulse.
     #[test]
-    fn publish_node_publishes_driven_payload() {
+    fn publish_node_publishes_per_trigger_pulse() {
         let n = mqtt(
             "m-1",
             json!({ "broker": "b", "topic": "microflow/sensor", "wifiSsid": "net", "direction": "publish" }),
         );
-        let e = emit(&n, Some("sensor_s_1_value"));
+        let e = emit(&n, &trigger_input("sensor_s_1_value"));
         let body = joined(&e.loop_body);
         assert!(body.contains("publish(mqtt_m_1_topic"), "publishes on its topic");
-        assert!(body.contains("sensor_s_1_value"), "publishes the driven payload");
+        assert!(body.contains("sensor_s_1_value"), "publishes the triggering payload");
+        assert!(
+            body.contains("!= mqtt_m_1_trigger_prev0"),
+            "publishes once per new sample, not every tick: {body}"
+        );
         // Publish Nodes expose no readable value.
-        assert_eq!(value_var(&n), None);
+        assert!(output(&n).is_none());
     }
 
     /// Scenario: the loop maintains the connection (reconnect on drop) without
     /// a host event loop.
     #[test]
     fn loop_maintains_connection_and_pumps_client() {
-        let e = emit(&mqtt("m-1", json!({ "broker": "b", "topic": "t", "wifiSsid": "net" })), None);
+        let e = emit(&mqtt("m-1", json!({ "broker": "b", "topic": "t", "wifiSsid": "net" })), &NodeInputs::default());
         let body = joined(&e.loop_body);
         assert!(body.contains("ensure_connected()"), "reconnects in loop");
         assert!(body.contains("mqtt_m_1_client.loop()"), "pumps the MQTT client");
@@ -367,7 +393,7 @@ mod tests {
                     "direction": "publish"
                 }),
             ),
-            Some("v"),
+            &trigger_input("v"),
         );
         let decls = joined(&e.declarations);
         // WiFi SSID/password live in the shared credentials preamble, not here.
@@ -383,7 +409,7 @@ mod tests {
     /// Scenario: Missing credentials produce a safe placeholder + a warning.
     #[test]
     fn missing_credentials_produce_safe_placeholder_and_warning() {
-        let e = emit(&mqtt("m-1", json!({ "topic": "microflow/sensor", "direction": "publish" })), Some("v"));
+        let e = emit(&mqtt("m-1", json!({ "topic": "microflow/sensor", "direction": "publish" })), &trigger_input("v"));
         let decls = joined(&e.declarations);
         assert!(decls.contains("REPLACE_ME"), "emits a credential placeholder");
         assert!(decls.contains("#warning"), "warns the Author at compile time");
@@ -395,15 +421,15 @@ mod tests {
     #[test]
     fn direction_defaults_to_subscribe() {
         let n = mqtt("m-1", json!({ "broker": "b", "topic": "t", "wifiSsid": "net" }));
-        let e = emit(&n, None);
+        let e = emit(&n, &NodeInputs::default());
         assert!(joined(&e.declarations).contains("subscribe(mqtt_m_1_topic)"), "defaults to subscribe");
-        assert!(value_var(&n).is_some(), "subscribe Node exposes a value");
+        assert!(output(&n).is_some(), "subscribe Node exposes a value");
     }
 
     /// Topic strings with a quote are escaped so generation stays valid.
     #[test]
     fn topic_is_escaped() {
-        let e = emit(&mqtt("m-1", json!({ "broker": "b", "topic": "a\"b", "wifiSsid": "net" })), None);
+        let e = emit(&mqtt("m-1", json!({ "broker": "b", "topic": "a\"b", "wifiSsid": "net" })), &NodeInputs::default());
         assert!(joined(&e.declarations).contains("\"a\\\"b\""), "escapes the quote in the topic");
     }
 
@@ -411,6 +437,6 @@ mod tests {
     #[test]
     fn emits_deterministically() {
         let n = mqtt("m-1", json!({ "broker": "b", "topic": "t", "wifiSsid": "net", "direction": "publish" }));
-        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+        assert_eq!(emit(&n, &trigger_input("v")), emit(&n, &trigger_input("v")));
     }
 }

--- a/crates/microflow-core/src/codegen/control/counter.rs
+++ b/crates/microflow-core/src/codegen/control/counter.rs
@@ -1,15 +1,18 @@
 //! Counter emitter — mirrors `runtime/control/counter.rs`.
 //!
-//! The live Counter starts at `0.0` and increments by one each time its
-//! `increment` port receives a signal. In the generated single-driver value
-//! model a Counter has one wired input that pulses it; the Sketch increments the
-//! running count on the *rising edge* of that driver (a transition from falsey
-//! to truthy), matching one signal == one increment. The count is a module-level
-//! `double` so it persists across `loop()` iterations exactly as the runtime's
-//! `ComponentBase` value persists across signals — the on-device count never
-//! resets between iterations.
+//! The live Counter starts at `0.0` and exposes four ports: `increment` and
+//! `decrement` step the count by one per received signal, `reset` returns it to
+//! zero, and `set` overwrites it with the incoming value. The generated C++
+//! binds each port to the edges actually wired into it: pulse ports fire on a
+//! source's emission tick (event sources) or on a rising edge of its level
+//! (state sources), and `set` fires whenever a wired source's value changes —
+//! one dispatch per new sample. Within one tick the ports apply in the fixed
+//! order `increment`, `decrement`, `reset`, `set`, keeping simultaneous firings
+//! deterministic. The count is a module-level `double` so it persists across
+//! `loop()` iterations exactly as the runtime's value persists across signals.
 
 use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::codegen::wire::{bind_pulses, NodeInputs};
 use crate::flow::FlowNode;
 
 /// The C++ `double` variable holding this Counter Node's running count. Exposed
@@ -19,37 +22,50 @@ pub fn value_var(node: &FlowNode) -> String {
     format!("counter_{}_count", node.id_token())
 }
 
-/// Emit C++ for a Counter Node. `driver` is the wired pulse input, or `None`
-/// when nothing is connected (the runtime never increments without a signal).
-///
-/// The count and a `_prev` edge-tracking flag are module-level so they persist
-/// across loop iterations; the increment only fires on a rising edge so a driver
-/// that stays truthy counts once, mirroring discrete signals.
+/// Emit C++ for a Counter Node, binding every wired port.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let token = node.id_token();
     let var = value_var(node);
-    let prev = format!("counter_{token}_prev");
 
     let mut e = NodeEmission {
         declarations: vec![format!("double {var} = 0.0;")],
         ..NodeEmission::default()
     };
 
-    if let Some(expr) = driver {
-        // Track the previous truthiness so a sustained-high driver counts once.
-        e.declarations.push(format!("bool {prev} = false;"));
-        e.loop_body.push(format!("bool counter_{token}_now = (bool)({expr});"));
-        e.loop_body
-            .push(format!("if (counter_{token}_now && !{prev}) {{ {var} += 1.0; }}"));
-        e.loop_body.push(format!("{prev} = counter_{token}_now;"));
+    // increment / decrement / reset: one action per fired source.
+    for (port, action) in [
+        ("increment", format!("{var} += 1.0;")),
+        ("decrement", format!("{var} -= 1.0;")),
+        ("reset", format!("{var} = 0.0;")),
+    ] {
+        let binding = bind_pulses(&format!("counter_{token}_{port}"), inputs.on(port));
+        e.declarations.extend(binding.declarations.iter().cloned());
+        e.loop_body.extend(binding.loop_lines.iter().cloned());
+        for fired in &binding.fired {
+            e.loop_body.push(format!("if ({fired}) {{ {action} }}"));
+        }
     }
+
+    // set: every new sample from a wired source overwrites the count.
+    let sources = inputs.on("set");
+    let binding = bind_pulses(&format!("counter_{token}_set"), sources);
+    e.declarations.extend(binding.declarations.iter().cloned());
+    e.loop_body.extend(binding.loop_lines.iter().cloned());
+    for (fired, source) in binding.fired.iter().zip(sources) {
+        e.loop_body.push(format!(
+            "if ({fired}) {{ {var} = {}; }}",
+            source.value.as_double()
+        ));
+    }
+
     e
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::{CppExpr, SourceExpr};
     use crate::flow::Position;
     use serde_json::json;
 
@@ -62,33 +78,86 @@ mod tests {
         }
     }
 
+    fn on(port: &str, expr: CppExpr) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add(port, SourceExpr::level(expr));
+        inputs
+    }
+
     #[test]
     fn count_starts_at_zero_and_persists() {
-        let e = emit(&counter("ct-1"), Some("v"));
+        let e = emit(&counter("ct-1"), &on("increment", CppExpr::boolean("v")));
         // Module-level declaration => persists across loop iterations.
         assert!(e.declarations.iter().any(|d| d.contains("double counter_ct_1_count = 0.0")));
     }
 
     #[test]
-    fn increments_on_rising_edge_only() {
-        let e = emit(&counter("ct-1"), Some("v"));
-        assert!(e.loop_body.iter().any(|l| l.contains("+= 1.0")), "must increment");
+    fn increments_once_per_source_change() {
+        let e = emit(&counter("ct-1"), &on("increment", CppExpr::boolean("v")));
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("+= 1.0"), "must increment");
         assert!(
-            e.loop_body.iter().any(|l| l.contains("&& !counter_ct_1_prev")),
-            "increment must be guarded by a rising edge"
+            body.contains("!= counter_ct_1_increment_prev0"),
+            "one increment per source change — a sustained level counts once: {body}"
         );
     }
 
     #[test]
-    fn no_driver_keeps_count_static() {
-        let e = emit(&counter("ct-1"), None);
-        assert!(e.loop_body.is_empty(), "no input => no increment");
+    fn rising_edge_sources_increment_only_on_entry() {
+        // A `true`-handle source (rising detector) counts presses only.
+        let mut inputs = NodeInputs::default();
+        inputs.add("increment", SourceExpr::rising(CppExpr::boolean("btn")));
+        let e = emit(&counter("ct-1"), &inputs);
+        assert!(
+            e.loop_body.iter().any(|l| l.contains("&& !counter_ct_1_increment_prev0")),
+            "rising sources keep their edge shape"
+        );
+    }
+
+    #[test]
+    fn decrement_reset_and_set_ports_are_bound() {
+        let mut inputs = NodeInputs::default();
+        inputs.add("decrement", SourceExpr::level(CppExpr::boolean("d")));
+        inputs.add("reset", SourceExpr::level(CppExpr::boolean("r")));
+        inputs.add("set", SourceExpr::level(CppExpr::number("s")));
+        let e = emit(&counter("ct-1"), &inputs);
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("-= 1.0"), "decrement bound: {body}");
+        assert!(body.contains("= 0.0;"), "reset bound: {body}");
+        assert!(body.contains("counter_ct_1_count = ((double)(s))"), "set bound: {body}");
+    }
+
+    #[test]
+    fn set_fires_on_value_change_not_rising_edge() {
+        let e = emit(&counter("ct-1"), &on("set", CppExpr::number("s")));
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("!="), "set uses change detection: {body}");
+    }
+
+    #[test]
+    fn event_sources_reuse_their_fired_flag() {
+        let mut inputs = NodeInputs::default();
+        inputs.add(
+            "increment",
+            SourceExpr::event(CppExpr::number("delay_d_value"), "delay_d_fired"),
+        );
+        let e = emit(&counter("ct-1"), &inputs);
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("if (delay_d_fired)"), "uses the source's fired flag: {body}");
+        assert!(!body.contains("_prev0"), "no synthesized tracker needed");
+    }
+
+    #[test]
+    fn no_input_keeps_count_static() {
+        let e = emit(&counter("ct-1"), &NodeInputs::default());
+        assert!(e.loop_body.is_empty(), "no input => no updates");
         assert!(e.declarations.iter().any(|d| d.contains("= 0.0")));
     }
 
     #[test]
     fn emits_deterministically() {
         let n = counter("ct-1");
-        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+        let inputs = on("increment", CppExpr::boolean("v"));
+        assert_eq!(emit(&n, &inputs), emit(&n, &inputs));
     }
 }

--- a/crates/microflow-core/src/codegen/control/delay.rs
+++ b/crates/microflow-core/src/codegen/control/delay.rs
@@ -1,20 +1,28 @@
 //! Delay emitter — mirrors `runtime/control/delay.rs`.
 //!
-//! The live Delay stores an incoming signal and re-emits it `delay` ms later
-//! (default `1000`) via a spawned thread that sleeps. On device the wait must be
+//! The live Delay stores the value arriving on its `trigger` port and re-emits
+//! it on `event` `delay` ms later (default `1000`). On device the wait must be
 //! non-blocking, so the generated Sketch captures the input value and a
 //! deadline timestamp in module-level state, then fires when
 //! `millis() - armed_at >= delay`. The loop never blocks while the Delay is
 //! pending — the rest of the Flow keeps running — and the unsigned elapsed-time
 //! subtraction survives `millis()` rollover.
 //!
-//! Arming is edge-triggered (a rising edge on the driver) so a single signal
-//! schedules a single fire, matching one `trigger` call == one delayed emit.
-//! `forgetPrevious` is reproduced by re-arming on each new edge (the latest edge
-//! wins), which is the same observable result as the runtime cancelling the
-//! prior thread.
+//! Arming is pulse-driven: event sources arm on their firing tick, level
+//! sources on a rising edge, so a single signal schedules a single fire. A
+//! `fired` flag is true exactly on the firing loop iteration — the on-device
+//! twin of the `event` emission — so pulse-consuming downstream ports see one
+//! event per fire even when consecutive delayed values are equal.
+//!
+//! `forgetPrevious` (the default) re-arms on every new trigger — the latest
+//! trigger wins, the same observable result as the runtime cancelling the
+//! prior wakeup. With `forgetPrevious` off the runtime queues every trigger
+//! independently; a single C++ timer slot cannot queue, so the generated code
+//! keeps the *first* pending deadline and ignores triggers while pending (the
+//! closest single-slot approximation).
 
 use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::codegen::wire::{bind_pulses, NodeInputs};
 use crate::config::delay::DelayConfig;
 use crate::flow::FlowNode;
 
@@ -25,51 +33,78 @@ pub fn value_var(node: &FlowNode) -> String {
     format!("delay_{}_value", node.id_token())
 }
 
-/// Emit C++ for a Delay Node. `driver` is the wired input to be delayed, or
-/// `None` when nothing is connected (the runtime never arms without a signal).
+/// The C++ `bool` variable that is true only on the loop iteration in which
+/// the delayed `event` fires.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn fired_var(node: &FlowNode) -> String {
+    format!("delay_{}_fired", node.id_token())
+}
+
+/// Emit C++ for a Delay Node from its `trigger` port. With nothing connected
+/// the Delay never arms (the runtime never fires without a signal).
+#[must_use]
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let token = node.id_token();
     let var = value_var(node);
+    let fired = fired_var(node);
     let pending = format!("delay_{token}_pending");
     let armed = format!("delay_{token}_armed_at");
     let stored = format!("delay_{token}_stored");
-    let prev = format!("delay_{token}_prev");
     let config: DelayConfig = serde_json::from_value(node.data.clone()).unwrap_or_default();
     let delay_ms = config.delay;
 
     let mut e = NodeEmission {
-        declarations: vec![format!("double {var} = 0.0;")],
+        declarations: vec![
+            format!("double {var} = 0.0;"),
+            format!("bool {fired} = false;"),
+        ],
         ..NodeEmission::default()
     };
 
-    if let Some(expr) = driver {
-        e.declarations.push(format!("bool {pending} = false;"));
-        e.declarations.push(format!("unsigned long {armed} = 0;"));
-        e.declarations.push(format!("double {stored} = 0.0;"));
-        e.declarations.push(format!("bool {prev} = false;"));
+    let sources = inputs.on("trigger");
+    if sources.is_empty() {
+        return e;
+    }
 
-        // Arm on a rising edge: capture the value and the deadline start.
-        e.loop_body.push(format!("bool delay_{token}_now = (bool)({expr});"));
-        e.loop_body.push(format!("if (delay_{token}_now && !{prev}) {{"));
-        e.loop_body.push(format!("  {stored} = (double)({expr});"));
+    e.declarations.push(format!("bool {pending} = false;"));
+    e.declarations.push(format!("unsigned long {armed} = 0;"));
+    e.declarations.push(format!("double {stored} = 0.0;"));
+
+    let binding = bind_pulses(&format!("delay_{token}_trigger"), sources);
+    e.declarations.extend(binding.declarations.iter().cloned());
+    e.loop_body.push(format!("{fired} = false;"));
+    e.loop_body.extend(binding.loop_lines.iter().cloned());
+
+    // Arm per fired source: capture the value and the deadline start. With
+    // `forgetPrevious` off, a pending deadline is kept (single-slot queue).
+    let arm_guard = if config.forget_previous {
+        String::new()
+    } else {
+        format!("!{pending} && ")
+    };
+    for (fired_expr, source) in binding.fired.iter().zip(sources) {
+        e.loop_body.push(format!("if ({arm_guard}{fired_expr}) {{"));
+        e.loop_body
+            .push(format!("  {stored} = {};", source.value.as_double()));
         e.loop_body.push(format!("  {armed} = millis();"));
         e.loop_body.push(format!("  {pending} = true;"));
         e.loop_body.push("}".to_string());
-        e.loop_body.push(format!("{prev} = delay_{token}_now;"));
-        // Fire once the delay has elapsed — non-blocking elapsed-time compare.
-        e.loop_body
-            .push(format!("if ({pending} && millis() - {armed} >= {delay_ms}UL) {{"));
-        e.loop_body.push(format!("  {var} = {stored};"));
-        e.loop_body.push(format!("  {pending} = false;"));
-        e.loop_body.push("}".to_string());
     }
+
+    // Fire once the delay has elapsed — non-blocking elapsed-time compare.
+    e.loop_body
+        .push(format!("if ({pending} && millis() - {armed} >= {delay_ms}UL) {{"));
+    e.loop_body.push(format!("  {var} = {stored};"));
+    e.loop_body.push(format!("  {fired} = true;"));
+    e.loop_body.push(format!("  {pending} = false;"));
+    e.loop_body.push("}".to_string());
     e
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::{CppExpr, SourceExpr};
     use crate::flow::Position;
     use serde_json::json;
 
@@ -82,9 +117,15 @@ mod tests {
         }
     }
 
+    fn trigger_input(expr: CppExpr) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add("trigger", SourceExpr::level(expr));
+        inputs
+    }
+
     #[test]
     fn fires_after_configured_delay_without_blocking() {
-        let e = emit(&delay("d-1", json!({ "delay": 750 })), Some("v"));
+        let e = emit(&delay("d-1", json!({ "delay": 750 })), &trigger_input(CppExpr::boolean("v")));
         assert!(
             e.loop_body.iter().any(|l| l.contains("millis() - delay_d_1_armed_at >= 750UL")),
             "delay must fire on an elapsed-time comparison"
@@ -93,28 +134,50 @@ mod tests {
     }
 
     #[test]
+    fn exposes_a_one_tick_fired_flag() {
+        let e = emit(&delay("d-1", json!({})), &trigger_input(CppExpr::boolean("v")));
+        assert!(e.declarations.iter().any(|d| d.contains("bool delay_d_1_fired = false")));
+        assert_eq!(e.loop_body.first().unwrap(), "delay_d_1_fired = false;");
+        assert!(e.loop_body.iter().any(|l| l.contains("delay_d_1_fired = true")));
+    }
+
+    #[test]
     fn defaults_to_one_second() {
-        let e = emit(&delay("d-1", json!({})), Some("v"));
+        let e = emit(&delay("d-1", json!({})), &trigger_input(CppExpr::boolean("v")));
         assert!(e.loop_body.iter().any(|l| l.contains(">= 1000UL")));
     }
 
     #[test]
     fn state_persists_across_iterations() {
-        let e = emit(&delay("d-1", json!({})), Some("v"));
+        let e = emit(&delay("d-1", json!({})), &trigger_input(CppExpr::boolean("v")));
         assert!(e.declarations.iter().any(|d| d.contains("bool delay_d_1_pending")));
         assert!(e.declarations.iter().any(|d| d.contains("unsigned long delay_d_1_armed_at")));
     }
 
     #[test]
-    fn no_driver_emits_no_timing() {
-        let e = emit(&delay("d-1", json!({})), None);
+    fn forget_previous_off_keeps_the_first_pending_deadline() {
+        let e = emit(
+            &delay("d-1", json!({ "forgetPrevious": false })),
+            &trigger_input(CppExpr::boolean("v")),
+        );
+        assert!(
+            e.loop_body.iter().any(|l| l.contains("if (!delay_d_1_pending && ")),
+            "arming is gated while pending"
+        );
+    }
+
+    #[test]
+    fn no_input_declares_but_never_arms() {
+        let e = emit(&delay("d-1", json!({})), &NodeInputs::default());
         assert!(e.loop_body.is_empty());
         assert!(e.declarations.iter().any(|d| d.contains("delay_d_1_value = 0.0")));
+        assert!(e.declarations.iter().any(|d| d.contains("delay_d_1_fired = false")));
     }
 
     #[test]
     fn emits_deterministically() {
         let n = delay("d-1", json!({ "delay": 200 }));
-        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+        let inputs = trigger_input(CppExpr::boolean("v"));
+        assert_eq!(emit(&n, &inputs), emit(&n, &inputs));
     }
 }

--- a/crates/microflow-core/src/codegen/control/interval.rs
+++ b/crates/microflow-core/src/codegen/control/interval.rs
@@ -1,17 +1,22 @@
 //! Interval emitter — mirrors `runtime/generator/interval.rs`.
 //!
-//! The live Interval spawns a thread that sleeps `interval` ms (clamped to a
-//! `MIN_INTERVAL_MS` of 16) and emits the elapsed milliseconds on every tick. On
-//! device there is no thread to sleep, so the generated Sketch keeps the timer's
-//! last-fire timestamp in a module-level `unsigned long` and, each `loop()`
-//! iteration, fires when `millis() - previous >= interval`. This is fully
-//! non-blocking: the loop never waits, multiple Intervals tick concurrently, and
-//! the unsigned subtraction survives `millis()` rollover (~49 days) without
-//! stalling. The output `double` holds the elapsed time since `setup()`, mirror‑
-//! ing the runtime's `start.elapsed()` value, so downstream Nodes see the same
-//! signal they do in live mode.
+//! The live Interval schedules a wakeup every `interval` ms (clamped to a
+//! `MIN_INTERVAL_MS` of 16) and emits the elapsed milliseconds on `event` each
+//! tick; it starts running on flow start, and its `start` / `stop` ports
+//! re-arm (resetting the elapsed base) or halt it. On device there is no
+//! scheduler to arm, so the generated Sketch keeps the timer's last-fire
+//! timestamp in a module-level `unsigned long` and, each `loop()` iteration,
+//! fires when `millis() - previous >= interval` while running. This is fully
+//! non-blocking: the loop never waits, multiple Intervals tick concurrently,
+//! and the unsigned subtraction survives `millis()` rollover (~49 days).
+//!
+//! The output `double` holds the elapsed time since the current start window
+//! (mirroring the runtime's `now - started_at` payload) and a `fired` flag is
+//! true exactly on firing iterations — the on-device twin of the `event`
+//! emission, consumed by pulse-driven downstream ports.
 
 use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::codegen::wire::{bind_pulses, NodeInputs};
 use crate::config::interval::IntervalConfig;
 use crate::flow::FlowNode;
 
@@ -19,46 +24,82 @@ use crate::flow::FlowNode;
 const MIN_INTERVAL_MS: u64 = 16;
 
 /// The C++ `double` variable holding this Interval Node's latest elapsed-time
-/// output (milliseconds since `setup()`), updated on each fire.
+/// output (milliseconds since its start window), updated on each fire.
 #[must_use]
 pub fn value_var(node: &FlowNode) -> String {
     format!("interval_{}_value", node.id_token())
 }
 
-/// Emit C++ for an Interval Node. The Interval is self-driving (it is a
-/// generator), so it ignores any `driver`; it ticks purely off the loop
-/// scheduler's `millis()` clock.
+/// The C++ `bool` variable that is true only on the loop iteration in which
+/// the Interval's `event` fires.
 #[must_use]
-pub fn emit(node: &FlowNode) -> NodeEmission {
+pub fn fired_var(node: &FlowNode) -> String {
+    format!("interval_{}_fired", node.id_token())
+}
+
+/// Emit C++ for an Interval Node. The Interval free-runs from `setup()` (the
+/// runtime arms itself on flow start); wired `start` / `stop` ports gate and
+/// re-base it exactly like the runtime's dispatch.
+#[must_use]
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let token = node.id_token();
     let var = value_var(node);
+    let fired = fired_var(node);
     let previous = format!("interval_{token}_previous");
     let start = format!("interval_{token}_start");
+    let running = format!("interval_{token}_running");
     let config: IntervalConfig = serde_json::from_value(node.data.clone()).unwrap_or_default();
     let interval_ms = config.interval.max(MIN_INTERVAL_MS);
+    // Mirrors on_start: the timer only free-runs when autoStart is set;
+    // otherwise a wired `start` pulse must arm it.
+    let auto_start = config.auto_start;
 
-    NodeEmission {
+    let mut e = NodeEmission {
         declarations: vec![
             format!("unsigned long {previous} = 0;"),
             format!("unsigned long {start} = 0;"),
             format!("double {var} = 0.0;"),
+            format!("bool {fired} = false;"),
+            format!("bool {running} = {auto_start};"),
         ],
         // Seed both timestamps so the first tick is measured from boot, not 0.
         setup: vec![format!("{previous} = millis();"), format!("{start} = millis();")],
-        loop_body: vec![
-            // Non-blocking: compare elapsed time, never block the loop.
-            format!("if (millis() - {previous} >= {interval_ms}UL) {{"),
-            format!("  {previous} += {interval_ms}UL;"),
-            format!("  {var} = (double)(millis() - {start});"),
-            "}".to_string(),
-        ],
         ..NodeEmission::default()
+    };
+
+    e.loop_body.push(format!("{fired} = false;"));
+
+    // start: re-arm and reset the elapsed base; stop: halt. Mirrors dispatch.
+    let start_binding = bind_pulses(&format!("interval_{token}_start_port"), inputs.on("start"));
+    e.declarations.extend(start_binding.declarations.iter().cloned());
+    e.loop_body.extend(start_binding.loop_lines.iter().cloned());
+    if let Some(any) = start_binding.any_fired() {
+        e.loop_body.push(format!(
+            "if ({any}) {{ {running} = true; {previous} = millis(); {start} = millis(); }}"
+        ));
     }
+    let stop_binding = bind_pulses(&format!("interval_{token}_stop_port"), inputs.on("stop"));
+    e.declarations.extend(stop_binding.declarations.iter().cloned());
+    e.loop_body.extend(stop_binding.loop_lines.iter().cloned());
+    if let Some(any) = stop_binding.any_fired() {
+        e.loop_body.push(format!("if ({any}) {{ {running} = false; }}"));
+    }
+
+    e.loop_body.extend([
+        // Non-blocking: compare elapsed time, never block the loop.
+        format!("if ({running} && millis() - {previous} >= {interval_ms}UL) {{"),
+        format!("  {previous} += {interval_ms}UL;"),
+        format!("  {var} = (double)(millis() - {start});"),
+        format!("  {fired} = true;"),
+        "}".to_string(),
+    ]);
+    e
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::{CppExpr, SourceExpr};
     use crate::flow::Position;
     use serde_json::json;
 
@@ -73,9 +114,11 @@ mod tests {
 
     #[test]
     fn fires_on_millis_comparison_without_blocking() {
-        let e = emit(&interval("iv-1", json!({ "interval": 500 })));
+        let e = emit(&interval("iv-1", json!({ "interval": 500 })), &NodeInputs::default());
         assert!(
-            e.loop_body.iter().any(|l| l.contains("millis() - interval_iv_1_previous >= 500UL")),
+            e.loop_body
+                .iter()
+                .any(|l| l.contains("millis() - interval_iv_1_previous >= 500UL")),
             "must compare elapsed millis against the configured interval"
         );
         assert!(
@@ -85,8 +128,16 @@ mod tests {
     }
 
     #[test]
+    fn exposes_a_one_tick_fired_flag() {
+        let e = emit(&interval("iv-1", json!({})), &NodeInputs::default());
+        assert!(e.declarations.iter().any(|d| d.contains("bool interval_iv_1_fired")));
+        assert_eq!(e.loop_body.first().unwrap(), "interval_iv_1_fired = false;");
+        assert!(e.loop_body.iter().any(|l| l.contains("interval_iv_1_fired = true")));
+    }
+
+    #[test]
     fn clamps_to_min_interval() {
-        let e = emit(&interval("iv-1", json!({ "interval": 1 })));
+        let e = emit(&interval("iv-1", json!({ "interval": 1 })), &NodeInputs::default());
         assert!(
             e.loop_body.iter().any(|l| l.contains(">= 16UL")),
             "interval below the runtime minimum must clamp to 16ms"
@@ -95,20 +146,32 @@ mod tests {
 
     #[test]
     fn defaults_to_one_second() {
-        let e = emit(&interval("iv-1", json!({})));
+        let e = emit(&interval("iv-1", json!({})), &NodeInputs::default());
         assert!(e.loop_body.iter().any(|l| l.contains(">= 1000UL")));
     }
 
     #[test]
     fn keeps_timestamps_across_iterations() {
-        let e = emit(&interval("iv-1", json!({})));
+        let e = emit(&interval("iv-1", json!({})), &NodeInputs::default());
         assert!(e.declarations.iter().any(|d| d.contains("unsigned long interval_iv_1_previous")));
         assert!(e.setup.iter().any(|s| s.contains("= millis()")), "timer seeded in setup");
     }
 
     #[test]
+    fn wired_start_and_stop_ports_gate_the_timer() {
+        let mut inputs = NodeInputs::default();
+        inputs.add("start", SourceExpr::level(CppExpr::boolean("go")));
+        inputs.add("stop", SourceExpr::level(CppExpr::boolean("halt")));
+        let e = emit(&interval("iv-1", json!({})), &inputs);
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("interval_iv_1_running = true"), "start re-arms: {body}");
+        assert!(body.contains("interval_iv_1_running = false"), "stop halts: {body}");
+        assert!(body.contains("if (interval_iv_1_running && millis()"), "tick is gated: {body}");
+    }
+
+    #[test]
     fn emits_deterministically() {
         let n = interval("iv-1", json!({ "interval": 250 }));
-        assert_eq!(emit(&n), emit(&n));
+        assert_eq!(emit(&n, &NodeInputs::default()), emit(&n, &NodeInputs::default()));
     }
 }

--- a/crates/microflow-core/src/codegen/control/trigger.rs
+++ b/crates/microflow-core/src/codegen/control/trigger.rs
@@ -1,47 +1,67 @@
 //! Trigger emitter — mirrors `runtime/control/trigger.rs`.
 //!
-//! The live Trigger watches a numeric signal and emits a boolean "bang" when the
-//! value moves past `threshold` in the configured direction (`increasing` /
-//! `decreasing`) within a recent window. It keeps a baseline from which the
-//! difference is measured. The generated Sketch reproduces this with a
-//! module-level baseline `double` and a boolean output: each loop iteration it
-//! compares the current driver value against the baseline and sets the output
-//! when the threshold is crossed in the correct direction. `relative` switches
-//! the comparison to a percentage of the baseline, matching the runtime. State
-//! persists across iterations so the baseline survives, and the output `bool` is
-//! read by downstream Nodes.
+//! The live Trigger watches the numeric signal on its `value` port and emits a
+//! `bang` (carrying the crossing value) when the value moves past `threshold`
+//! in the configured direction (`increasing` / `decreasing`). The generated
+//! Sketch reproduces this with a module-level baseline `double` and a boolean
+//! output: each loop iteration it compares the current input against the
+//! baseline and sets the output when the threshold is crossed in the correct
+//! direction — so the output `bool` is true exactly on crossing ticks, the
+//! on-device twin of the `bang` emission. The crossing value is captured into
+//! a payload variable for downstream consumers of the bang's value. `relative`
+//! switches the comparison to a percentage of the baseline, matching the
+//! runtime. Trigger does not aggregate: extra sources on `value` are noted and
+//! the first drives.
 
 use crate::codegen::emit::{cpp_double, NodeEmission, NodeToken};
+use crate::codegen::wire::{extra_sources_note, NodeInputs};
 use crate::config::trigger::{TriggerBehaviour, TriggerConfig};
 use crate::flow::FlowNode;
 
-/// The C++ `bool` variable holding this Trigger Node's latest bang state.
+/// The C++ `bool` variable holding this Trigger Node's latest bang state —
+/// true only on the loop iteration in which the threshold was crossed.
 #[must_use]
 pub fn state_var(node: &FlowNode) -> String {
     format!("trigger_{}_result", node.id_token())
 }
 
-/// Emit C++ for a Trigger Node. `driver` is the wired numeric input, or `None`
-/// when nothing is connected (the runtime never bangs without a signal).
+/// The C++ `double` variable holding the value that produced the most recent
+/// bang — the on-device twin of the bang emission's payload.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn value_payload_var(node: &FlowNode) -> String {
+    format!("trigger_{}_value", node.id_token())
+}
+
+/// Emit C++ for a Trigger Node from its `value` port. With nothing connected
+/// the result stays `false` (the runtime never bangs without a signal).
+#[must_use]
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let token = node.id_token();
     let var = state_var(node);
+    let payload = value_payload_var(node);
     let baseline = format!("trigger_{token}_baseline");
     let seeded = format!("trigger_{token}_seeded");
     let config: TriggerConfig = serde_json::from_value(node.data.clone()).unwrap_or_default();
     let threshold = cpp_double(config.threshold);
 
     let mut e = NodeEmission {
-        declarations: vec![format!("bool {var} = false;")],
+        declarations: vec![
+            format!("bool {var} = false;"),
+            format!("double {payload} = 0.0;"),
+        ],
         ..NodeEmission::default()
     };
 
-    if let Some(expr) = driver {
+    let sources = inputs.on("value");
+    if let Some(note) = extra_sources_note("value", sources) {
+        e.declarations.push(note);
+    }
+    if let Some(source) = sources.first() {
         e.declarations.push(format!("double {baseline} = 0.0;"));
         e.declarations.push(format!("bool {seeded} = false;"));
 
-        e.loop_body.push(format!("double trigger_{token}_now = (double)({expr});"));
+        e.loop_body
+            .push(format!("double trigger_{token}_now = {};", source.value.as_double()));
         // Seed the baseline from the first reading, like the runtime's first sample.
         e.loop_body
             .push(format!("if (!{seeded}) {{ {baseline} = trigger_{token}_now; {seeded} = true; }}"));
@@ -61,6 +81,9 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
         };
         e.loop_body
             .push(format!("{var} = ({direction}) && ({magnitude});"));
+        // Capture the crossing value as the bang payload, like emit_with_value.
+        e.loop_body
+            .push(format!("if ({var}) {{ {payload} = trigger_{token}_now; }}"));
         // Track the latest value as the new baseline for the next comparison.
         e.loop_body.push(format!("{baseline} = trigger_{token}_now;"));
     }
@@ -70,6 +93,7 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::{CppExpr, SourceExpr};
     use crate::flow::Position;
     use serde_json::json;
 
@@ -82,9 +106,15 @@ mod tests {
         }
     }
 
+    fn value_input(expr: CppExpr) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add("value", SourceExpr::level(expr));
+        inputs
+    }
+
     #[test]
     fn bangs_on_absolute_threshold() {
-        let e = emit(&trigger("tg-1", json!({ "threshold": 10.0 })), Some("v"));
+        let e = emit(&trigger("tg-1", json!({ "threshold": 10.0 })), &value_input(CppExpr::number("v")));
         assert!(e.declarations.iter().any(|d| d.contains("bool trigger_tg_1_result")));
         assert!(
             e.loop_body.iter().any(|l| l.contains(">= 10.0")),
@@ -93,8 +123,20 @@ mod tests {
     }
 
     #[test]
+    fn captures_the_crossing_value_as_payload() {
+        let e = emit(&trigger("tg-1", json!({})), &value_input(CppExpr::number("v")));
+        assert!(e.declarations.iter().any(|d| d.contains("double trigger_tg_1_value")));
+        assert!(
+            e.loop_body
+                .iter()
+                .any(|l| l.contains("trigger_tg_1_value = trigger_tg_1_now")),
+            "bang payload captured"
+        );
+    }
+
+    #[test]
     fn decreasing_is_the_default_direction() {
-        let e = emit(&trigger("tg-1", json!({})), Some("v"));
+        let e = emit(&trigger("tg-1", json!({})), &value_input(CppExpr::number("v")));
         assert!(
             e.loop_body.iter().any(|l| l.contains("diff <= 0.0")),
             "default behaviour is decreasing"
@@ -103,19 +145,25 @@ mod tests {
 
     #[test]
     fn increasing_flips_the_direction() {
-        let e = emit(&trigger("tg-1", json!({ "behaviour": "increasing" })), Some("v"));
+        let e = emit(
+            &trigger("tg-1", json!({ "behaviour": "increasing" })),
+            &value_input(CppExpr::number("v")),
+        );
         assert!(e.loop_body.iter().any(|l| l.contains("diff > 0.0")));
     }
 
     #[test]
     fn relative_uses_percentage() {
-        let e = emit(&trigger("tg-1", json!({ "relative": true, "threshold": 20.0 })), Some("v"));
+        let e = emit(
+            &trigger("tg-1", json!({ "relative": true, "threshold": 20.0 })),
+            &value_input(CppExpr::number("v")),
+        );
         assert!(e.loop_body.iter().any(|l| l.contains("* 100.0")), "relative => percent compare");
     }
 
     #[test]
-    fn no_driver_leaves_false() {
-        let e = emit(&trigger("tg-1", json!({})), None);
+    fn no_input_leaves_false() {
+        let e = emit(&trigger("tg-1", json!({})), &NodeInputs::default());
         assert!(e.loop_body.is_empty());
         assert!(e.declarations.iter().any(|d| d.contains("= false;")));
     }
@@ -123,6 +171,7 @@ mod tests {
     #[test]
     fn emits_deterministically() {
         let n = trigger("tg-1", json!({ "threshold": 3.0, "behaviour": "increasing" }));
-        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+        let inputs = value_input(CppExpr::number("v"));
+        assert_eq!(emit(&n, &inputs), emit(&n, &inputs));
     }
 }

--- a/crates/microflow-core/src/codegen/emit.rs
+++ b/crates/microflow-core/src/codegen/emit.rs
@@ -129,6 +129,39 @@ pub fn str_or_default(node: &FlowNode, key: &str, default: &str) -> String {
         .to_string()
 }
 
+/// Escape `s` into a double-quoted C++ string literal. User-authored config
+/// (topics, prompts, credentials, labels) flows into the Sketch through this,
+/// so a quote, backslash, or newline in the value cannot break out of the
+/// literal and corrupt — or inject code into — the generated file.
+#[must_use]
+pub fn cpp_string_literal(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            // Other control characters as 3-digit octal (self-terminating,
+            // unlike \x which greedily consumes following hex digits).
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\{:03o}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Sanitize `s` for use inside a single-line `//` comment: line breaks and
+/// other control characters collapse to spaces so the comment cannot spill
+/// onto a new (uncommented) line.
+#[must_use]
+pub fn cpp_comment_text(s: &str) -> String {
+    s.chars().map(|c| if c.is_control() { ' ' } else { c }).collect()
+}
+
 /// Format an `f64` as a C++ `double` literal that round-trips deterministically.
 /// Integer-valued numbers gain a trailing `.0` so the literal is unambiguously
 /// floating point.

--- a/crates/microflow-core/src/codegen/generator/oscillator.rs
+++ b/crates/microflow-core/src/codegen/generator/oscillator.rs
@@ -10,6 +10,7 @@
 //! the scheduler's clock, never waits.
 
 use crate::codegen::emit::{cpp_double, NodeEmission, NodeToken};
+use crate::codegen::wire::{bind_pulses, NodeInputs};
 use crate::config::oscillator::{OscillatorConfig, Waveform};
 use crate::flow::FlowNode;
 
@@ -23,13 +24,17 @@ pub fn value_var(node: &FlowNode) -> String {
     format!("oscillator_{}_value", node.id_token())
 }
 
-/// Emit C++ for an Oscillator Node. The Oscillator is a generator: it ignores
-/// any wired input and ticks purely off the loop scheduler's `millis()` clock.
+/// Emit C++ for an Oscillator Node. It samples its waveform off the loop
+/// scheduler's `millis()` clock while running; `autoStart` (mirroring the
+/// runtime's `on_start`) decides whether it free-runs from `setup()`, and
+/// wired `start` / `stop` / `reset` ports gate and re-base it exactly like
+/// the runtime's dispatch (`reset` restarts the phase only while running).
 #[must_use]
-pub fn emit(node: &FlowNode) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let token = node.id_token();
     let value = value_var(node);
     let start = format!("oscillator_{token}_start");
+    let running = format!("oscillator_{token}_running");
     let t = format!("oscillator_{token}_t");
 
     let config: OscillatorConfig = serde_json::from_value(node.data.clone()).unwrap_or_default();
@@ -41,10 +46,12 @@ pub fn emit(node: &FlowNode) -> NodeEmission {
 
     // `t` is the elapsed-millis timestamp plus phase, mirroring the runtime which
     // adds `config.phase` to `start.elapsed()`. All branches reduce `t` modulo
-    // the period before sampling, exactly as `calculate_waveform` does.
-    let mut loop_body = vec![
+    // the period before sampling, exactly as `calculate_waveform` does. The
+    // whole sample block is gated on `running`, indented for readability.
+    let mut sample_lines = vec![
         format!("double {t} = (double)(millis() - {start}) + {phase};"),
     ];
+    let loop_body = &mut sample_lines;
     let sample = match config.waveform {
         Waveform::Square => {
             loop_body.push(format!("{t} = fmod({t}, {period});"));
@@ -73,15 +80,43 @@ pub fn emit(node: &FlowNode) -> NodeEmission {
     };
     loop_body.push(sample);
 
-    NodeEmission {
+    let mut e = NodeEmission {
         declarations: vec![
             format!("unsigned long {start} = 0;"),
             format!("double {value} = 0.0;"),
+            format!("bool {running} = {};", config.auto_start),
         ],
         setup: vec![format!("{start} = millis();")],
-        loop_body,
         ..NodeEmission::default()
+    };
+
+    // start: run and re-base the phase; stop: halt; reset: restart the phase
+    // only while running (the runtime's stop-then-start-if-was-running).
+    let start_binding = bind_pulses(&format!("oscillator_{token}_start_port"), inputs.on("start"));
+    e.declarations.extend(start_binding.declarations.iter().cloned());
+    e.loop_body.extend(start_binding.loop_lines.iter().cloned());
+    if let Some(any) = start_binding.any_fired() {
+        e.loop_body
+            .push(format!("if ({any}) {{ {running} = true; {start} = millis(); }}"));
     }
+    let stop_binding = bind_pulses(&format!("oscillator_{token}_stop_port"), inputs.on("stop"));
+    e.declarations.extend(stop_binding.declarations.iter().cloned());
+    e.loop_body.extend(stop_binding.loop_lines.iter().cloned());
+    if let Some(any) = stop_binding.any_fired() {
+        e.loop_body.push(format!("if ({any}) {{ {running} = false; }}"));
+    }
+    let reset_binding = bind_pulses(&format!("oscillator_{token}_reset_port"), inputs.on("reset"));
+    e.declarations.extend(reset_binding.declarations.iter().cloned());
+    e.loop_body.extend(reset_binding.loop_lines.iter().cloned());
+    if let Some(any) = reset_binding.any_fired() {
+        e.loop_body
+            .push(format!("if ({any} && {running}) {{ {start} = millis(); }}"));
+    }
+
+    e.loop_body.push(format!("if ({running}) {{"));
+    e.loop_body.extend(sample_lines.iter().map(|l| format!("  {l}")));
+    e.loop_body.push("}".to_string());
+    e
 }
 
 #[cfg(test)]
@@ -101,7 +136,7 @@ mod tests {
 
     #[test]
     fn oscillator_samples_against_millis_non_blocking() {
-        let e = emit(&oscillator("osc-1", json!({ "waveform": "sinus", "period": 1000 })));
+        let e = emit(&oscillator("osc-1", json!({ "waveform": "sinus", "period": 1000 })), &NodeInputs::default());
         assert!(e.loop_body.iter().any(|l| l.contains("millis() - oscillator_osc_1_start")));
         assert!(e.loop_body.iter().any(|l| l.contains("sin(")), "sinus waveform");
         assert!(!e.loop_body.iter().any(|l| l.contains("delay(")), "must not block");
@@ -109,41 +144,70 @@ mod tests {
 
     #[test]
     fn oscillator_square_waveform() {
-        let e = emit(&oscillator("osc-1", json!({ "waveform": "square" })));
+        let e = emit(&oscillator("osc-1", json!({ "waveform": "square" })), &NodeInputs::default());
         assert!(e.loop_body.iter().any(|l| l.contains("* 2.0 <")));
     }
 
     #[test]
     fn oscillator_sawtooth_and_triangle() {
-        let saw = emit(&oscillator("osc-1", json!({ "waveform": "sawtooth" })));
+        let saw = emit(&oscillator("osc-1", json!({ "waveform": "sawtooth" })), &NodeInputs::default());
         assert!(saw.loop_body.iter().any(|l| l.contains("2.0 /")));
-        let tri = emit(&oscillator("osc-1", json!({ "waveform": "triangle" })));
+        let tri = emit(&oscillator("osc-1", json!({ "waveform": "triangle" })), &NodeInputs::default());
         assert!(tri.loop_body.iter().any(|l| l.contains("4.0 /")));
     }
 
     #[test]
     fn oscillator_random_uses_amplitude_and_shift() {
-        let e = emit(&oscillator("osc-1", json!({ "waveform": "random", "amplitude": 2.0, "shift": 1.0 })));
+        let e = emit(
+            &oscillator("osc-1", json!({ "waveform": "random", "amplitude": 2.0, "shift": 1.0 })),
+            &NodeInputs::default(),
+        );
         assert!(e.loop_body.iter().any(|l| l.contains("random(")));
     }
 
     #[test]
     fn oscillator_clamps_zero_period() {
-        let e = emit(&oscillator("osc-1", json!({ "period": 0 })));
+        let e = emit(&oscillator("osc-1", json!({ "period": 0 })), &NodeInputs::default());
         // Falls back to the default period rather than dividing by zero.
         assert!(e.loop_body.iter().any(|l| l.contains("1000.0")));
     }
 
     #[test]
     fn oscillator_seeds_start_in_setup() {
-        let e = emit(&oscillator("osc-1", json!({})));
+        let e = emit(&oscillator("osc-1", json!({})), &NodeInputs::default());
         assert!(e.setup.iter().any(|s| s.contains("= millis()")));
         assert!(e.declarations.iter().any(|d| d.contains("double oscillator_osc_1_value")));
     }
 
     #[test]
+    fn oscillator_gates_sampling_on_running() {
+        let e = emit(&oscillator("osc-1", json!({})), &NodeInputs::default());
+        assert!(
+            e.loop_body.iter().any(|l| l.starts_with("if (oscillator_osc_1_running) {")),
+            "sample block is gated on running"
+        );
+    }
+
+    #[test]
+    fn oscillator_start_stop_reset_ports_gate_the_signal() {
+        use crate::codegen::wire::{CppExpr, SourceExpr};
+        let mut inputs = NodeInputs::default();
+        inputs.add("start", SourceExpr::level(CppExpr::boolean("go")));
+        inputs.add("stop", SourceExpr::level(CppExpr::boolean("halt")));
+        inputs.add("reset", SourceExpr::level(CppExpr::boolean("again")));
+        let e = emit(&oscillator("osc-1", json!({})), &inputs);
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("oscillator_osc_1_running = true"), "start runs: {body}");
+        assert!(body.contains("oscillator_osc_1_running = false"), "stop halts: {body}");
+        assert!(
+            body.contains("&& oscillator_osc_1_running) { oscillator_osc_1_start = millis(); }"),
+            "reset re-bases only while running: {body}"
+        );
+    }
+
+    #[test]
     fn oscillator_emits_deterministically() {
         let n = oscillator("osc-1", json!({ "waveform": "square", "period": 500 }));
-        assert_eq!(emit(&n), emit(&n));
+        assert_eq!(emit(&n, &NodeInputs::default()), emit(&n, &NodeInputs::default()));
     }
 }

--- a/crates/microflow-core/src/codegen/input/i2c_device.rs
+++ b/crates/microflow-core/src/codegen/input/i2c_device.rs
@@ -9,12 +9,9 @@
 //! the unsigned/signed integer formats. Downstream Nodes read that value.
 
 use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::codegen::wire::{bind_pulses, NodeInputs};
+use crate::config::i2c_device::{I2cDeviceConfig, OutputFormat};
 use crate::flow::FlowNode;
-
-/// Default I2C address matches `runtime/input/i2c_device.rs::default_address`.
-const DEFAULT_ADDRESS: u8 = 0x48;
-/// Default read length matches `runtime/input/i2c_device.rs::default_read_length`.
-const DEFAULT_READ_LENGTH: u8 = 2;
 
 /// The C++ `long` variable name holding this device's latest decoded reading.
 #[must_use]
@@ -22,42 +19,25 @@ pub fn value_var(node: &FlowNode) -> String {
     format!("i2c_{}_value", node.id_token())
 }
 
-/// Whether the device streams every loop (`true`, default) or reads only when
-/// its `trigger` input fires (`false`). Mirrors the runtime config's `autoread`
-/// (default on) — an absent key keeps a pre-`autoread` doc streaming.
-fn autoread(node: &FlowNode) -> bool {
-    node.data.get("autoread").and_then(serde_json::Value::as_bool).unwrap_or(true)
-}
-
-fn u8_field(node: &FlowNode, key: &str, default: u8) -> u8 {
-    node.data
-        .get(key)
-        .and_then(serde_json::Value::as_u64)
-        .and_then(|n| u8::try_from(n).ok())
-        .unwrap_or(default)
-}
-
-/// True when the configured output format treats the bytes as a signed integer.
-fn is_signed(node: &FlowNode) -> bool {
-    node.data
-        .get("output")
-        .and_then(serde_json::Value::as_str)
-        .is_some_and(|t| t.eq_ignore_ascii_case("signed_int") || t.eq_ignore_ascii_case("signedint"))
-}
-
-/// Emit C++ for an `I2cDevice` Node. `driver` is the optional upstream trigger
-/// expression: when `autoread` is off the read fires on its rising edge (the
-/// generated twin of the runtime's `trigger` handle), otherwise it is ignored
-/// because the device streams every loop.
+/// Emit C++ for an `I2cDevice` Node. When `autoread` is off, the read fires
+/// on pulses from the sources wired into the `trigger` port (the generated
+/// twin of the runtime's `trigger` handle); otherwise the device streams
+/// every loop and trigger wiring is ignored. The `write` port carries raw
+/// byte payloads with no on-device value model; wiring it emits a note.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
+    // Deserialize the SAME config the runtime builds from (ungated in
+    // `crate::config::i2c_device`), so codegen and interpret never disagree on
+    // field parsing or defaults. Malformed data falls back to defaults rather
+    // than erroring — the sketch generator has no per-node failure channel.
+    let config: I2cDeviceConfig = serde_json::from_value(node.data.clone()).unwrap_or_default();
+
     let token = node.id_token();
     let value = value_var(node);
-    let addr = u8_field(node, "address", DEFAULT_ADDRESS);
-    let register = effective_register(node);
-    // Web sends camelCase keys; mirrors the runtime config's `rename_all`.
-    let read_length = u8_field(node, "readLength", DEFAULT_READ_LENGTH).max(1);
-    let signed = is_signed(node);
+    let addr = config.address;
+    let register = effective_register(&config);
+    let read_length = config.read_length.max(1);
+    let signed = config.output == OutputFormat::SignedInt;
 
     let acc = format!("i2c_{token}_acc");
     let i = format!("i2c_{token}_i");
@@ -66,7 +46,7 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
     // No-hold sensors (SHT2x/HTU21) NACK until their conversion completes, so the
     // command write must end with a STOP and be followed by a delay before the
     // read. Other devices keep the repeated-start (no STOP, no delay) read.
-    let delay_ms = read_delay_ms(node);
+    let delay_ms = read_delay_ms(&config);
     let stop_tx = if delay_ms > 0 { "true" } else { "false" };
     let mut loop_body = vec![
         format!("Wire.beginTransmission((uint8_t){addr});"),
@@ -90,35 +70,38 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
     loop_body.push("}".to_string());
     loop_body.push(format!("{value} = {acc};"));
 
-    // `autoread` off ⇒ trigger-only: read on the driver's rising edge (mirrors the
-    // runtime `trigger` handle), not every loop. With no upstream trigger wired the
-    // device never reads — the value stays at its 0 default, matching the runtime,
-    // where no continuous read is armed and nothing calls `request_read`.
+    // `autoread` off ⇒ trigger-only: read on a pulse from any source wired
+    // into the `trigger` port (mirrors the runtime `trigger` handle), not
+    // every loop. With no trigger wired the device never reads — the value
+    // stays at its 0 default, matching the runtime, where no continuous read
+    // is armed and nothing calls `request_read`.
     let mut declarations = vec![format!("long {value} = 0;")];
-    if !autoread(node) {
-        loop_body = match driver {
-            Some(expr) => {
-                let prev = format!("i2c_{token}_prev");
-                let trig = format!("i2c_{token}_trig");
-                declarations.push(format!("bool {prev} = false;"));
-                let mut gated = vec![
-                    format!("bool {trig} = (bool)({expr});"),
-                    format!("if ({trig} && !{prev}) {{"),
-                ];
+    if !config.autoread {
+        let binding = bind_pulses(&format!("i2c_{token}_trigger"), inputs.on("trigger"));
+        loop_body = match binding.any_fired() {
+            Some(any) => {
+                declarations.extend(binding.declarations.iter().cloned());
+                let mut gated = binding.loop_lines.clone();
+                gated.push(format!("if ({any}) {{"));
                 gated.extend(loop_body.into_iter().map(|l| format!("  {l}")));
                 gated.push("}".to_string());
-                gated.push(format!("{prev} = {trig};"));
                 gated
             }
             None => Vec::new(),
         };
+    }
+    if !inputs.on("write").is_empty() {
+        declarations.push(
+            "// note: input 'write' carries raw byte payloads codegen cannot express on-device — edge ignored"
+                .to_string(),
+        );
     }
 
     // Power on / configure known devices once in setup(), mirroring the runtime's
     // `device_init_writes`. Keyed off the `device` preset id so generic/custom
     // devices emit nothing extra.
     let mut setup = vec!["Wire.begin();".to_string()];
-    for &payload in device_init_writes(node) {
+    for &payload in crate::config::i2c_device::device_init_writes(&config.device) {
         setup.push(format!("Wire.beginTransmission((uint8_t){addr});"));
         for &byte in payload {
             setup.push(format!("Wire.write((uint8_t){byte});"));
@@ -134,28 +117,13 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
     }
 }
 
-/// The `device` preset id from the Node, or `""` when absent (→ no init).
-fn device_id(node: &FlowNode) -> &str {
-    node.data.get("device").and_then(serde_json::Value::as_str).unwrap_or("")
-}
-
-/// One-time I2C writes a known device needs before it produces data. Delegates to
-/// the ungated [`crate::config::i2c_device::device_init_writes`] table so the
-/// generated sketch's `setup()` stays byte-identical to the live runtime's
-/// `initialize()` — one source, no hand-mirroring drift.
-fn device_init_writes(node: &FlowNode) -> &'static [&'static [u8]] {
-    crate::config::i2c_device::device_init_writes(device_id(node))
-}
-
 /// The register actually read, with the hold-master → no-hold safety override.
 /// Delegates to the shared [`crate::config::i2c_device::effective_register`] (see
 /// there for why a stale hold-master 0xE3/0xE5 must be remapped before it hangs
 /// the AVR bus). Sharing it also gives codegen the runtime's stale-label
 /// normalisation, which the old hand-mirrored copy lacked.
-fn effective_register(node: &FlowNode) -> u8 {
-    let register = u8_field(node, "register", 0);
-    let addr = u8_field(node, "address", DEFAULT_ADDRESS);
-    crate::config::i2c_device::effective_register(device_id(node), addr, register)
+fn effective_register(config: &I2cDeviceConfig) -> u8 {
+    crate::config::i2c_device::effective_register(&config.device, config.address, config.register)
 }
 
 /// Delay (ms) inserted between the register write and the read for no-hold
@@ -164,8 +132,8 @@ fn effective_register(node: &FlowNode) -> u8 {
 /// codegen's own — the generated sketch uses a plain `delay()` (not Firmata's
 /// 7-bit-capped `I2C_CONFIG`), so 30ms is safe and leaves more margin over the 15ms
 /// worst-case 11-bit conversion. Zero ⇒ repeated-start immediate read.
-fn read_delay_ms(node: &FlowNode) -> u32 {
-    if crate::config::i2c_device::is_no_hold_sht2x(device_id(node)) { 30 } else { 0 }
+fn read_delay_ms(config: &I2cDeviceConfig) -> u32 {
+    if crate::config::i2c_device::is_no_hold_sht2x(&config.device) { 30 } else { 0 }
 }
 
 #[cfg(test)]
@@ -183,9 +151,17 @@ mod tests {
         }
     }
 
+    /// A single boolean source wired into the `trigger` port.
+    fn trigger_input(expr: &str) -> NodeInputs {
+        use crate::codegen::wire::{CppExpr, SourceExpr};
+        let mut inputs = NodeInputs::default();
+        inputs.add("trigger", SourceExpr::level(CppExpr::boolean(expr)));
+        inputs
+    }
+
     #[test]
     fn i2c_includes_wire_and_begins_bus() {
-        let e = emit(&i2c("d-1", json!({})), None);
+        let e = emit(&i2c("d-1", json!({})), &NodeInputs::default());
         assert!(e.includes.iter().any(|i| i.contains("Wire.h")));
         assert!(e.setup.iter().any(|s| s.contains("Wire.begin()")));
     }
@@ -193,7 +169,7 @@ mod tests {
     #[test]
     fn i2c_reads_configured_length_and_address() {
         // camelCase `readLength` — the key the web actually sends.
-        let e = emit(&i2c("d-1", json!({ "address": 0x40, "readLength": 3 })), None);
+        let e = emit(&i2c("d-1", json!({ "address": 0x40, "readLength": 3 })), &NodeInputs::default());
         assert!(e.loop_body.iter().any(|l| l.contains("requestFrom") && l.contains("64")));
         assert!(e.loop_body.iter().any(|l| l.contains("< 3 &&")));
     }
@@ -202,13 +178,13 @@ mod tests {
     fn i2c_snake_case_read_length_is_ignored() {
         // Guard the rename: the old snake_case key must NOT be honored, else the
         // runtime (camelCase) and codegen would disagree on byte count.
-        let e = emit(&i2c("d-1", json!({ "read_length": 8 })), None);
+        let e = emit(&i2c("d-1", json!({ "read_length": 8 })), &NodeInputs::default());
         assert!(e.loop_body.iter().any(|l| l.contains("< 2 &&")), "must fall back to default 2");
     }
 
     #[test]
     fn i2c_tcs34725_enables_adc_in_setup() {
-        let e = emit(&i2c("d-1", json!({ "device": "tcs34725", "address": 0x29 })), None);
+        let e = emit(&i2c("d-1", json!({ "device": "tcs34725", "address": 0x29 })), &NodeInputs::default());
         // ENABLE register 0x80 = 128, value 3 written once in setup().
         assert!(e.setup.iter().any(|s| s.contains("128")), "must write ENABLE register");
         assert!(e.setup.iter().any(|s| s.contains("Wire.write((uint8_t)3)")));
@@ -216,14 +192,14 @@ mod tests {
 
     #[test]
     fn i2c_custom_device_emits_no_init_writes() {
-        let e = emit(&i2c("d-1", json!({ "device": "custom" })), None);
+        let e = emit(&i2c("d-1", json!({ "device": "custom" })), &NodeInputs::default());
         // Only Wire.begin() — no extra transmissions for generic devices.
         assert_eq!(e.setup, vec!["Wire.begin();".to_string()]);
     }
 
     #[test]
     fn i2c_mpu6050_wakes_from_sleep_in_setup() {
-        let e = emit(&i2c("d-1", json!({ "device": "mpu6050", "address": 0x68 })), None);
+        let e = emit(&i2c("d-1", json!({ "device": "mpu6050", "address": 0x68 })), &NodeInputs::default());
         // PWR_MGMT_1 (0x6B = 107) = 0x00 clears the SLEEP bit in setup().
         assert!(e.setup.iter().any(|s| s.contains("Wire.write((uint8_t)107)")), "must write PWR_MGMT_1");
         assert!(e.setup.iter().any(|s| s.contains("(uint8_t)104")), "must address the MPU6050");
@@ -231,7 +207,7 @@ mod tests {
 
     #[test]
     fn i2c_bmp280_configures_without_a_humidity_write() {
-        let e = emit(&i2c("d-1", json!({ "device": "bmp280_pressure", "address": 0x76 })), None);
+        let e = emit(&i2c("d-1", json!({ "device": "bmp280_pressure", "address": 0x76 })), &NodeInputs::default());
         // ctrl_meas (0xF4 = 244) + config (0xF5 = 245); NO ctrl_hum (0xF2 = 242).
         assert!(e.setup.iter().any(|s| s.contains("Wire.write((uint8_t)244)")), "must write ctrl_meas");
         assert!(e.setup.iter().any(|s| s.contains("Wire.write((uint8_t)245)")), "must write config");
@@ -244,7 +220,7 @@ mod tests {
         // label ("MPU6050") skipped the init in the generated sketch while the
         // runtime (which normalised) still emitted it. Routing both through the
         // shared normalised table removes that divergence.
-        let e = emit(&i2c("d-1", json!({ "device": "MPU6050", "address": 0x68 })), None);
+        let e = emit(&i2c("d-1", json!({ "device": "MPU6050", "address": 0x68 })), &NodeInputs::default());
         assert!(e.setup.iter().any(|s| s.contains("Wire.write((uint8_t)107)")), "stale label must still wake");
     }
 
@@ -255,7 +231,7 @@ mod tests {
                 "d-1",
                 json!({ "device": "sht21_temp", "address": 0x40, "register": 0xF3, "readLength": 2 }),
             ),
-            None,
+            &NodeInputs::default(),
         );
         // No-hold: STOP after the command write, then a delay before the read.
         assert!(e.loop_body.iter().any(|l| l.contains("Wire.endTransmission(true)")));
@@ -270,27 +246,27 @@ mod tests {
         // A doc saved before the no-hold preset change still carries 0xE3 (=227);
         // the sketch must write the no-hold 0xF3 (=243) instead, never the
         // bus-hanging hold-master register.
-        let e = emit(&i2c("d-1", json!({ "device": "sht21_temp", "register": 0xE3 })), None);
+        let e = emit(&i2c("d-1", json!({ "device": "sht21_temp", "register": 0xE3 })), &NodeInputs::default());
         assert!(e.loop_body.iter().any(|l| l.contains("Wire.write((uint8_t)243)")), "must remap to 0xF3");
         assert!(!e.loop_body.iter().any(|l| l.contains("Wire.write((uint8_t)227)")), "must not emit 0xE3");
     }
 
     #[test]
     fn i2c_non_sht_keeps_repeated_start_without_delay() {
-        let e = emit(&i2c("d-1", json!({ "device": "tcs34725", "address": 0x29 })), None);
+        let e = emit(&i2c("d-1", json!({ "device": "tcs34725", "address": 0x29 })), &NodeInputs::default());
         assert!(e.loop_body.iter().any(|l| l.contains("Wire.endTransmission(false)")));
         assert!(!e.loop_body.iter().any(|l| l.starts_with("delay(")), "non-no-hold must not delay");
     }
 
     #[test]
     fn i2c_sign_extends_for_signed_format() {
-        let e = emit(&i2c("d-1", json!({ "output": "signed_int" })), None);
+        let e = emit(&i2c("d-1", json!({ "output": "signed_int" })), &NodeInputs::default());
         assert!(e.loop_body.iter().any(|l| l.contains("0x80")), "signed must sign-extend");
     }
 
     #[test]
     fn i2c_unsigned_does_not_sign_extend() {
-        let e = emit(&i2c("d-1", json!({ "output": "unsigned_int" })), None);
+        let e = emit(&i2c("d-1", json!({ "output": "unsigned_int" })), &NodeInputs::default());
         assert!(!e.loop_body.iter().any(|l| l.contains("0x80")));
     }
 
@@ -299,7 +275,7 @@ mod tests {
         // Absent `autoread` ⇒ streaming: the read runs unconditionally every loop,
         // even with a driver wired (matches the runtime, which streams on the
         // sampling interval and treats `trigger` as an extra manual read).
-        let e = emit(&i2c("d-1", json!({})), Some("btn_state"));
+        let e = emit(&i2c("d-1", json!({})), &trigger_input("btn_state"));
         assert!(e.loop_body.iter().any(|l| l.contains("requestFrom")), "must read");
         assert!(!e.loop_body.iter().any(|l| l.contains("btn_state")), "streaming ignores driver");
         assert!(!e.declarations.iter().any(|d| d.contains("_prev")), "no edge state when streaming");
@@ -307,13 +283,16 @@ mod tests {
 
     #[test]
     fn i2c_autoread_off_reads_only_on_trigger_rising_edge() {
-        // autoread off + driver wired ⇒ the read is gated behind the driver's
+        // autoread off + trigger wired ⇒ the read is gated behind the source's
         // rising edge (the generated twin of the runtime `trigger` handle).
-        let e = emit(&i2c("d-1", json!({ "autoread": false })), Some("btn_state"));
-        assert!(e.declarations.iter().any(|d| d.contains("i2c_d_1_prev")), "tracks previous edge");
+        let e = emit(&i2c("d-1", json!({ "autoread": false })), &trigger_input("btn_state"));
         assert!(
-            e.loop_body.iter().any(|l| l.contains("i2c_d_1_trig") && l.contains("!i2c_d_1_prev")),
-            "reads only on rising edge",
+            e.declarations.iter().any(|d| d.contains("i2c_d_1_trigger_prev0")),
+            "tracks previous edge"
+        );
+        assert!(
+            e.loop_body.iter().any(|l| l.contains("!= i2c_d_1_trigger_prev0")),
+            "reads only when the trigger source changes",
         );
         assert!(e.loop_body.iter().any(|l| l.contains("requestFrom")), "still performs the read");
     }
@@ -322,7 +301,7 @@ mod tests {
     fn i2c_autoread_off_without_trigger_never_reads() {
         // autoread off + no driver ⇒ no read at all (value stays 0), mirroring the
         // runtime where nothing is armed and no trigger source exists.
-        let e = emit(&i2c("d-1", json!({ "autoread": false })), None);
+        let e = emit(&i2c("d-1", json!({ "autoread": false })), &NodeInputs::default());
         assert!(!e.loop_body.iter().any(|l| l.contains("requestFrom")), "must not read");
         assert_eq!(e.declarations, vec!["long i2c_d_1_value = 0;".to_string()]);
     }
@@ -330,6 +309,6 @@ mod tests {
     #[test]
     fn i2c_emits_deterministically() {
         let n = i2c("d-1", json!({ "address": 0x48, "read_length": 2 }));
-        assert_eq!(emit(&n, None), emit(&n, None));
+        assert_eq!(emit(&n, &NodeInputs::default()), emit(&n, &NodeInputs::default()));
     }
 }

--- a/crates/microflow-core/src/codegen/mod.rs
+++ b/crates/microflow-core/src/codegen/mod.rs
@@ -364,23 +364,20 @@ fn wire_inputs(flow: &FlowUpdate) -> Wiring<'_> {
             ));
             continue;
         };
-        match output_expression(source_node, source_handle) {
-            Some(expr) => {
-                wiring
-                    .inputs
-                    .entry(target)
-                    .or_default()
-                    .add(target_handle, expr);
-            }
-            None => {
-                let kind = source_node.node_type.as_deref().unwrap_or("unknown");
-                wiring.notes.entry(target).or_default().push(format!(
-                    "// note: input '{}' from node '{}' ({kind}) output '{}' has no on-device value — edge ignored",
-                    emit::cpp_comment_text(target_handle),
-                    emit::cpp_comment_text(source),
-                    emit::cpp_comment_text(source_handle),
-                ));
-            }
+        if let Some(expr) = output_expression(source_node, source_handle) {
+            wiring
+                .inputs
+                .entry(target)
+                .or_default()
+                .add(target_handle, expr);
+        } else {
+            let kind = source_node.node_type.as_deref().unwrap_or("unknown");
+            wiring.notes.entry(target).or_default().push(format!(
+                "// note: input '{}' from node '{}' ({kind}) output '{}' has no on-device value — edge ignored",
+                emit::cpp_comment_text(target_handle),
+                emit::cpp_comment_text(source),
+                emit::cpp_comment_text(source_handle),
+            ));
         }
     }
     wiring
@@ -639,7 +636,7 @@ mod tests {
     }
 
     /// An edge with explicit source/target handles, matching the real Flow
-    /// wire contract (source handle ∈ emits(), target handle ∈ ports()).
+    /// wire contract (source handle ∈ `emits()`, target handle ∈ `ports()`).
     fn edge_h(source: &str, source_handle: &str, target: &str, target_handle: &str) -> FlowEdge {
         FlowEdge {
             id: None,
@@ -880,7 +877,7 @@ mod tests {
     }
 
     /// Scenario: a Button's `value` into a Led's `value` is PWM brightness —
-    /// the runtime's brightness dispatch (Bool ⇒ as_u8 ⇒ 0/1), not a digital
+    /// the runtime's brightness dispatch (Bool ⇒ `as_u8` ⇒ 0/1), not a digital
     /// level write.
     #[test]
     fn button_value_into_led_value_is_brightness() {

--- a/crates/microflow-core/src/codegen/mod.rs
+++ b/crates/microflow-core/src/codegen/mod.rs
@@ -32,6 +32,7 @@ pub mod output;
 pub mod placeholder;
 pub mod transformation;
 pub mod validate;
+pub mod wire;
 
 /// Interpret↔emit parity guards (test-only). Pins each operation variant / port
 /// to an exhaustive emit-vs-passthrough classification so runtime↔codegen drift
@@ -47,6 +48,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use ts_rs::TS;
 use validate::ValidationProblem;
+use wire::{CppExpr, NodeInputs, SourceExpr};
 
 /// The outcome of generating a Sketch for a selected board target.
 ///
@@ -132,13 +134,30 @@ fn emit_sketch(
     target: &BoardTarget,
     credentials: Option<&Credentials>,
 ) -> String {
-    let order = traversal_order(flow);
-    let drivers = driver_expressions(flow);
+    let order = nodes_in_id_order(flow);
+    let wiring = wire_inputs(flow);
 
-    // Emit each Node in deterministic traversal order, collecting fragments.
-    // The target supplies the board's pin facts so emission is board-correct.
-    let emissions: Vec<NodeEmission> =
-        order.iter().map(|node| emit_node(node, &drivers, target)).collect();
+    // Emit each Node in deterministic id order, collecting fragments. The
+    // target supplies the board's pin facts so emission is board-correct.
+    let empty = NodeInputs::default();
+    let emissions: Vec<NodeEmission> = order
+        .iter()
+        .map(|node| {
+            let inputs = wiring.inputs.get(node.id.as_str()).unwrap_or(&empty);
+            let mut emission = emit_node(node, inputs, target);
+            // Surface wiring the generated code cannot honor as explicit
+            // comments on the Node instead of silently dropping the edges.
+            if let Some(notes) = wiring.notes.get(node.id.as_str()) {
+                emission.declarations.extend(notes.iter().cloned());
+            }
+            emission
+        })
+        .collect();
+
+    // Loop bodies run in dataflow (topological) order so a value produced this
+    // tick is consumed this tick, matching the runtime's event cascade instead
+    // of introducing id-dependent one-tick delays.
+    let loop_permutation = loop_order(flow, &order);
 
     // Cloud-capable Sketches (Cloud Nodes on a networking target) connect to
     // WiFi on boot. The preamble is gated on Networking capability + cloud-node
@@ -158,62 +177,70 @@ fn emit_sketch(
     sketch.push_str(&includes_region(&emissions, preamble.as_ref()));
     sketch.push_str(&declarations(&order, &emissions, preamble.as_ref()));
     sketch.push_str(&setup_region(&emissions, preamble.as_ref()));
-    sketch.push_str(&loop_region(&emissions));
+    sketch.push_str(&loop_region(&emissions, &loop_permutation));
 
     sketch
 }
 
-/// Deterministic traversal of the Flow.
-///
-/// Nodes are visited in stable `id` order; adjacency is followed depth-first
-/// guarded by a `visited` set so cycles terminate. Disconnected Nodes are still
-/// reached because the outer loop seeds the walk from every Node in id order.
-/// The returned vector lists every Node exactly once.
-fn traversal_order(flow: &FlowUpdate) -> Vec<&FlowNode> {
+/// Every Node exactly once, in stable `id` order — the deterministic spine for
+/// the declarations and `setup()` regions. Duplicate ids collapse to the last
+/// occurrence (the `BTreeMap` build), mirroring how the runtime's component map
+/// would key them.
+fn nodes_in_id_order(flow: &FlowUpdate) -> Vec<&FlowNode> {
     let by_id: BTreeMap<&str, &FlowNode> =
         flow.nodes.iter().map(|n| (n.id.as_str(), n)).collect();
-
-    // Adjacency keyed by source id, targets kept sorted + deduped for determinism.
-    let mut adjacency: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
-    for edge in &flow.edges {
-        adjacency
-            .entry(edge.source.as_str())
-            .or_default()
-            .insert(edge.target.as_str());
-    }
-
-    let mut visited: BTreeSet<&str> = BTreeSet::new();
-    let mut order: Vec<&FlowNode> = Vec::with_capacity(by_id.len());
-
-    // Seed from every Node in id order so disconnected Nodes are included and
-    // the result is independent of edge declaration order.
-    for &id in by_id.keys() {
-        visit(id, &by_id, &adjacency, &mut visited, &mut order);
-    }
-
-    order
+    by_id.into_values().collect()
 }
 
-/// Depth-first visit guarded by `visited`; the guard is what makes cycles
-/// terminate. Children are followed in sorted id order for determinism.
-fn visit<'a>(
-    id: &'a str,
-    by_id: &BTreeMap<&'a str, &'a FlowNode>,
-    adjacency: &BTreeMap<&'a str, BTreeSet<&'a str>>,
-    visited: &mut BTreeSet<&'a str>,
-    order: &mut Vec<&'a FlowNode>,
-) {
-    if !visited.insert(id) {
-        return;
-    }
-    if let Some(node) = by_id.get(id) {
-        order.push(node);
-    }
-    if let Some(targets) = adjacency.get(id) {
-        for &target in targets {
-            visit(target, by_id, adjacency, visited, order);
+/// The permutation of `order` (as indices) used for the `loop()` region:
+/// topological over the Flow's edges (Kahn's algorithm, smallest-id-first for
+/// determinism), so producers run before consumers within a single tick. Nodes
+/// on a cycle cannot be topologically placed; they are appended afterwards in
+/// id order, which keeps generation total and deterministic for cyclic graphs
+/// (the cycle then propagates across ticks, as any fixed order must).
+fn loop_order(flow: &FlowUpdate, order: &[&FlowNode]) -> Vec<usize> {
+    let index_of: BTreeMap<&str, usize> =
+        order.iter().enumerate().map(|(i, n)| (n.id.as_str(), i)).collect();
+
+    // Deduped edge set between known Nodes; self-edges would deadlock Kahn and
+    // carry no ordering information, so they are skipped.
+    let mut successors: BTreeMap<usize, BTreeSet<usize>> = BTreeMap::new();
+    let mut indegree = vec![0usize; order.len()];
+    for edge in &flow.edges {
+        let (Some(&s), Some(&t)) =
+            (index_of.get(edge.source.as_str()), index_of.get(edge.target.as_str()))
+        else {
+            continue;
+        };
+        if s == t {
+            continue;
+        }
+        if successors.entry(s).or_default().insert(t) {
+            indegree[t] += 1;
         }
     }
+
+    // Kahn with a sorted ready set: smallest node index (= smallest id) first.
+    let mut ready: BTreeSet<usize> =
+        (0..order.len()).filter(|&i| indegree[i] == 0).collect();
+    let mut result: Vec<usize> = Vec::with_capacity(order.len());
+    while let Some(&i) = ready.iter().next() {
+        ready.remove(&i);
+        result.push(i);
+        if let Some(next) = successors.get(&i) {
+            for &t in next {
+                indegree[t] -= 1;
+                if indegree[t] == 0 {
+                    ready.insert(t);
+                }
+            }
+        }
+    }
+
+    // Cyclic remainder in id order.
+    let placed: BTreeSet<usize> = result.iter().copied().collect();
+    result.extend((0..order.len()).filter(|i| !placed.contains(i)));
+    result
 }
 
 /// File header comment naming the board target and the Node count the skeleton
@@ -230,30 +257,26 @@ fn header(order: &[&FlowNode], target: &BoardTarget) -> String {
 
 /// Dispatch a single Node to its per-type C++ emitter, mirroring the live
 /// `ComponentRegistry`. Node types outside the supported core hardware-IO set
-/// (Cloud Nodes like Mqtt/Figma/Llm/Monitor, unknown types, and typeless
-/// Nodes) fall through to [`placeholder::emit`], which returns a graceful
-/// comment fragment so generation never crashes or blanks the sketch.
-/// `drivers` maps a target Node id to the C++ expression that drives it (from
-/// its wired source), so output Nodes write what their input reads. `_target`
-/// is the validated board target; pin numbers written by the emitters are the
-/// Node's own pin, which validation has already confirmed exists on the target.
-fn emit_node(
-    node: &FlowNode,
-    drivers: &BTreeMap<&str, String>,
-    _target: &BoardTarget,
-) -> NodeEmission {
-    let driver = drivers.get(node.id.as_str()).map(String::as_str);
+/// (unknown types and typeless Nodes) fall through to [`placeholder::emit`],
+/// which returns a graceful comment fragment so generation never crashes or
+/// blanks the sketch. `inputs` carries every wired input grouped by the edge's
+/// real `target_handle` (port), resolved to typed source expressions — the
+/// static twin of the runtime router's `(source, source_handle)` →
+/// `(target, target_handle)` dispatch. `_target` is the validated board
+/// target; pin numbers written by the emitters are the Node's own pin, which
+/// validation has already confirmed exists on the target.
+fn emit_node(node: &FlowNode, inputs: &NodeInputs, _target: &BoardTarget) -> NodeEmission {
     match node.node_type.as_deref() {
-        Some("Led") => output::led::emit(node, driver),
-        Some("Relay") => output::relay::emit(node, driver),
-        Some("Servo") => output::servo::emit(node, driver),
-        Some("Rgb") => output::rgb::emit(node, driver),
-        Some("Piezo") => output::piezo::emit(node, driver),
-        Some("Pixel") => output::pixel::emit(node, driver),
-        Some("Matrix") => output::matrix::emit(node, driver),
-        Some("Stepper") => output::stepper::emit(node, driver),
+        Some("Led") => output::led::emit(node, inputs),
+        Some("Relay") => output::relay::emit(node, inputs),
+        Some("Servo") => output::servo::emit(node, inputs),
+        Some("Rgb") => output::rgb::emit(node, inputs),
+        Some("Piezo") => output::piezo::emit(node, inputs),
+        Some("Pixel") => output::pixel::emit(node, inputs),
+        Some("Matrix") => output::matrix::emit(node, inputs),
+        Some("Stepper") => output::stepper::emit(node, inputs),
         // Vibration shares the live Led implementation (digital on/off output).
-        Some("Vibration") => output::led::emit(node, driver),
+        Some("Vibration") => output::led::emit(node, inputs),
         Some("Button") => input::button::emit(node),
         // Force, HallEffect, Ldr, Potentiometer, and Tilt are all analog inputs
         // backed by the live Sensor implementation, so they share its emitter.
@@ -264,29 +287,27 @@ fn emit_node(
         Some("Motion") => input::motion::emit(node),
         Some("Proximity") => input::proximity::emit(node),
         Some("Hotkey") => input::hotkey::emit(node),
-        Some("I2cDevice") => input::i2c_device::emit(node, driver),
-        Some("Oscillator") => generator::oscillator::emit(node),
-        Some("Calculate") => transformation::calculate::emit(node, driver),
-        Some("Compare") => transformation::compare::emit(node, driver),
-        Some("Gate") => transformation::gate::emit(node, driver),
-        Some("RangeMap") => transformation::range_map::emit(node, driver),
-        Some("Smooth") => transformation::smooth::emit(node, driver),
-        Some("Function") => transformation::function::emit(node, driver),
-        Some("Delay") => control::delay::emit(node, driver),
-        Some("Interval") => control::interval::emit(node),
-        Some("Trigger") => control::trigger::emit(node, driver),
-        Some("Counter") => control::counter::emit(node, driver),
+        Some("I2cDevice") => input::i2c_device::emit(node, inputs),
+        Some("Oscillator") => generator::oscillator::emit(node, inputs),
+        Some("Calculate") => transformation::calculate::emit(node, inputs),
+        Some("Compare") => transformation::compare::emit(node, inputs),
+        Some("Gate") => transformation::gate::emit(node, inputs),
+        Some("RangeMap") => transformation::range_map::emit(node, inputs),
+        Some("Smooth") => transformation::smooth::emit(node, inputs),
+        Some("Function") => transformation::function::emit(node, inputs),
+        Some("Delay") => control::delay::emit(node, inputs),
+        Some("Interval") => control::interval::emit(node, inputs),
+        Some("Trigger") => control::trigger::emit(node, inputs),
+        Some("Counter") => control::counter::emit(node, inputs),
         Some("Constant") => control::constant::emit(node),
         // Cloud Nodes with an on-device emitter only reach here on a networking
         // target — validation refuses them otherwise. Mqtt (Task #38), Figma and
         // Monitor (Task #42) bridge over the network transport; Llm (Task #44)
         // issues HTTP requests over the same shared WiFi connection.
-        Some("Mqtt") => cloud::mqtt::emit(node, driver),
-        Some("Figma") => cloud::figma::emit(node, driver),
-        Some("Monitor") => cloud::monitor::emit(node, driver),
-        // The Llm Node's `driver` is its `trigger` input — when it fires, the
-        // sketch issues the LLM request over the shared WiFi connection.
-        Some("Llm") => cloud::llm::emit(node, driver),
+        Some("Mqtt") => cloud::mqtt::emit(node, inputs),
+        Some("Figma") => cloud::figma::emit(node, inputs),
+        Some("Monitor") => cloud::monitor::emit(node, inputs),
+        Some("Llm") => cloud::llm::emit(node, inputs),
         // AudioPlayer is a browser-only playback Node — it plays audio in the
         // web UI and has no Arduino hardware equivalent. We route it explicitly
         // (rather than letting it fall through) so the skip is intentional and
@@ -296,74 +317,163 @@ fn emit_node(
     }
 }
 
-/// Build the map from a target Node id to the C++ expression that drives it.
+/// The resolved wiring of a Flow: per-target typed inputs plus the comment
+/// notes for edges the generated code cannot honor (missing source Node, or a
+/// source handle with no on-device expression). Notes are keyed by the Node
+/// they annotate so they land in that Node's declaration slot.
+struct Wiring<'a> {
+    inputs: BTreeMap<&'a str, NodeInputs>,
+    notes: BTreeMap<&'a str, Vec<String>>,
+}
+
+/// Build the handle-aware wiring for `flow`.
 ///
-/// An output Node (Led/Relay/Servo) wired from an input Node (Button/Sensor)
-/// reads that input's state/value variable. When a target has multiple incoming
-/// edges, the source with the smallest id wins, keeping the result
-/// deterministic. Edges from sources that expose no readable expression are
-/// ignored.
-fn driver_expressions(flow: &FlowUpdate) -> BTreeMap<&str, String> {
+/// Edges are processed in a deterministic order — sorted by
+/// `(target, target_handle, source, source_handle)` and deduped — so the
+/// per-port source lists (and therefore all generated variable names) are
+/// independent of edge declaration order. Every edge either contributes a
+/// typed [`SourceExpr`] under its real target port, or a visible note.
+fn wire_inputs(flow: &FlowUpdate) -> Wiring<'_> {
     let by_id: BTreeMap<&str, &FlowNode> =
         flow.nodes.iter().map(|n| (n.id.as_str(), n)).collect();
 
-    // For determinism, choose the smallest source id per target.
-    let mut chosen: BTreeMap<&str, &str> = BTreeMap::new();
-    for edge in &flow.edges {
-        let target = edge.target.as_str();
-        let source = edge.source.as_str();
-        chosen
-            .entry(target)
-            .and_modify(|s| {
-                if source < *s {
-                    *s = source;
-                }
-            })
-            .or_insert(source);
-    }
-
-    chosen
-        .into_iter()
-        .filter_map(|(target, source)| {
-            let src_node = by_id.get(source)?;
-            source_expression(src_node).map(|expr| (target, expr))
+    let ordered: BTreeSet<(&str, &str, &str, &str)> = flow
+        .edges
+        .iter()
+        .map(|e| {
+            (
+                e.target.as_str(),
+                e.target_handle.as_str(),
+                e.source.as_str(),
+                e.source_handle.as_str(),
+            )
         })
-        .collect()
+        .collect();
+
+    let mut wiring = Wiring { inputs: BTreeMap::new(), notes: BTreeMap::new() };
+    for (target, target_handle, source, source_handle) in ordered {
+        // Edges into unknown Nodes have no emission slot to annotate; skip.
+        if !by_id.contains_key(target) {
+            continue;
+        }
+        let Some(source_node) = by_id.get(source) else {
+            wiring.notes.entry(target).or_default().push(format!(
+                "// note: input '{}' is wired from missing node '{}' — edge ignored",
+                emit::cpp_comment_text(target_handle),
+                emit::cpp_comment_text(source),
+            ));
+            continue;
+        };
+        match output_expression(source_node, source_handle) {
+            Some(expr) => {
+                wiring
+                    .inputs
+                    .entry(target)
+                    .or_default()
+                    .add(target_handle, expr);
+            }
+            None => {
+                let kind = source_node.node_type.as_deref().unwrap_or("unknown");
+                wiring.notes.entry(target).or_default().push(format!(
+                    "// note: input '{}' from node '{}' ({kind}) output '{}' has no on-device value — edge ignored",
+                    emit::cpp_comment_text(target_handle),
+                    emit::cpp_comment_text(source),
+                    emit::cpp_comment_text(source_handle),
+                ));
+            }
+        }
+    }
+    wiring
 }
 
-/// The C++ expression a source Node exposes for downstream Nodes to read, or
-/// `None` if the Node type produces no readable value.
-fn source_expression(node: &FlowNode) -> Option<String> {
-    match node.node_type.as_deref() {
-        Some("Button") => Some(input::button::state_var(node)),
-        Some("Sensor" | "Force" | "HallEffect" | "Ldr" | "Potentiometer" | "Tilt") => {
-            Some(input::sensor::value_var(node))
+/// The typed C++ expression `node` exposes on emit handle `handle`, or `None`
+/// if that handle has no on-device value. Handle names mirror each runtime
+/// component's `emits()` list (`"value"` is `ComponentBase::VALUE_HANDLE`, the
+/// auto-emitted stored value).
+///
+/// Boolean state Nodes (Button/Switch/Motion/Hotkey and the Compare/Gate
+/// results) also expose their `"true"` / `"false"` emit handles as the state
+/// (or its negation): the runtime fires those handles exactly when the state
+/// transitions, so a pulse-consuming port sees the same firing ticks via its
+/// edge detector, and a level-consuming port sees the last delivered payload.
+fn output_expression(node: &FlowNode, handle: &str) -> Option<SourceExpr> {
+    /// The `"value"`/`"event"`/`"true"`/`"false"` family shared by the boolean
+    /// state Nodes, built over the Node's state variable. `value`/`event` fire
+    /// on every state change (the runtime emits on each update, both button
+    /// edges); `true` / `false` fire only when the state enters that side, so
+    /// they carry a rising-edge detector over the (possibly negated) state.
+    fn bool_state(state: String, handle: &str) -> Option<SourceExpr> {
+        match handle {
+            "value" | "event" => Some(SourceExpr::level(CppExpr::boolean(state))),
+            "true" => Some(SourceExpr::rising(CppExpr::boolean(state))),
+            "false" => Some(SourceExpr::rising(CppExpr::boolean(format!("(!{state})")))),
+            _ => None,
         }
-        Some("Switch") => Some(input::switch::state_var(node)),
-        Some("Motion") => Some(input::motion::state_var(node)),
-        Some("Proximity") => Some(input::proximity::value_var(node)),
-        Some("Hotkey") => Some(input::hotkey::state_var(node)),
-        Some("I2cDevice") => Some(input::i2c_device::value_var(node)),
-        Some("Oscillator") => Some(generator::oscillator::value_var(node)),
-        Some("Calculate") => Some(transformation::calculate::value_var(node)),
-        Some("Compare") => Some(transformation::compare::state_var(node)),
-        Some("Gate") => Some(transformation::gate::state_var(node)),
-        Some("RangeMap") => Some(transformation::range_map::value_var(node)),
-        Some("Smooth") => Some(transformation::smooth::value_var(node)),
-        Some("Function") => Some(transformation::function::value_var(node)),
-        Some("Delay") => Some(control::delay::value_var(node)),
-        Some("Interval") => Some(control::interval::value_var(node)),
-        Some("Trigger") => Some(control::trigger::state_var(node)),
-        Some("Counter") => Some(control::counter::value_var(node)),
-        Some("Constant") => Some(control::constant::value_var(node)),
-        // A subscribe Mqtt Node surfaces its latest inbound message as a value;
-        // a publish Mqtt Node exposes none (returns `None`).
-        Some("Mqtt") => cloud::mqtt::value_var(node),
-        // A Figma Node surfaces the latest inbound variable value downstream.
-        // Monitor is a display-only sink and exposes no readable value.
-        Some("Figma") => cloud::figma::value_var(node),
-        // An Llm Node surfaces its latest response text downstream.
-        Some("Llm") => cloud::llm::value_var(node),
+    }
+
+    match node.node_type.as_deref() {
+        Some("Button") => bool_state(input::button::state_var(node), handle),
+        Some("Switch") => bool_state(input::switch::state_var(node), handle),
+        Some("Motion") => bool_state(input::motion::state_var(node), handle),
+        Some("Hotkey") => bool_state(input::hotkey::state_var(node), handle),
+        Some("Sensor" | "Force" | "HallEffect" | "Ldr" | "Potentiometer" | "Tilt")
+            if handle == "value" =>
+        {
+            Some(SourceExpr::level(CppExpr::number(input::sensor::value_var(node))))
+        }
+        Some("Proximity") if handle == "value" => {
+            Some(SourceExpr::level(CppExpr::number(input::proximity::value_var(node))))
+        }
+        Some("I2cDevice") if handle == "value" => {
+            Some(SourceExpr::level(CppExpr::number(input::i2c_device::value_var(node))))
+        }
+        Some("Oscillator") if handle == "value" => {
+            Some(SourceExpr::level(CppExpr::number(generator::oscillator::value_var(node))))
+        }
+        Some("Constant") if handle == "value" => {
+            Some(SourceExpr::level(CppExpr::number(control::constant::value_var(node))))
+        }
+        Some("Counter") if handle == "value" => {
+            Some(SourceExpr::level(CppExpr::number(control::counter::value_var(node))))
+        }
+        Some("Calculate") if handle == "value" => {
+            Some(SourceExpr::level(CppExpr::number(transformation::calculate::value_var(node))))
+        }
+        Some("Compare") => bool_state(transformation::compare::state_var(node), handle),
+        Some("Gate") => bool_state(transformation::gate::state_var(node), handle),
+        // The runtime RangeMap emits the mapped number on `to`; its stored
+        // `value` is a two-element Array with no C++ counterpart.
+        Some("RangeMap") if handle == "to" => {
+            Some(SourceExpr::level(CppExpr::number(transformation::range_map::value_var(node))))
+        }
+        Some("Smooth") if handle == "value" => {
+            Some(SourceExpr::level(CppExpr::number(transformation::smooth::value_var(node))))
+        }
+        Some("Function") if handle == "value" => {
+            Some(SourceExpr::level(CppExpr::number(transformation::function::value_var(node))))
+        }
+        // Delay re-emits its stored payload on `event` when the timer fires.
+        Some("Delay") if handle == "event" => Some(SourceExpr::event(
+            CppExpr::number(control::delay::value_var(node)),
+            control::delay::fired_var(node),
+        )),
+        // Interval emits elapsed milliseconds on `event` each period.
+        Some("Interval") if handle == "event" => Some(SourceExpr::event(
+            CppExpr::number(control::interval::value_var(node)),
+            control::interval::fired_var(node),
+        )),
+        // Trigger emits the crossing value on `bang`; its stored `value` is
+        // never written by the runtime, so only `bang` is exposed.
+        Some("Trigger") if handle == "bang" => Some(SourceExpr::event(
+            CppExpr::number(control::trigger::value_payload_var(node)),
+            control::trigger::state_var(node),
+        )),
+        // A subscribe Mqtt Node surfaces its latest inbound message; a publish
+        // Mqtt Node exposes none. Figma surfaces the latest inbound variable
+        // value; Monitor is a display-only sink. Llm surfaces its response.
+        Some("Mqtt") if handle == "value" => cloud::mqtt::output(node),
+        Some("Figma") if handle == "value" || handle == "change" => cloud::figma::output(node),
+        Some("Llm") if handle == "value" => cloud::llm::output(node),
         _ => None,
     }
 }
@@ -448,8 +558,9 @@ fn setup_region(
 /// Non-blocking, `millis()`-based scheduler `loop()`. It compares `millis()`
 /// against a per-tick deadline instead of calling blocking `delay()`, giving a
 /// deterministic, host-free model. Per-Node read/write logic runs inside the
-/// scheduled-task block in traversal order.
-fn loop_region(emissions: &[NodeEmission]) -> String {
+/// scheduled-task block in `permutation` (dataflow) order, so a value written
+/// by a producer this tick is read by its consumers this tick.
+fn loop_region(emissions: &[NodeEmission], permutation: &[usize]) -> String {
     let mut out = String::from(
         "void loop() {\n  \
 static unsigned long previousMillis = 0;\n  \
@@ -459,7 +570,7 @@ if (currentMillis - previousMillis >= interval) {\n    \
 previousMillis = currentMillis;\n    \
 // --- Scheduled tasks ---\n",
     );
-    for line in emissions.iter().flat_map(|e| &e.loop_body) {
+    for line in permutation.iter().flat_map(|&i| &emissions[i].loop_body) {
         out.push_str("    ");
         out.push_str(line);
         out.push('\n');
@@ -522,13 +633,20 @@ mod tests {
         }
     }
 
+    /// An edge over the default `value` handles — the most common wiring.
     fn edge(source: &str, target: &str) -> FlowEdge {
+        edge_h(source, "value", target, "value")
+    }
+
+    /// An edge with explicit source/target handles, matching the real Flow
+    /// wire contract (source handle ∈ emits(), target handle ∈ ports()).
+    fn edge_h(source: &str, source_handle: &str, target: &str, target_handle: &str) -> FlowEdge {
         FlowEdge {
             id: None,
             source: source.to_string(),
             target: target.to_string(),
-            source_handle: "out".to_string(),
-            target_handle: "in".to_string(),
+            source_handle: source_handle.to_string(),
+            target_handle: target_handle.to_string(),
         }
     }
 
@@ -729,7 +847,8 @@ mod tests {
         assert!(sketch.contains("#include <Servo.h>"), "servo include");
     }
 
-    /// Scenario: A Button drives a Led through an edge.
+    /// Scenario: A Button drives a Led through an edge — wired into the Led's
+    /// `true`/`false` ports (on-press on, on-release off), the digital pairing.
     #[test]
     fn button_drives_led_through_an_edge() {
         let flow = FlowUpdate {
@@ -737,7 +856,10 @@ mod tests {
                 node_data("led-1", "Led", json!({ "pin": 13 })),
                 node_data("btn-1", "Button", json!({ "pin": 6 })),
             ],
-            edges: vec![edge("btn-1", "led-1")],
+            edges: vec![
+                edge_h("btn-1", "true", "led-1", "true"),
+                edge_h("btn-1", "false", "led-1", "false"),
+            ],
         };
 
         let sketch = generate_sketch_text(&flow);
@@ -745,10 +867,38 @@ mod tests {
         // The Button reads its input into a state var.
         assert!(sketch.contains("button_btn_1_state = "), "button read into state var");
         assert!(sketch.contains("digitalRead"), "button digitalRead");
-        // The Led writes that state.
+        // Press drives HIGH, release drives LOW — pulse-bound to the ports.
         assert!(
-            sketch.contains("digitalWrite(led_led_1_pin, (button_btn_1_state)"),
-            "led must be driven by the button state, got:\n{sketch}"
+            sketch.contains("digitalWrite(led_led_1_pin, HIGH)"),
+            "led must turn on from the button's true handle, got:\n{sketch}"
+        );
+        assert!(
+            sketch.contains("digitalWrite(led_led_1_pin, LOW)"),
+            "led must turn off from the button's false handle, got:\n{sketch}"
+        );
+        assert!(sketch.contains("button_btn_1_state"), "the pulses derive from the state");
+    }
+
+    /// Scenario: a Button's `value` into a Led's `value` is PWM brightness —
+    /// the runtime's brightness dispatch (Bool ⇒ as_u8 ⇒ 0/1), not a digital
+    /// level write.
+    #[test]
+    fn button_value_into_led_value_is_brightness() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+                node_data("btn-1", "Button", json!({ "pin": 6 })),
+            ],
+            edges: vec![edge("btn-1", "led-1")],
+        };
+        let sketch = generate_sketch_text(&flow);
+        assert!(
+            sketch.contains("analogWrite(led_led_1_pin"),
+            "value port drives PWM like the runtime, got:\n{sketch}"
+        );
+        assert!(
+            sketch.contains("(button_btn_1_state) ? 1 : 0"),
+            "Bool payload maps through as_u8 (1/0), got:\n{sketch}"
         );
     }
 
@@ -1028,7 +1178,8 @@ mod tests {
                     json!({ "broker": "b", "topic": "microflow/out", "direction": "publish", "wifiSsid": "net" }),
                 ),
             ],
-            edges: vec![edge("sensor-1", "mqtt-1")],
+            // A publish Mqtt Node sends on its `trigger` port.
+            edges: vec![edge_h("sensor-1", "value", "mqtt-1", "trigger")],
         };
 
         let sketch = sketch_for(&flow, &networking_target());
@@ -1172,7 +1323,7 @@ mod tests {
                     }),
                 ),
             ],
-            edges: vec![edge("button-1", "llm-1")],
+            edges: vec![edge_h("button-1", "true", "llm-1", "trigger")],
         };
 
         let sketch = sketch_for(&flow, &networking_target());
@@ -1372,8 +1523,13 @@ mod tests {
             "calc must apply ceil to its input, got:\n{sketch}"
         );
         assert!(sketch.contains("sensor_sensor_1_value"), "calc reads the sensor");
-        // The Led is driven by the Calculate result, not a placeholder.
-        assert!(sketch.contains("digitalWrite(led_led_1_pin, (calculate_calc_1_value)"));
+        // The Led's value port is driven by the Calculate result (PWM), not a
+        // placeholder.
+        assert!(
+            sketch.contains("constrain((double)(calculate_calc_1_value), 0.0, 255.0)"),
+            "led brightness clamps the calc result like as_u8, got:\n{sketch}"
+        );
+        assert!(sketch.contains("analogWrite(led_led_1_pin"), "led PWM write");
         assert!(!sketch.contains("// unsupported Node calc"), "calc must not be a placeholder");
         assert!(!sketch.contains("delay("), "stays non-blocking");
     }
@@ -1400,6 +1556,7 @@ mod tests {
             sketch.contains("> 512.0"),
             "compare must emit the greater-than test, got:\n{sketch}"
         );
+        assert!(sketch.contains("sensor_sensor_1_value"), "compare reads the sensor");
         assert!(!sketch.contains("// unsupported Node cmp"));
     }
 
@@ -1418,13 +1575,17 @@ mod tests {
         let sketch = generate_sketch_text(&flow);
 
         assert!(sketch.contains("bool gate_gate_1_result"), "gate bool decl");
-        // nand on a single input inverts it.
+        // nand over the runtime's truthy count: with one input, != 1 inverts it.
         assert!(
-            sketch.contains("gate_gate_1_result = (!((bool)(button_btn_1_state)))"),
-            "nand gate must invert the button, got:\n{sketch}"
+            sketch.contains("gate_gate_1_true_count = ((button_btn_1_state) ? 1 : 0)"),
+            "gate counts its truthy inputs, got:\n{sketch}"
         );
-        // The Led reads the gate result.
-        assert!(sketch.contains("digitalWrite(led_led_1_pin, (gate_gate_1_result)"));
+        assert!(
+            sketch.contains("gate_gate_1_result = (gate_gate_1_true_count != 1)"),
+            "nand gate must invert the single input, got:\n{sketch}"
+        );
+        // The Led's value port reads the gate result (Bool ⇒ brightness 1/0).
+        assert!(sketch.contains("(gate_gate_1_result) ? 1 : 0"), "led driven by the gate");
     }
 
     /// Scenario: `RangeMap` and Smooth Nodes preserve their live behavior.
@@ -1444,7 +1605,8 @@ mod tests {
                     json!({ "type": "movingAverage", "windowSize": 4 }),
                 ),
             ],
-            edges: vec![edge("sensor-1", "rm-1"), edge("rm-1", "sm-1")],
+            // RangeMap emits its mapped number on the `to` handle.
+            edges: vec![edge("sensor-1", "rm-1"), edge_h("rm-1", "to", "sm-1", "value")],
         };
 
         let sketch = generate_sketch_text(&flow);
@@ -1522,7 +1684,8 @@ mod tests {
                 ),
                 node_data("led-1", "Led", json!({ "pin": 13 })),
             ],
-            edges: vec![edge("sensor-1", "fn-1"), edge("fn-1", "led-1")],
+            // The Function's input port is `trigger`.
+            edges: vec![edge_h("sensor-1", "value", "fn-1", "trigger"), edge("fn-1", "led-1")],
         };
 
         let sketch = generate_sketch_text(&flow);
@@ -1539,8 +1702,11 @@ mod tests {
             sketch.contains("sensor_sensor_1_value"),
             "function reads the sensor input"
         );
-        // The Led is driven by the Function result, not a placeholder.
-        assert!(sketch.contains("digitalWrite(led_led_1_pin, (function_fn_1_value)"));
+        // The Led's value port is driven by the Function result (PWM clamp).
+        assert!(
+            sketch.contains("constrain((double)(function_fn_1_value), 0.0, 255.0)"),
+            "led brightness driven by the function result, got:\n{sketch}"
+        );
         assert!(
             !sketch.contains("unsupported Function Node fn_1"),
             "supported logic must not be marked unsupported, got:\n{sketch}"
@@ -1641,7 +1807,11 @@ mod tests {
                 node_data("delay-1", "Delay", json!({ "delay": 1000 })),
                 node_data("led-1", "Led", json!({ "pin": 13 })),
             ],
-            edges: vec![edge("btn-1", "delay-1"), edge("delay-1", "led-1")],
+            // The Delay arms on `trigger` and re-emits on `event`.
+            edges: vec![
+                edge_h("btn-1", "value", "delay-1", "trigger"),
+                edge_h("delay-1", "event", "led-1", "value"),
+            ],
         };
 
         let sketch = generate_sketch_text(&flow);
@@ -1655,7 +1825,7 @@ mod tests {
         assert!(!sketch.contains("delay("), "delay must be non-blocking");
         // The rest of the Flow keeps running: the Led is driven by the Delay output.
         assert!(
-            sketch.contains("digitalWrite(led_led_1_pin, (delay_delay_1_value)"),
+            sketch.contains("constrain((double)(delay_delay_1_value), 0.0, 255.0)"),
             "led must read the delayed value, got:\n{sketch}"
         );
         assert!(!sketch.contains("// unsupported Node delay"), "delay must not be a placeholder");
@@ -1669,7 +1839,7 @@ mod tests {
                 node_data("iv-1", "Interval", json!({ "interval": 500 })),
                 node_data("led-1", "Led", json!({ "pin": 13 })),
             ],
-            edges: vec![edge("iv-1", "led-1")],
+            edges: vec![edge_h("iv-1", "event", "led-1", "value")],
         };
 
         let sketch = generate_sketch_text(&flow);
@@ -1692,7 +1862,7 @@ mod tests {
                 node_data("btn-1", "Button", json!({ "pin": 6 })),
                 node_data("ct-1", "Counter", json!({})),
             ],
-            edges: vec![edge("btn-1", "ct-1")],
+            edges: vec![edge_h("btn-1", "true", "ct-1", "increment")],
         };
 
         let sketch = generate_sketch_text(&flow);
@@ -1716,7 +1886,7 @@ mod tests {
                 node_data("tg-1", "Trigger", json!({ "threshold": 5.0, "behaviour": "increasing" })),
                 node_data("const-1", "Constant", json!({ "value": 42.0 })),
             ],
-            edges: vec![edge("sensor-1", "tg-1")],
+            edges: vec![edge_h("sensor-1", "value", "tg-1", "value")],
         };
 
         let sketch = generate_sketch_text(&flow);
@@ -1746,7 +1916,7 @@ mod tests {
                 node_data("iv-1", "Interval", json!({ "interval": 200 })),
                 node_data("delay-1", "Delay", json!({ "delay": 1000 })),
             ],
-            edges: vec![edge("iv-1", "delay-1")],
+            edges: vec![edge_h("iv-1", "event", "delay-1", "trigger")],
         };
 
         let sketch = generate_sketch_text(&flow);
@@ -1761,10 +1931,15 @@ mod tests {
             "delay timer present, got:\n{sketch}"
         );
         assert!(!sketch.contains("delay("), "concurrent timers must not block");
-        // The Delay is armed from the Interval's output (nested timing wired through).
+        // The Delay is armed from the Interval's event — via its fired flag,
+        // not a synthesized edge over the value.
         assert!(
-            sketch.contains("(double)(interval_iv_1_value)") || sketch.contains("(interval_iv_1_value)"),
-            "delay must be driven by the interval, got:\n{sketch}"
+            sketch.contains("delay_delay_1_pending && interval_iv_1_fired) {"),
+            "delay must arm on the interval's event ticks, got:\n{sketch}"
+        );
+        assert!(
+            sketch.contains("delay_delay_1_stored = ((double)(interval_iv_1_value))"),
+            "delay stores the interval's payload, got:\n{sketch}"
         );
     }
 
@@ -1830,9 +2005,9 @@ mod tests {
         assert!(sketch.contains("bool hotkey_hk_1_state"), "hotkey declares state");
         assert!(sketch.contains("i2c_i2c_1_value = "), "i2c reads");
         assert!(sketch.contains("sensor_pot_1_value = analogRead"), "potentiometer is a Sensor");
-        // The Switch reading feeds the Led (value flows into the Flow).
+        // The Switch reading feeds the Led's value port (Bool ⇒ brightness 1/0).
         assert!(
-            sketch.contains("digitalWrite(led_led_1_pin, (switch_sw_1_state)"),
+            sketch.contains("(switch_sw_1_state) ? 1 : 0"),
             "switch value must drive the led, got:\n{sketch}"
         );
         assert!(!sketch.contains("delay("), "stays non-blocking");
@@ -1841,8 +2016,9 @@ mod tests {
     /// Scenario: Remaining output Nodes drive their hardware.
     ///
     /// A Sensor drives each remaining non-Cloud output Node (Rgb, Piezo, Pixel,
-    /// Matrix, Stepper, and the Led-backed Vibration). Each must emit real drive
-    /// logic from the incoming value, pulling in any required library.
+    /// Matrix, Stepper, and the Led-backed Vibration) — each through one of its
+    /// real ports. Each must emit real drive logic from the incoming value,
+    /// pulling in any required library.
     #[test]
     fn remaining_output_nodes_drive_their_hardware() {
         let flow = FlowUpdate {
@@ -1850,17 +2026,20 @@ mod tests {
                 node_data("sensor-1", "Sensor", json!({ "pin": "A0" })),
                 node_data("rgb-1", "Rgb", json!({})),
                 node_data("pz-1", "Piezo", json!({})),
-                node_data("px-1", "Pixel", json!({ "length": 8 })),
-                node_data("mx-1", "Matrix", json!({})),
+                node_data("px-1", "Pixel", json!({ "length": 8, "presets": [["#ff0000"]] })),
+                node_data("mx-1", "Matrix", json!({ "shapes": [["11111111"]] })),
                 node_data("st-1", "Stepper", json!({})),
                 node_data("vb-1", "Vibration", json!({ "pin": 5 })),
             ],
             edges: vec![
-                edge("sensor-1", "rgb-1"),
-                edge("sensor-1", "pz-1"),
+                // Rgb has per-channel ports; Piezo buzzes on `trigger`;
+                // Pixel/Matrix select presets/shapes on `value`; the Stepper's
+                // `to` port is the absolute target.
+                edge_h("sensor-1", "value", "rgb-1", "red"),
+                edge_h("sensor-1", "value", "pz-1", "trigger"),
                 edge("sensor-1", "px-1"),
                 edge("sensor-1", "mx-1"),
-                edge("sensor-1", "st-1"),
+                edge_h("sensor-1", "value", "st-1", "to"),
                 edge("sensor-1", "vb-1"),
             ],
         };
@@ -1873,7 +2052,7 @@ mod tests {
         assert!(sketch.contains("pixel_px_1.setPixelColor"), "pixel fills");
         assert!(sketch.contains("matrix_mx_1.setRow"), "matrix lights");
         assert!(sketch.contains("stepper_st_1.moveTo"), "stepper targets value");
-        assert!(sketch.contains("digitalWrite(led_vb_1_pin"), "vibration is an Led output");
+        assert!(sketch.contains("analogWrite(led_vb_1_pin"), "vibration is an Led output");
         // Library-backed Nodes pull in their includes.
         assert!(sketch.contains("#include <Adafruit_NeoPixel.h>"), "pixel include");
         assert!(sketch.contains("#include <LedControl.h>"), "matrix include");
@@ -1902,9 +2081,9 @@ mod tests {
         assert!(sketch.contains("oscillator_osc_1_value = "), "oscillator output");
         // No blocking wait anywhere.
         assert!(!sketch.contains("delay("), "oscillator must be non-blocking");
-        // The signal flows onward to the wired Servo.
+        // The signal flows onward to the wired Servo's value port.
         assert!(
-            sketch.contains("(oscillator_osc_1_value)"),
+            sketch.contains("(oscillator_osc_1_value)") && sketch.contains("servo_servo_1.write("),
             "oscillator must drive the servo, got:\n{sketch}"
         );
         assert!(!sketch.contains("// unsupported Node osc"), "oscillator must not be a placeholder");
@@ -1985,6 +2164,105 @@ mod tests {
             edges: vec![edge("osc-1", "rgb-1"), edge("sw-1", "st-1")],
         };
         assert_eq!(generate(&flow, &default_target()).unwrap(), generate(&flow, &default_target()).unwrap());
+    }
+
+    // --- Handle-aware wiring model ---
+
+    /// Loop bodies run in dataflow (topological) order: a producer whose id
+    /// sorts *after* its consumer still executes first within a tick, so the
+    /// consumer reads this tick's value instead of last tick's.
+    #[test]
+    fn loop_bodies_run_in_dataflow_order() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                // "a-led" sorts before "z-sensor"; the edge points z → a.
+                node_data("a-led", "Led", json!({ "pin": 13 })),
+                node_data("z-sensor", "Sensor", json!({ "pin": "A0" })),
+            ],
+            edges: vec![edge("z-sensor", "a-led")],
+        };
+        let sketch = generate_sketch_text(&flow);
+        let loop_idx = sketch.find("// --- Scheduled tasks ---").expect("loop region");
+        let read = sketch[loop_idx..].find("sensor_z_sensor_value = analogRead").expect("sensor read in loop");
+        let write = sketch[loop_idx..].find("analogWrite(led_a_led_pin").expect("led write in loop");
+        assert!(
+            read < write,
+            "producer must run before consumer within one tick, got:\n{sketch}"
+        );
+    }
+
+    /// An edge the generated code cannot honor (a source handle with no
+    /// on-device value) is surfaced as an explicit note on the target Node
+    /// instead of silently dropped.
+    #[test]
+    fn unmappable_edges_surface_as_notes() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("btn-1", "Button", json!({ "pin": 6 })),
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+            ],
+            // `hold` is a real Button emit with no on-device expression yet.
+            edges: vec![edge_h("btn-1", "hold", "led-1", "value")],
+        };
+        let sketch = generate_sketch_text(&flow);
+        assert!(
+            sketch.contains("// note: input 'value' from node 'btn-1' (Button) output 'hold' has no on-device value"),
+            "the dropped edge must be visible in the sketch, got:\n{sketch}"
+        );
+        assert!(!sketch.contains("analogWrite(led_led_1_pin"), "the led stays unwired");
+    }
+
+    /// An edge from a missing source Node is noted, not silently dropped.
+    #[test]
+    fn edge_from_missing_node_surfaces_as_note() {
+        let flow = FlowUpdate {
+            nodes: vec![node_data("led-1", "Led", json!({ "pin": 13 }))],
+            edges: vec![edge("ghost", "led-1")],
+        };
+        let sketch = generate_sketch_text(&flow);
+        assert!(
+            sketch.contains("wired from missing node 'ghost'"),
+            "missing-source edges must be visible, got:\n{sketch}"
+        );
+    }
+
+    /// Calculate aggregates every source wired into its `value` port — the
+    /// runtime's snapshot fold, no longer a single-driver passthrough.
+    #[test]
+    fn calculate_folds_all_wired_inputs() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("c1", "Constant", json!({ "value": 2.0 })),
+                node_data("c2", "Constant", json!({ "value": 3.0 })),
+                node_data("calc-1", "Calculate", json!({ "function": "add" })),
+            ],
+            edges: vec![edge("c1", "calc-1"), edge("c2", "calc-1")],
+        };
+        let sketch = generate_sketch_text(&flow);
+        assert!(
+            sketch.contains("((double)(constant_c1_value)) + ((double)(constant_c2_value))"),
+            "add must sum every wired input, got:\n{sketch}"
+        );
+    }
+
+    /// Colliding identifier tokens refuse generation with problems naming the
+    /// token (the emitted globals would collide and the sketch would not
+    /// compile) — the validity invariant holds end-to-end.
+    #[test]
+    fn colliding_node_ids_refuse_generation() {
+        let flow = FlowUpdate {
+            nodes: vec![
+                node_data("led-1", "Led", json!({ "pin": 13 })),
+                node_data("led_1", "Led", json!({ "pin": 12 })),
+            ],
+            edges: vec![],
+        };
+        match generate(&flow, &default_target()).expect("generation never errors") {
+            GenerationOutcome::Problems(problems) => {
+                assert_eq!(problems.len(), 2, "both colliding nodes flagged");
+            }
+            GenerationOutcome::Sketch(s) => panic!("expected problems, got sketch:\n{s}"),
+        }
     }
 
     /// Determinism holds for a control-heavy Flow.

--- a/crates/microflow-core/src/codegen/output/led.rs
+++ b/crates/microflow-core/src/codegen/output/led.rs
@@ -1,26 +1,34 @@
 //! Led emitter — mirrors `runtime/output/led.rs`.
 //!
 //! The live Led sets `pinMode(pin, OUTPUT)` then `digitalWrite(pin, LOW)` on
-//! initialize (off by default). On/off drive `digitalWrite`; brightness drives
-//! `analogWrite` (PWM). The generated sketch emits the OUTPUT pin setup and a
-//! `digitalWrite` in `loop()` that reflects the wired source's state, matching
-//! the runtime's default-off behavior.
+//! initialize (off by default) and exposes four ports: `true` / `false` switch
+//! it digitally on/off, `toggle` flips it, and `value` drives PWM brightness
+//! (the incoming value clamped to `0..=255`, exactly `ComponentValue::as_u8`
+//! with the runtime's 255 fallback for non-numeric payloads). The generated
+//! sketch binds each wired port: pulse ports act on their sources' firing
+//! ticks; `value` is a level write each loop. An on/off state variable tracks
+//! the runtime's `is_on` so `toggle` flips from the last written state.
 
 use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::codegen::wire::{bind_pulses, extra_sources_note, NodeInputs};
 use crate::config::led::LedConfig;
 use crate::flow::FlowNode;
 
-/// Emit C++ for a Led Node. `driver` is the C++ boolean expression that drives
-/// the Led's state (from a wired input), or `None` for an unconnected Led which
-/// stays in its initialized-off state.
+/// Emit C++ for a Led Node (also backs the Vibration Node, a digital output
+/// sharing the live Led implementation). Unwired Leds stay initialized-off.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let config: LedConfig = serde_json::from_value(node.data.clone()).unwrap_or_default();
     let pin = config.pin;
-    let var = format!("led_{}_pin", node.id_token());
+    let token = node.id_token();
+    let var = format!("led_{token}_pin");
+    let on = format!("led_{token}_on");
 
     let mut e = NodeEmission {
-        declarations: vec![format!("const uint8_t {var} = {pin};")],
+        declarations: vec![
+            format!("const uint8_t {var} = {pin};"),
+            format!("bool {on} = false;"),
+        ],
         setup: vec![
             format!("pinMode({var}, OUTPUT);"),
             // Mirror runtime initialize: start off.
@@ -29,16 +37,49 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
         ..NodeEmission::default()
     };
 
-    if let Some(expr) = driver {
-        e.loop_body
-            .push(format!("digitalWrite({var}, ({expr}) ? HIGH : LOW);"));
+    // value: PWM brightness, a level write each tick (the runtime writes on
+    // every dispatched value; sampling the level each loop is its polled twin).
+    let value_sources = inputs.on("value");
+    if let Some(note) = extra_sources_note("value", value_sources) {
+        e.declarations.push(note);
     }
+    if let Some(source) = value_sources.first() {
+        let b = format!("led_{token}_brightness");
+        e.loop_body
+            .push(format!("uint8_t {b} = {};", source.value.as_u8_or(255)));
+        e.loop_body.push(format!("analogWrite({var}, {b});"));
+        e.loop_body.push(format!("{on} = {b} > 0;"));
+    }
+
+    // true / false: idempotent digital writes on any firing source.
+    for (port, level, state) in [("true", "HIGH", "true"), ("false", "LOW", "false")] {
+        let binding = bind_pulses(&format!("led_{token}_{port}"), inputs.on(port));
+        e.declarations.extend(binding.declarations.iter().cloned());
+        e.loop_body.extend(binding.loop_lines.iter().cloned());
+        if let Some(any) = binding.any_fired() {
+            e.loop_body.push(format!(
+                "if ({any}) {{ digitalWrite({var}, {level}); {on} = {state}; }}"
+            ));
+        }
+    }
+
+    // toggle: one flip per fired source, from the tracked on/off state.
+    let binding = bind_pulses(&format!("led_{token}_toggle"), inputs.on("toggle"));
+    e.declarations.extend(binding.declarations.iter().cloned());
+    e.loop_body.extend(binding.loop_lines.iter().cloned());
+    for fired in &binding.fired {
+        e.loop_body.push(format!(
+            "if ({fired}) {{ {on} = !{on}; digitalWrite({var}, {on} ? HIGH : LOW); }}"
+        ));
+    }
+
     e
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::{CppExpr, SourceExpr};
     use crate::flow::Position;
     use serde_json::json;
 
@@ -51,18 +92,24 @@ mod tests {
         }
     }
 
+    fn on(port: &str, expr: CppExpr) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add(port, SourceExpr::level(expr));
+        inputs
+    }
+
     /// Scenario: Each supported Node type emits deterministic code.
     #[test]
     fn led_emits_deterministically() {
         let n = led("led-1", json!({ "pin": 13 }));
-        let first = emit(&n, None);
-        let second = emit(&n, None);
+        let first = emit(&n, &NodeInputs::default());
+        let second = emit(&n, &NodeInputs::default());
         assert_eq!(first, second, "same Led must emit identical C++ each time");
     }
 
     #[test]
     fn led_sets_output_pin_mode_and_starts_off() {
-        let e = emit(&led("led-1", json!({ "pin": 8 })), None);
+        let e = emit(&led("led-1", json!({ "pin": 8 })), &NodeInputs::default());
         assert!(e.declarations.iter().any(|d| d.contains("= 8;")));
         assert!(e.setup.iter().any(|s| s.contains("pinMode") && s.contains("OUTPUT")));
         assert!(e.setup.iter().any(|s| s.contains("digitalWrite") && s.contains("LOW")));
@@ -70,13 +117,55 @@ mod tests {
 
     #[test]
     fn led_uses_default_pin_when_missing() {
-        let e = emit(&led("led-1", json!({})), None);
+        let e = emit(&led("led-1", json!({})), &NodeInputs::default());
         assert!(e.declarations.iter().any(|d| d.contains("= 13;")));
     }
 
     #[test]
-    fn led_writes_driver_expression_in_loop() {
-        let e = emit(&led("led-1", json!({ "pin": 5 })), Some("btn_6_state"));
-        assert!(e.loop_body.iter().any(|l| l.contains("digitalWrite") && l.contains("btn_6_state")));
+    fn value_port_drives_pwm_brightness_like_the_runtime() {
+        let e = emit(&led("led-1", json!({ "pin": 5 })), &on("value", CppExpr::number("sensor_v")));
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("constrain((double)(sensor_v), 0.0, 255.0)"), "as_u8 clamp: {body}");
+        assert!(body.contains("analogWrite(led_led_1_pin"), "value is a PWM write: {body}");
+        assert!(body.contains("led_led_1_on = led_led_1_brightness > 0"), "tracks is_on: {body}");
+    }
+
+    #[test]
+    fn bool_source_on_value_maps_to_zero_or_one_like_as_u8() {
+        let e = emit(&led("led-1", json!({})), &on("value", CppExpr::boolean("btn")));
+        assert!(
+            e.loop_body.iter().any(|l| l.contains("(btn) ? 1 : 0")),
+            "Bool(as_u8) is 1/0, mirroring the runtime"
+        );
+    }
+
+    #[test]
+    fn true_and_false_ports_write_digital_levels_on_pulse() {
+        let mut inputs = NodeInputs::default();
+        // The wiring layer maps a Button's `true`/`false` handles to
+        // rising-edge sources; mirror that shape here.
+        inputs.add("true", SourceExpr::rising(CppExpr::boolean("a")));
+        inputs.add("false", SourceExpr::rising(CppExpr::boolean("b")));
+        let e = emit(&led("led-1", json!({})), &inputs);
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("digitalWrite(led_led_1_pin, HIGH)"), "true port: {body}");
+        assert!(body.contains("digitalWrite(led_led_1_pin, LOW)"), "false port: {body}");
+        assert!(body.contains("&& !led_led_1_true_prev0"), "pulse-driven: {body}");
+    }
+
+    #[test]
+    fn toggle_port_flips_tracked_state_per_pulse() {
+        let e = emit(&led("led-1", json!({})), &on("toggle", CppExpr::boolean("btn")));
+        let body = e.loop_body.join("\n");
+        assert!(
+            body.contains("led_led_1_on = !led_led_1_on"),
+            "toggle flips the tracked state: {body}"
+        );
+    }
+
+    #[test]
+    fn unwired_led_does_no_loop_work() {
+        let e = emit(&led("led-1", json!({})), &NodeInputs::default());
+        assert!(e.loop_body.is_empty());
     }
 }

--- a/crates/microflow-core/src/codegen/output/matrix.rs
+++ b/crates/microflow-core/src/codegen/output/matrix.rs
@@ -1,15 +1,18 @@
 //! Matrix emitter — mirrors `runtime/output/matrix.rs`.
 //!
-//! The live Matrix drives a MAX7219 LED matrix over bit-banged SPI (data, clock,
-//! CS pins), initialising the chip out of shutdown, setting a scan limit and
-//! intensity, and clearing the display. The generated sketch uses the standard
-//! Arduino `LedControl` library, whose `LedControl(dataPin, clkPin, csPin,
-//! numDevices)` wraps exactly this MAX7219 protocol: `setup()` wakes each device
-//! from power-down (`shutdown(i, false)`), sets a mid intensity, and clears the
-//! display — mirroring the runtime's `init_max7219` + blank-on-init. When wired
-//! from an upstream signal the whole display is lit or cleared accordingly.
+//! The live Matrix drives MAX7219 LED matrices (data/clock/CS pins, chained
+//! devices). Its `value` port selects a configured *shape* by index (clamped
+//! to the shape list) and displays it; `reset` clears the display; and
+//! `reinitialize` re-runs the chip init (wake from shutdown, intensity, clear).
+//! Shapes are rows of binary strings, sliced per chained device — the
+//! generated sketch parses them at generation time into static row-byte
+//! tables, so an index arriving on `value` lights the same pixels on-device.
+//! The sketch uses the standard Arduino `LedControl` library, whose
+//! `LedControl(dataPin, clkPin, csPin, numDevices)` wraps exactly this MAX7219
+//! protocol.
 
 use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::codegen::wire::{bind_pulses, extra_sources_note, NodeInputs};
 use crate::flow::FlowNode;
 
 /// Pin defaults match `runtime/output/matrix.rs` (data=2, clock=3, cs=4).
@@ -37,10 +40,30 @@ fn devices(node: &FlowNode) -> u8 {
         .max(1)
 }
 
-/// Emit C++ for a Matrix Node. `driver` is an optional boolean: when wired, a
-/// true value lights every LED and a false value clears the display.
+/// The configured shapes: rows of binary strings (`"01111110…"`), one row
+/// list per shape.
+fn shapes(node: &FlowNode) -> Vec<Vec<String>> {
+    node.data
+        .get("shapes")
+        .and_then(|s| serde_json::from_value(s.clone()).ok())
+        .unwrap_or_default()
+}
+
+/// The row byte for `device`/`row` of `shape` — the generation-time twin of
+/// the runtime's `display_shape` slicing (bad/short binary parses to 0).
+fn row_byte(shape: &[String], device: u8, row: usize) -> u8 {
+    let Some(row_str) = shape.get(row) else { return 0 };
+    let start = usize::from(device) * 8;
+    if start >= row_str.len() {
+        return 0;
+    }
+    let end = (start + 8).min(row_str.len());
+    u8::from_str_radix(&row_str[start..end], 2).unwrap_or(0)
+}
+
+/// Emit C++ for a Matrix Node. Unwired, the display stays cleared.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let token = node.id_token();
     let obj = format!("matrix_{token}");
     let data = pin(node, "data", DEFAULT_DATA);
@@ -50,29 +73,94 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
     let i = format!("matrix_{token}_i");
     let row = format!("matrix_{token}_row");
 
+    let init_lines = vec![
+        format!("for (int {i} = 0; {i} < {devices}; {i}++) {{"),
+        // Mirror init_max7219: wake from shutdown, mid intensity, clear.
+        format!("  {obj}.shutdown({i}, false);"),
+        format!("  {obj}.setIntensity({i}, 8);"),
+        format!("  {obj}.clearDisplay({i});"),
+        "}".to_string(),
+    ];
+
     let mut e = NodeEmission {
         includes: vec!["#include <LedControl.h>".to_string()],
         declarations: vec![format!(
             "LedControl {obj}({data}, {clock}, {cs}, {devices});"
         )],
-        setup: vec![
-            format!("for (int {i} = 0; {i} < {devices}; {i}++) {{"),
-            // Mirror init_max7219: wake from shutdown, mid intensity, clear.
-            format!("  {obj}.shutdown({i}, false);"),
-            format!("  {obj}.setIntensity({i}, 8);"),
-            format!("  {obj}.clearDisplay({i});"),
-            "}".to_string(),
-        ],
+        setup: init_lines.clone(),
         ..NodeEmission::default()
     };
 
-    if let Some(expr) = driver {
-        e.loop_body.push(format!("for (int {i} = 0; {i} < {devices}; {i}++) {{"));
-        e.loop_body.push(format!("  for (int {row} = 0; {row} < 8; {row}++) {{"));
+    // value: shape index selection over generation-time row-byte tables.
+    let value_sources = inputs.on("value");
+    if let Some(note) = extra_sources_note("value", value_sources) {
+        e.declarations.push(note);
+    }
+    if let Some(source) = value_sources.first() {
+        let shape_list = shapes(node);
+        if shape_list.is_empty() {
+            e.declarations.push(
+                "// note: 'value' selects a shape, but no shapes are configured — edge has no effect"
+                    .to_string(),
+            );
+        } else {
+            let table = format!("matrix_{token}_shapes");
+            let count = shape_list.len();
+            let width = usize::from(devices) * 8;
+            let rows: Vec<String> = shape_list
+                .iter()
+                .map(|shape| {
+                    let bytes: Vec<String> = (0..devices)
+                        .flat_map(|d| (0..8).map(move |r| (d, r)))
+                        .map(|(d, r)| format!("0x{:02X}", row_byte(shape, d, r)))
+                        .collect();
+                    format!("  {{{}}}", bytes.join(", "))
+                })
+                .collect();
+            e.declarations
+                .push(format!("const uint8_t {table}[{count}][{width}] = {{"));
+            e.declarations.push(rows.join(",\n"));
+            e.declarations.push("};".to_string());
+
+            let binding = bind_pulses(&format!("matrix_{token}_value"), &value_sources[..1]);
+            e.declarations.extend(binding.declarations.iter().cloned());
+            e.loop_body.extend(binding.loop_lines.iter().cloned());
+            let fired = &binding.fired[0];
+            let idx = format!("matrix_{token}_idx");
+            let last = count - 1;
+            e.loop_body.push(format!("if ({fired}) {{"));
+            e.loop_body.push(format!(
+                "  uint8_t {idx} = (uint8_t)constrain(round({}), 0.0, {last}.0);",
+                source.value.as_double()
+            ));
+            e.loop_body.push(format!("  for (int {i} = 0; {i} < {devices}; {i}++) {{"));
+            e.loop_body.push(format!("    for (int {row} = 0; {row} < 8; {row}++) {{"));
+            e.loop_body.push(format!(
+                "      {obj}.setRow({i}, {row}, {table}[{idx}][{i} * 8 + {row}]);"
+            ));
+            e.loop_body.push("    }".to_string());
+            e.loop_body.push("  }".to_string());
+            e.loop_body.push("}".to_string());
+        }
+    }
+
+    // reset: clear every device.
+    let binding = bind_pulses(&format!("matrix_{token}_reset"), inputs.on("reset"));
+    e.declarations.extend(binding.declarations.iter().cloned());
+    e.loop_body.extend(binding.loop_lines.iter().cloned());
+    if let Some(any) = binding.any_fired() {
         e.loop_body.push(format!(
-            "    {obj}.setRow({i}, {row}, ({expr}) ? 0xFF : 0x00);"
+            "if ({any}) {{ for (int {i} = 0; {i} < {devices}; {i}++) {{ {obj}.clearDisplay({i}); }} }}"
         ));
-        e.loop_body.push("  }".to_string());
+    }
+
+    // reinitialize: re-run the chip init sequence.
+    let binding = bind_pulses(&format!("matrix_{token}_reinit"), inputs.on("reinitialize"));
+    e.declarations.extend(binding.declarations.iter().cloned());
+    e.loop_body.extend(binding.loop_lines.iter().cloned());
+    if let Some(any) = binding.any_fired() {
+        e.loop_body.push(format!("if ({any}) {{"));
+        e.loop_body.extend(init_lines.iter().map(|l| format!("  {l}")));
         e.loop_body.push("}".to_string());
     }
     e
@@ -81,6 +169,7 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::{CppExpr, SourceExpr};
     use crate::flow::Position;
     use serde_json::json;
 
@@ -93,35 +182,84 @@ mod tests {
         }
     }
 
+    fn on(port: &str, expr: CppExpr) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add(port, SourceExpr::level(expr));
+        inputs
+    }
+
     #[test]
     fn matrix_includes_library_and_declares_object() {
-        let e = emit(&matrix("mx-1", json!({})), None);
+        let e = emit(&matrix("mx-1", json!({})), &NodeInputs::default());
         assert!(e.includes.iter().any(|i| i.contains("LedControl.h")));
         assert!(e.declarations.iter().any(|d| d.contains("LedControl matrix_mx_1(2, 3, 4, 1)")));
     }
 
     #[test]
     fn matrix_wakes_and_clears_on_setup() {
-        let e = emit(&matrix("mx-1", json!({})), None);
+        let e = emit(&matrix("mx-1", json!({})), &NodeInputs::default());
         assert!(e.setup.iter().any(|s| s.contains("shutdown") && s.contains("false")));
         assert!(e.setup.iter().any(|s| s.contains("clearDisplay")));
     }
 
     #[test]
-    fn matrix_lights_display_from_value() {
-        let e = emit(&matrix("mx-1", json!({})), Some("btn_state"));
-        assert!(e.loop_body.iter().any(|l| l.contains("setRow") && l.contains("btn_state")));
+    fn value_port_selects_shapes_from_baked_tables() {
+        let shape = vec!["11111111".to_string(); 8];
+        let e = emit(
+            &matrix("mx-1", json!({ "shapes": [shape, ["10000001"]] })),
+            &on("value", CppExpr::number("idx_src")),
+        );
+        let decls = e.declarations.join("\n");
+        assert!(decls.contains("matrix_mx_1_shapes[2][8]"), "{decls}");
+        assert!(decls.contains("0xFF"), "full row parsed: {decls}");
+        assert!(decls.contains("0x81"), "sparse row parsed: {decls}");
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("setRow"), "{body}");
+        assert!(body.contains("constrain(round("), "index clamp: {body}");
+    }
+
+    #[test]
+    fn shapes_slice_per_chained_device() {
+        // Two devices: the row string carries 16 bits, split 8/8.
+        let shape = vec!["1111111100000001".to_string()];
+        assert_eq!(row_byte(&shape, 0, 0), 0xFF);
+        assert_eq!(row_byte(&shape, 1, 0), 0x01);
+        assert_eq!(row_byte(&shape, 0, 3), 0, "missing rows are blank");
+    }
+
+    #[test]
+    fn value_without_shapes_is_noted() {
+        let e = emit(&matrix("mx-1", json!({})), &on("value", CppExpr::number("v")));
+        assert!(e.loop_body.is_empty());
+        assert!(e.declarations.iter().any(|d| d.contains("no shapes are configured")));
+    }
+
+    #[test]
+    fn reset_port_clears_every_device() {
+        let e = emit(&matrix("mx-1", json!({ "devices": 2 })), &on("reset", CppExpr::boolean("r")));
+        assert!(e.loop_body.iter().any(|l| l.contains("clearDisplay")));
+    }
+
+    #[test]
+    fn reinitialize_port_reruns_chip_init() {
+        let e = emit(&matrix("mx-1", json!({})), &on("reinitialize", CppExpr::boolean("r")));
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("shutdown") && body.contains("setIntensity"), "{body}");
     }
 
     #[test]
     fn matrix_reads_custom_pins() {
-        let e = emit(&matrix("mx-1", json!({ "pins": { "data": 7, "clock": 8, "cs": 9 }, "devices": 2 })), None);
+        let e = emit(
+            &matrix("mx-1", json!({ "pins": { "data": 7, "clock": 8, "cs": 9 }, "devices": 2 })),
+            &NodeInputs::default(),
+        );
         assert!(e.declarations.iter().any(|d| d.contains("(7, 8, 9, 2)")));
     }
 
     #[test]
     fn matrix_emits_deterministically() {
-        let n = matrix("mx-1", json!({ "devices": 2 }));
-        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+        let n = matrix("mx-1", json!({ "devices": 2, "shapes": [["1"]] }));
+        let inputs = on("value", CppExpr::number("v"));
+        assert_eq!(emit(&n, &inputs), emit(&n, &inputs));
     }
 }

--- a/crates/microflow-core/src/codegen/output/piezo.rs
+++ b/crates/microflow-core/src/codegen/output/piezo.rs
@@ -1,21 +1,31 @@
 //! Piezo emitter — mirrors `runtime/output/piezo.rs`.
 //!
-//! The live Piezo buzzer plays a tone by toggling its pin at the note's
-//! half-period (the Johnny-Five approach). The Arduino core exposes exactly this
-//! via the built-in `tone(pin, frequency, duration)` / `noTone(pin)`, which is
-//! non-blocking (it runs off a hardware timer). The generated sketch sets the
-//! pin OUTPUT, and — when triggered from an upstream signal — sounds the
-//! configured frequency for the configured duration, falling silent otherwise.
-//! No blocking `delay()` is used: `tone(...)` returns immediately.
+//! The live Piezo exposes a `trigger` port (buzz the configured frequency for
+//! the configured duration, or start the configured song) and a `stop` port.
+//! The Arduino core provides exactly the buzz primitive via the built-in
+//! `tone(pin, frequency, duration)` / `noTone(pin)`, which is non-blocking (it
+//! runs off a hardware timer). The generated sketch sets the pin OUTPUT and
+//! binds both ports as pulses: one `tone(...)` per trigger firing — the
+//! one-shot twin of the runtime's buzz-per-event — and `noTone` on stop.
+//! Song playback walks a scheduled note queue on the host and has no
+//! generated counterpart yet; a song-configured Node emits an explicit note.
 
 use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::codegen::wire::{bind_pulses, NodeInputs};
 use crate::config::piezo::PiezoConfig;
 use crate::flow::FlowNode;
 
-/// Emit C++ for a Piezo Node. `driver` is an optional boolean trigger: while
-/// true the buzzer sounds, otherwise it is silenced.
+/// True when the Node is configured as a song player rather than a buzzer.
+fn is_song(node: &FlowNode) -> bool {
+    node.data
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|t| t.eq_ignore_ascii_case("song"))
+}
+
+/// Emit C++ for a Piezo Node. Unwired, it stays silent.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let token = node.id_token();
     let pin_var = format!("piezo_{token}_pin");
     let config: PiezoConfig = serde_json::from_value(node.data.clone()).unwrap_or_default();
@@ -33,14 +43,28 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
         ..NodeEmission::default()
     };
 
-    if let Some(expr) = driver {
-        e.loop_body.push(format!("if ({expr}) {{"));
+    // trigger: one buzz per firing source. Song playback is host-only.
+    let trigger_binding = bind_pulses(&format!("piezo_{token}_trigger"), inputs.on("trigger"));
+    e.declarations.extend(trigger_binding.declarations.iter().cloned());
+    e.loop_body.extend(trigger_binding.loop_lines.iter().cloned());
+    if let Some(any) = trigger_binding.any_fired() {
+        if is_song(node) {
+            e.declarations.push(
+                "// note: song playback is not generated on-device; the trigger buzzes the base frequency instead"
+                    .to_string(),
+            );
+        }
         // tone() is non-blocking — it drives a hardware timer and returns at once.
         e.loop_body
-            .push(format!("  tone({pin_var}, {frequency}, {duration});"));
-        e.loop_body.push("} else {".to_string());
-        e.loop_body.push(format!("  noTone({pin_var});"));
-        e.loop_body.push("}".to_string());
+            .push(format!("if ({any}) {{ tone({pin_var}, {frequency}, {duration}); }}"));
+    }
+
+    // stop: silence on any firing source.
+    let stop_binding = bind_pulses(&format!("piezo_{token}_stop"), inputs.on("stop"));
+    e.declarations.extend(stop_binding.declarations.iter().cloned());
+    e.loop_body.extend(stop_binding.loop_lines.iter().cloned());
+    if let Some(any) = stop_binding.any_fired() {
+        e.loop_body.push(format!("if ({any}) {{ noTone({pin_var}); }}"));
     }
     e
 }
@@ -48,6 +72,7 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::{CppExpr, SourceExpr};
     use crate::flow::Position;
     use serde_json::json;
 
@@ -60,34 +85,61 @@ mod tests {
         }
     }
 
+    fn on(port: &str, expr: CppExpr) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add(port, SourceExpr::level(expr));
+        inputs
+    }
+
     #[test]
     fn piezo_sets_output_and_starts_silent() {
-        let e = emit(&piezo("pz-1", json!({ "pin": 11 })), None);
+        let e = emit(&piezo("pz-1", json!({ "pin": 11 })), &NodeInputs::default());
         assert!(e.setup.iter().any(|s| s.contains("pinMode") && s.contains("OUTPUT")));
         assert!(e.setup.iter().any(|s| s.contains("noTone")));
     }
 
     #[test]
-    fn piezo_sounds_configured_frequency_when_triggered() {
-        let e = emit(&piezo("pz-1", json!({ "frequency": 880, "duration": 250 })), Some("btn_state"));
-        assert!(e.loop_body.iter().any(|l| l.contains("tone(") && l.contains("880") && l.contains("250")));
+    fn piezo_sounds_configured_frequency_once_per_trigger_pulse() {
+        let e = emit(
+            &piezo("pz-1", json!({ "frequency": 880, "duration": 250 })),
+            &on("trigger", CppExpr::boolean("btn_state")),
+        );
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("tone(") && body.contains("880") && body.contains("250"), "{body}");
+        assert!(
+            body.contains("!= piezo_pz_1_trigger_prev0"),
+            "one-shot per trigger change, not every truthy tick: {body}"
+        );
+    }
+
+    #[test]
+    fn stop_port_silences_the_buzzer() {
+        let e = emit(&piezo("pz-1", json!({})), &on("stop", CppExpr::boolean("halt")));
+        assert!(e.loop_body.iter().any(|l| l.contains("noTone(piezo_pz_1_pin)")));
     }
 
     #[test]
     fn piezo_is_non_blocking() {
-        let e = emit(&piezo("pz-1", json!({})), Some("v"));
+        let e = emit(&piezo("pz-1", json!({})), &on("trigger", CppExpr::boolean("v")));
         assert!(!e.loop_body.iter().any(|l| l.contains("delay(")), "piezo must not block");
     }
 
     #[test]
     fn piezo_uses_default_frequency() {
-        let e = emit(&piezo("pz-1", json!({})), Some("v"));
+        let e = emit(&piezo("pz-1", json!({})), &on("trigger", CppExpr::boolean("v")));
         assert!(e.loop_body.iter().any(|l| l.contains("440")));
+    }
+
+    #[test]
+    fn song_configuration_is_noted() {
+        let e = emit(&piezo("pz-1", json!({ "type": "song" })), &on("trigger", CppExpr::boolean("v")));
+        assert!(e.declarations.iter().any(|d| d.contains("song playback")));
     }
 
     #[test]
     fn piezo_emits_deterministically() {
         let n = piezo("pz-1", json!({ "frequency": 440 }));
-        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+        let inputs = on("trigger", CppExpr::boolean("v"));
+        assert_eq!(emit(&n, &inputs), emit(&n, &inputs));
     }
 }

--- a/crates/microflow-core/src/codegen/output/pixel.rs
+++ b/crates/microflow-core/src/codegen/output/pixel.rs
@@ -1,15 +1,20 @@
 //! Pixel emitter — mirrors `runtime/output/pixel.rs`.
 //!
-//! The live Pixel drives an addressable `NeoPixel` strip (WS2812-style). It
-//! configures the strip length, pin and colour order, and pushes per-pixel
-//! colours, clearing the strip on initialize. The generated sketch uses the
-//! Adafruit `NeoPixel` library: it `#include <Adafruit_NeoPixel.h>`, declares a
-//! strip object sized to the configured length on the configured pin with the
-//! matching colour order, calls `begin()` + `clear()` + `show()` in `setup()`
-//! (mirroring the runtime's off-on-init), and — when wired from an upstream
-//! brightness value — fills the whole strip with that grayscale level each loop.
+//! The live Pixel drives an addressable `NeoPixel` strip (WS2812-style). Its
+//! `value` port selects a configured *preset* by index (clamped to the preset
+//! list) and applies that preset's per-pixel hex colors; `reset` clears the
+//! strip. The generated sketch uses the Adafruit `NeoPixel` library and bakes
+//! the presets into static color tables (hex parsed at generation time with
+//! the runtime's exact `parse_hex_color` semantics), so an index arriving on
+//! `value` applies the same colors on-device. Presets shorter than the strip
+//! write only their own pixels, like the runtime's `take(length)`.
+//!
+//! The `color` (direct hex/array payload) and `set` (single-pixel) ports carry
+//! string/object payloads with no on-device value model yet; wiring them emits
+//! an explicit note instead of wrong code.
 
 use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::codegen::wire::{bind_pulses, extra_sources_note, NodeInputs};
 use crate::config::pixel::PixelConfig;
 use crate::flow::FlowNode;
 
@@ -23,10 +28,26 @@ fn neo_color_flag(color_order: &str) -> &'static str {
     }
 }
 
-/// Emit C++ for a Pixel Node. `driver` is an optional grayscale brightness
-/// (0..=255) applied to every pixel; `None` leaves the strip cleared.
+/// Parse a `#rgb` / `#rrggbb` hex color to `0x00RRGGBB` — a transcription of
+/// the runtime's `parse_hex_color` (bad input parses to 0/black).
+fn parse_hex_color(hex: &str) -> u32 {
+    let hex = hex.trim_start_matches('#');
+    match hex.len() {
+        3 => {
+            let r = u8::from_str_radix(&hex[0..1], 16).unwrap_or(0);
+            let g = u8::from_str_radix(&hex[1..2], 16).unwrap_or(0);
+            let b = u8::from_str_radix(&hex[2..3], 16).unwrap_or(0);
+            // Expand 4-bit to 8-bit: 0xA -> 0xAA
+            u32::from(r | (r << 4)) << 16 | u32::from(g | (g << 4)) << 8 | u32::from(b | (b << 4))
+        }
+        6 => u32::from_str_radix(hex, 16).unwrap_or(0),
+        _ => 0,
+    }
+}
+
+/// Emit C++ for a Pixel Node. Unwired, the strip stays cleared.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let token = node.id_token();
     let obj = format!("pixel_{token}");
     let config: PixelConfig = serde_json::from_value(node.data.clone()).unwrap_or_default();
@@ -49,17 +70,91 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
         ..NodeEmission::default()
     };
 
-    if let Some(expr) = driver {
-        let level = format!("constrain((int)({expr}), 0, 255)");
-        e.loop_body.push(format!("int {token}_level = {level};"));
-        e.loop_body.push(format!(
-            "for (uint16_t {i} = 0; {i} < {length}; {i}++) {{"
-        ));
-        e.loop_body.push(format!(
-            "  {obj}.setPixelColor({i}, {obj}.Color({token}_level, {token}_level, {token}_level));"
-        ));
-        e.loop_body.push("}".to_string());
-        e.loop_body.push(format!("{obj}.show();"));
+    // value: preset index selection over generation-time color tables.
+    let value_sources = inputs.on("value");
+    if let Some(note) = extra_sources_note("value", value_sources) {
+        e.declarations.push(note);
+    }
+    if let Some(source) = value_sources.first() {
+        if config.presets.is_empty() {
+            e.declarations.push(
+                "// note: 'value' selects a preset, but no presets are configured — edge has no effect"
+                    .to_string(),
+            );
+        } else {
+            let presets = format!("pixel_{token}_presets");
+            let lengths = format!("pixel_{token}_preset_len");
+            let count = config.presets.len();
+            let width = config
+                .presets
+                .iter()
+                .map(|p| p.len().min(length as usize))
+                .max()
+                .unwrap_or(0)
+                .max(1);
+            let rows: Vec<String> = config
+                .presets
+                .iter()
+                .map(|preset| {
+                    let mut colors: Vec<String> = preset
+                        .iter()
+                        .take(width)
+                        .map(|hex| format!("0x{:06X}", parse_hex_color(hex)))
+                        .collect();
+                    colors.resize(width, "0x000000".to_string());
+                    format!("  {{{}}}", colors.join(", "))
+                })
+                .collect();
+            e.declarations
+                .push(format!("const uint32_t {presets}[{count}][{width}] = {{"));
+            e.declarations.push(rows.join(",\n"));
+            e.declarations.push("};".to_string());
+            let lens: Vec<String> = config
+                .presets
+                .iter()
+                .map(|p| p.len().min(length as usize).to_string())
+                .collect();
+            e.declarations
+                .push(format!("const uint16_t {lengths}[{count}] = {{{}}};", lens.join(", ")));
+
+            // Apply on every new index sample (change pulse), clamped like the
+            // runtime's `index.min(len - 1)`.
+            let binding = bind_pulses(&format!("pixel_{token}_value"), &value_sources[..1]);
+            e.declarations.extend(binding.declarations.iter().cloned());
+            e.loop_body.extend(binding.loop_lines.iter().cloned());
+            let fired = &binding.fired[0];
+            let idx = format!("pixel_{token}_idx");
+            let last = count - 1;
+            e.loop_body.push(format!("if ({fired}) {{"));
+            e.loop_body.push(format!(
+                "  uint16_t {idx} = (uint16_t)constrain(round({}), 0.0, {last}.0);",
+                source.value.as_double()
+            ));
+            e.loop_body.push(format!(
+                "  for (uint16_t {i} = 0; {i} < {lengths}[{idx}]; {i}++) {{ {obj}.setPixelColor({i}, {presets}[{idx}][{i}]); }}"
+            ));
+            e.loop_body.push(format!("  {obj}.show();"));
+            e.loop_body.push("}".to_string());
+        }
+    }
+
+    // reset: clear the strip.
+    let binding = bind_pulses(&format!("pixel_{token}_reset"), inputs.on("reset"));
+    e.declarations.extend(binding.declarations.iter().cloned());
+    e.loop_body.extend(binding.loop_lines.iter().cloned());
+    if let Some(any) = binding.any_fired() {
+        e.loop_body
+            .push(format!("if ({any}) {{ {obj}.clear(); {obj}.show(); }}"));
+    }
+
+    // color / set: payload shapes (hex strings, per-pixel objects) with no
+    // on-device value model — note instead of guessing.
+    for port in ["color", "set"] {
+        if !inputs.on(port).is_empty() {
+            e.declarations.push(format!(
+                "// note: input '{port}' carries payloads codegen cannot express on-device — edge ignored"
+            ));
+        }
     }
     e
 }
@@ -67,6 +162,7 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::{CppExpr, SourceExpr};
     use crate::flow::Position;
     use serde_json::json;
 
@@ -79,37 +175,87 @@ mod tests {
         }
     }
 
+    fn on(port: &str, expr: CppExpr) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add(port, SourceExpr::level(expr));
+        inputs
+    }
+
     #[test]
     fn pixel_includes_library_and_declares_strip() {
-        let e = emit(&pixel("px-1", json!({ "pin": 6, "length": 16 })), None);
+        let e = emit(&pixel("px-1", json!({ "pin": 6, "length": 16 })), &NodeInputs::default());
         assert!(e.includes.iter().any(|i| i.contains("Adafruit_NeoPixel.h")));
         assert!(e.declarations.iter().any(|d| d.contains("Adafruit_NeoPixel pixel_px_1(16, 6")));
     }
 
     #[test]
     fn pixel_begins_and_clears_on_setup() {
-        let e = emit(&pixel("px-1", json!({})), None);
+        let e = emit(&pixel("px-1", json!({})), &NodeInputs::default());
         assert!(e.setup.iter().any(|s| s.contains(".begin()")));
         assert!(e.setup.iter().any(|s| s.contains(".clear()")));
     }
 
     #[test]
-    fn pixel_fills_strip_from_value() {
-        let e = emit(&pixel("px-1", json!({ "length": 8 })), Some("sensor_x_value"));
-        assert!(e.loop_body.iter().any(|l| l.contains("setPixelColor")));
-        assert!(e.loop_body.iter().any(|l| l.contains("sensor_x_value")));
-        assert!(e.loop_body.iter().any(|l| l.contains(".show()")));
+    fn value_port_selects_presets_from_baked_tables() {
+        let e = emit(
+            &pixel(
+                "px-1",
+                json!({ "length": 4, "presets": [["#ff0000", "#00ff00"], ["#0000ff"]] }),
+            ),
+            &on("value", CppExpr::number("idx_src")),
+        );
+        let decls = e.declarations.join("\n");
+        assert!(decls.contains("0xFF0000") && decls.contains("0x00FF00") && decls.contains("0x0000FF"), "{decls}");
+        assert!(decls.contains("pixel_px_1_preset_len[2] = {2, 1}"), "per-preset lengths: {decls}");
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("setPixelColor"), "{body}");
+        assert!(body.contains("constrain(round(") && body.contains("1.0)"), "index clamp: {body}");
+        assert!(body.contains(".show()"), "{body}");
+    }
+
+    #[test]
+    fn short_hex_colors_expand_like_the_runtime() {
+        assert_eq!(parse_hex_color("#fff"), 0x00FF_FFFF);
+        assert_eq!(parse_hex_color("#a2c"), 0x00AA_22CC);
+        assert_eq!(parse_hex_color("123456"), 0x0012_3456);
+        assert_eq!(parse_hex_color("zzz"), 0);
+    }
+
+    #[test]
+    fn value_without_presets_is_noted() {
+        let e = emit(&pixel("px-1", json!({})), &on("value", CppExpr::number("v")));
+        assert!(e.loop_body.is_empty());
+        assert!(e.declarations.iter().any(|d| d.contains("no presets are configured")));
+    }
+
+    #[test]
+    fn reset_port_clears_the_strip() {
+        let e = emit(&pixel("px-1", json!({})), &on("reset", CppExpr::boolean("r")));
+        assert!(e.loop_body.iter().any(|l| l.contains(".clear(); pixel_px_1.show();")));
+    }
+
+    #[test]
+    fn color_and_set_ports_are_noted() {
+        let mut inputs = NodeInputs::default();
+        inputs.add("color", SourceExpr::level(CppExpr::text("hex")));
+        inputs.add("set", SourceExpr::level(CppExpr::number("v")));
+        let e = emit(&pixel("px-1", json!({})), &inputs);
+        assert_eq!(
+            e.declarations.iter().filter(|d| d.contains("edge ignored")).count(),
+            2
+        );
     }
 
     #[test]
     fn pixel_honours_color_order() {
-        let e = emit(&pixel("px-1", json!({ "color_order": "RGB" })), None);
+        let e = emit(&pixel("px-1", json!({ "color_order": "RGB" })), &NodeInputs::default());
         assert!(e.declarations.iter().any(|d| d.contains("NEO_RGB")));
     }
 
     #[test]
     fn pixel_emits_deterministically() {
-        let n = pixel("px-1", json!({ "length": 12 }));
-        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+        let n = pixel("px-1", json!({ "length": 12, "presets": [["#fff"]] }));
+        let inputs = on("value", CppExpr::number("v"));
+        assert_eq!(emit(&n, &inputs), emit(&n, &inputs));
     }
 }

--- a/crates/microflow-core/src/codegen/output/relay.rs
+++ b/crates/microflow-core/src/codegen/output/relay.rs
@@ -1,42 +1,68 @@
 //! Relay emitter — mirrors `runtime/output/relay.rs`.
 //!
-//! The live Relay sets `pinMode(pin, OUTPUT)` and starts closed. For a
-//! Normally-Open (NO) relay, "open" writes HIGH and "close" writes LOW; for a
-//! Normally-Closed (NC) relay the signal is inverted. The generated sketch
-//! emits the OUTPUT setup and, when driven, a `digitalWrite` that honours the
-//! relay type so emitted behavior matches the runtime.
+//! The live Relay sets `pinMode(pin, OUTPUT)` and starts closed. Its ports are
+//! `true` (open), `false` (close), and `toggle` — there is no level-valued
+//! `value` port. For a Normally-Open (NO) relay, "open" writes HIGH and
+//! "close" writes LOW; for a Normally-Closed (NC) relay the signal is
+//! inverted. The generated sketch emits the OUTPUT setup and binds each wired
+//! port as a pulse, tracking the open/closed state so `toggle` flips from the
+//! last written state exactly like the runtime's `is_open`.
 
 use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::codegen::wire::{bind_pulses, NodeInputs};
 use crate::config::relay::{RelayConfig, RelayType};
 use crate::flow::FlowNode;
 
-/// Emit C++ for a Relay Node. `driver` is the C++ boolean expression for the
-/// desired open/closed state (true = open), or `None` for an unconnected relay
-/// which stays in its initialized-closed state.
+/// Emit C++ for a Relay Node. An unwired relay stays initialized-closed.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let config: RelayConfig = serde_json::from_value(node.data.clone()).unwrap_or_default();
     let pin = config.pin;
-    let var = format!("relay_{}_pin", node.id_token());
+    let token = node.id_token();
+    let var = format!("relay_{token}_pin");
+    let open_state = format!("relay_{token}_open");
     // NO: open => HIGH; NC: open => LOW. Closing is the inverse.
     let nc = config.r#type == RelayType::NC;
+    let open_level = if nc { "LOW" } else { "HIGH" };
+    let closed = closed_level(nc);
 
     let mut e = NodeEmission {
-        declarations: vec![format!("const uint8_t {var} = {pin};")],
+        declarations: vec![
+            format!("const uint8_t {var} = {pin};"),
+            format!("bool {open_state} = false;"),
+        ],
         setup: vec![
             format!("pinMode({var}, OUTPUT);"),
             // Mirror runtime initialize: start closed.
-            format!("digitalWrite({var}, {});", closed_level(nc)),
+            format!("digitalWrite({var}, {closed});"),
         ],
         ..NodeEmission::default()
     };
 
-    if let Some(expr) = driver {
-        let open_level = if nc { "LOW" } else { "HIGH" };
-        let closed = closed_level(nc);
-        e.loop_body
-            .push(format!("digitalWrite({var}, ({expr}) ? {open_level} : {closed});"));
+    // true / false: idempotent open/close on any firing source.
+    for (port, level, state) in
+        [("true", open_level, "true"), ("false", closed, "false")]
+    {
+        let binding = bind_pulses(&format!("relay_{token}_{port}"), inputs.on(port));
+        e.declarations.extend(binding.declarations.iter().cloned());
+        e.loop_body.extend(binding.loop_lines.iter().cloned());
+        if let Some(any) = binding.any_fired() {
+            e.loop_body.push(format!(
+                "if ({any}) {{ digitalWrite({var}, {level}); {open_state} = {state}; }}"
+            ));
+        }
     }
+
+    // toggle: one flip per fired source.
+    let binding = bind_pulses(&format!("relay_{token}_toggle"), inputs.on("toggle"));
+    e.declarations.extend(binding.declarations.iter().cloned());
+    e.loop_body.extend(binding.loop_lines.iter().cloned());
+    for fired in &binding.fired {
+        e.loop_body.push(format!(
+            "if ({fired}) {{ {open_state} = !{open_state}; digitalWrite({var}, {open_state} ? {open_level} : {closed}); }}"
+        ));
+    }
+
     e
 }
 
@@ -52,6 +78,7 @@ fn closed_level(normally_closed: bool) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::{CppExpr, SourceExpr};
     use crate::flow::Position;
     use serde_json::json;
 
@@ -64,9 +91,15 @@ mod tests {
         }
     }
 
+    fn on(port: &str, expr: CppExpr) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add(port, SourceExpr::level(expr));
+        inputs
+    }
+
     #[test]
     fn relay_sets_output_and_starts_closed_no() {
-        let e = emit(&relay("r-1", json!({ "pin": 10 })), None);
+        let e = emit(&relay("r-1", json!({ "pin": 10 })), &NodeInputs::default());
         assert!(e.setup.iter().any(|s| s.contains("OUTPUT")));
         // NO relay closed => LOW.
         assert!(e.setup.iter().any(|s| s.contains("digitalWrite") && s.contains("LOW")));
@@ -74,14 +107,50 @@ mod tests {
 
     #[test]
     fn relay_nc_inverts_closed_level() {
-        let e = emit(&relay("r-1", json!({ "pin": 10, "type": "NC" })), None);
+        let e = emit(&relay("r-1", json!({ "pin": 10, "type": "NC" })), &NodeInputs::default());
         // NC relay closed => HIGH.
         assert!(e.setup.iter().any(|s| s.contains("digitalWrite") && s.contains("HIGH")));
     }
 
     #[test]
+    fn true_port_opens_and_false_port_closes() {
+        let mut inputs = NodeInputs::default();
+        inputs.add("true", SourceExpr::level(CppExpr::boolean("a")));
+        inputs.add("false", SourceExpr::level(CppExpr::boolean("b")));
+        let e = emit(&relay("r-1", json!({ "pin": 10 })), &inputs);
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("digitalWrite(relay_r_1_pin, HIGH); relay_r_1_open = true"), "{body}");
+        assert!(body.contains("digitalWrite(relay_r_1_pin, LOW); relay_r_1_open = false"), "{body}");
+    }
+
+    #[test]
+    fn nc_relay_swaps_open_and_closed_levels() {
+        let e = emit(&relay("r-1", json!({ "type": "NC" })), &on("true", CppExpr::boolean("a")));
+        assert!(
+            e.loop_body.iter().any(|l| l.contains("digitalWrite(relay_r_1_pin, LOW); relay_r_1_open = true")),
+            "NC open writes LOW"
+        );
+    }
+
+    #[test]
+    fn toggle_flips_tracked_state() {
+        let e = emit(&relay("r-1", json!({})), &on("toggle", CppExpr::boolean("btn")));
+        assert!(
+            e.loop_body.iter().any(|l| l.contains("relay_r_1_open = !relay_r_1_open")),
+            "toggle flips is_open"
+        );
+    }
+
+    #[test]
+    fn unwired_relay_does_no_loop_work() {
+        let e = emit(&relay("r-1", json!({})), &NodeInputs::default());
+        assert!(e.loop_body.is_empty());
+    }
+
+    #[test]
     fn relay_emits_deterministically() {
         let n = relay("r-1", json!({ "pin": 10, "type": "NC" }));
-        assert_eq!(emit(&n, Some("x")), emit(&n, Some("x")));
+        let inputs = on("toggle", CppExpr::boolean("x"));
+        assert_eq!(emit(&n, &inputs), emit(&n, &inputs));
     }
 }

--- a/crates/microflow-core/src/codegen/output/rgb.rs
+++ b/crates/microflow-core/src/codegen/output/rgb.rs
@@ -1,14 +1,20 @@
 //! Rgb emitter — mirrors `runtime/output/rgb.rs`.
 //!
-//! The live RGB LED drives three PWM pins (red/green/blue). It sets each pin to
-//! PWM mode and turns the LED off on initialize. A common-anode (`isAnode`) LED
-//! is active-low, so its channel writes are inverted (`255 - value`). The
-//! generated sketch declares the three pin constants, sets them OUTPUT, writes
-//! them off in `setup()`, and — when wired from a single upstream value — drives
-//! all three channels with that brightness via `analogWrite`, honouring the
-//! anode inversion so emitted behavior matches the runtime.
+//! The live RGB LED drives three PWM pins (red/green/blue) from a stored
+//! `Rgba` color and exposes five ports: `red` / `green` / `blue` set one
+//! channel each (`0..=255`), `alpha` scales all channels (a `0..=100` percent
+//! mapped to `0..=1` intensity), and `off` resets the color. Every update
+//! recomputes the hardware writes as `channel * alpha`, inverted (`255 - v`)
+//! for a common-anode (`isAnode`) LED.
+//!
+//! The generated sketch keeps the color as module-level state, binds each
+//! wired channel port as a level assignment (`off` as a pulse), and rewrites
+//! all three pins each loop from the same intensity/anode math — so a single
+//! sensor can now drive one channel while a constant holds another, exactly
+//! like the live Node.
 
 use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::codegen::wire::{bind_pulses, extra_sources_note, NodeInputs};
 use crate::flow::FlowNode;
 
 /// Channel pin defaults match `runtime/output/rgb.rs` (red=9, green=10, blue=11).
@@ -31,46 +37,88 @@ fn is_anode(node: &FlowNode) -> bool {
     node.data.get("isAnode").and_then(serde_json::Value::as_bool).unwrap_or(false)
 }
 
-/// Emit C++ for an Rgb Node. `driver` is an optional brightness expression
-/// (0..=255) applied to every channel; `None` leaves the LED off.
+/// Emit C++ for an Rgb Node. Unwired channels keep their initial `0`.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let token = node.id_token();
-    let red = format!("rgb_{token}_red_pin");
-    let green = format!("rgb_{token}_green_pin");
-    let blue = format!("rgb_{token}_blue_pin");
     let anode = is_anode(node);
     // Off level: common-anode is active-low, so "off" is 255.
     let off = if anode { 255 } else { 0 };
+    let alpha = format!("rgb_{token}_a");
 
-    let mut e = NodeEmission {
-        declarations: vec![
-            format!("const uint8_t {red} = {};", channel_pin(node, "red", DEFAULT_RED)),
-            format!("const uint8_t {green} = {};", channel_pin(node, "green", DEFAULT_GREEN)),
-            format!("const uint8_t {blue} = {};", channel_pin(node, "blue", DEFAULT_BLUE)),
-        ],
-        setup: vec![
-            format!("pinMode({red}, OUTPUT);"),
-            format!("pinMode({green}, OUTPUT);"),
-            format!("pinMode({blue}, OUTPUT);"),
-            // Mirror runtime initialize: start off.
-            format!("analogWrite({red}, {off});"),
-            format!("analogWrite({green}, {off});"),
-            format!("analogWrite({blue}, {off});"),
-        ],
-        ..NodeEmission::default()
-    };
+    let mut e = NodeEmission::default();
+    let mut channel_vars: Vec<(String, String)> = Vec::new();
+    for (channel, default) in [
+        ("red", DEFAULT_RED),
+        ("green", DEFAULT_GREEN),
+        ("blue", DEFAULT_BLUE),
+    ] {
+        let pin_var = format!("rgb_{token}_{channel}_pin");
+        let level_var = format!("rgb_{token}_{channel}");
+        e.declarations
+            .push(format!("const uint8_t {pin_var} = {};", channel_pin(node, channel, default)));
+        e.declarations.push(format!("uint8_t {level_var} = 0;"));
+        e.setup.push(format!("pinMode({pin_var}, OUTPUT);"));
+        // Mirror runtime initialize: start off.
+        e.setup.push(format!("analogWrite({pin_var}, {off});"));
+        channel_vars.push((pin_var, level_var));
+    }
+    e.declarations.push(format!("double {alpha} = 1.0;"));
 
-    if let Some(expr) = driver {
-        // Common-anode inverts the duty cycle.
-        let level = if anode {
-            format!("(255 - constrain((int)({expr}), 0, 255))")
-        } else {
-            format!("constrain((int)({expr}), 0, 255)")
-        };
-        e.loop_body.push(format!("analogWrite({red}, {level});"));
-        e.loop_body.push(format!("analogWrite({green}, {level});"));
-        e.loop_body.push(format!("analogWrite({blue}, {level});"));
+    // red / green / blue: per-channel level assignments (as_u8, default 0).
+    let mut any_wired = false;
+    for (channel, (_, level_var)) in
+        ["red", "green", "blue"].iter().zip(&channel_vars)
+    {
+        let sources = inputs.on(channel);
+        if let Some(note) = extra_sources_note(channel, sources) {
+            e.declarations.push(note);
+        }
+        if let Some(source) = sources.first() {
+            any_wired = true;
+            e.loop_body
+                .push(format!("{level_var} = {};", source.value.as_u8_or(0)));
+        }
+    }
+
+    // alpha: 0..=100 percent → 0..=1 intensity (runtime clamp).
+    let alpha_sources = inputs.on("alpha");
+    if let Some(note) = extra_sources_note("alpha", alpha_sources) {
+        e.declarations.push(note);
+    }
+    if let Some(source) = alpha_sources.first() {
+        any_wired = true;
+        let v = source.value.as_double_or("100.0");
+        e.loop_body
+            .push(format!("{alpha} = constrain({v} / 100.0, 0.0, 1.0);"));
+    }
+
+    // off: reset the stored color, like the runtime's default Rgba.
+    let binding = bind_pulses(&format!("rgb_{token}_off"), inputs.on("off"));
+    e.declarations.extend(binding.declarations.iter().cloned());
+    e.loop_body.extend(binding.loop_lines.iter().cloned());
+    if let Some(any) = binding.any_fired() {
+        any_wired = true;
+        let resets: Vec<String> = channel_vars
+            .iter()
+            .map(|(_, level)| format!("{level} = 0;"))
+            .collect();
+        e.loop_body
+            .push(format!("if ({any}) {{ {} {alpha} = 1.0; }}", resets.join(" ")));
+    }
+
+    // Rewrite the hardware from the stored color each tick — the polled twin
+    // of the runtime's update_hardware after every dispatch.
+    if any_wired {
+        for (pin_var, level_var) in &channel_vars {
+            let intensity = format!("(uint8_t)((double){level_var} * {alpha})");
+            let written = if anode {
+                format!("(255 - {intensity})")
+            } else {
+                intensity
+            };
+            e.loop_body.push(format!("analogWrite({pin_var}, {written});"));
+        }
     }
     e
 }
@@ -78,6 +126,7 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::{CppExpr, SourceExpr};
     use crate::flow::Position;
     use serde_json::json;
 
@@ -90,38 +139,77 @@ mod tests {
         }
     }
 
+    fn on(port: &str, expr: CppExpr) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add(port, SourceExpr::level(expr));
+        inputs
+    }
+
     #[test]
     fn rgb_sets_three_pwm_pins_and_starts_off() {
-        let e = emit(&rgb("rgb-1", json!({})), None);
+        let e = emit(&rgb("rgb-1", json!({})), &NodeInputs::default());
         assert_eq!(e.setup.iter().filter(|s| s.contains("pinMode")).count(), 3);
         assert!(e.declarations.iter().any(|d| d.contains("= 9;")));
         assert!(e.setup.iter().filter(|s| s.contains("analogWrite") && s.contains(", 0)")).count() >= 3);
     }
 
     #[test]
-    fn rgb_drives_all_channels_from_value() {
-        let e = emit(&rgb("rgb-1", json!({})), Some("sensor_x_value"));
-        assert_eq!(e.loop_body.iter().filter(|l| l.contains("analogWrite") && l.contains("sensor_x_value")).count(), 3);
+    fn each_channel_port_drives_its_own_pin() {
+        let mut inputs = NodeInputs::default();
+        inputs.add("red", SourceExpr::level(CppExpr::number("r_v")));
+        inputs.add("blue", SourceExpr::level(CppExpr::number("b_v")));
+        let e = emit(&rgb("rgb-1", json!({})), &inputs);
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("rgb_rgb_1_red = ") && body.contains("r_v"), "red bound: {body}");
+        assert!(body.contains("rgb_rgb_1_blue = ") && body.contains("b_v"), "blue bound: {body}");
+        assert!(!body.contains("rgb_rgb_1_green = "), "green stays unwired: {body}");
+        // All three pins still rewritten from state.
+        assert_eq!(body.matches("analogWrite(").count(), 3);
+    }
+
+    #[test]
+    fn alpha_port_scales_intensity_like_the_runtime() {
+        let e = emit(&rgb("rgb-1", json!({})), &on("alpha", CppExpr::number("a_v")));
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("/ 100.0, 0.0, 1.0"), "percent → intensity clamp: {body}");
+        assert!(body.contains("* rgb_rgb_1_a"), "channels scale by alpha: {body}");
+    }
+
+    #[test]
+    fn off_port_resets_the_stored_color() {
+        let e = emit(&rgb("rgb-1", json!({})), &on("off", CppExpr::boolean("kill")));
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("rgb_rgb_1_red = 0;") && body.contains("rgb_rgb_1_a = 1.0;"), "{body}");
     }
 
     #[test]
     fn rgb_anode_inverts_levels() {
-        let e = emit(&rgb("rgb-1", json!({ "isAnode": true })), Some("v"));
+        let e = emit(&rgb("rgb-1", json!({ "isAnode": true })), &on("red", CppExpr::number("v")));
         assert!(e.loop_body.iter().any(|l| l.contains("255 -")));
         assert!(e.setup.iter().any(|s| s.contains("analogWrite") && s.contains(", 255)")));
     }
 
     #[test]
     fn rgb_reads_custom_pins() {
-        let e = emit(&rgb("rgb-1", json!({ "pins": { "red": 3, "green": 5, "blue": 6 } })), None);
+        let e = emit(
+            &rgb("rgb-1", json!({ "pins": { "red": 3, "green": 5, "blue": 6 } })),
+            &NodeInputs::default(),
+        );
         assert!(e.declarations.iter().any(|d| d.contains("= 3;")));
         assert!(e.declarations.iter().any(|d| d.contains("= 5;")));
         assert!(e.declarations.iter().any(|d| d.contains("= 6;")));
     }
 
     #[test]
+    fn unwired_rgb_does_no_loop_work() {
+        let e = emit(&rgb("rgb-1", json!({})), &NodeInputs::default());
+        assert!(e.loop_body.is_empty());
+    }
+
+    #[test]
     fn rgb_emits_deterministically() {
         let n = rgb("rgb-1", json!({ "isAnode": true }));
-        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+        let inputs = on("red", CppExpr::number("v"));
+        assert_eq!(emit(&n, &inputs), emit(&n, &inputs));
     }
 }

--- a/crates/microflow-core/src/codegen/output/servo.rs
+++ b/crates/microflow-core/src/codegen/output/servo.rs
@@ -1,21 +1,31 @@
 //! Servo emitter — mirrors `runtime/output/servo.rs`.
 //!
-//! The live Servo uses the Firmata SERVO pin mode and centers itself to the
-//! midpoint of its `[min, max]` range on initialize. The generated sketch uses
-//! the Arduino `Servo` library: it `#include <Servo.h>`, declares a `Servo`
-//! object, `attach`es it to the pin in `setup()`, and `write`s the center
-//! position — matching the runtime's centering behavior. The `#include` and
-//! object are only present because a Servo Node exists (the assembler
-//! de-duplicates the include).
+//! The live Servo centers itself to the midpoint of its `[min, max]` range on
+//! initialize and exposes five ports: `value` moves a standard servo to the
+//! clamped position (or, for a continuous servo, maps a `-1..=1` speed to a
+//! `0..=180` write with a `|speed| < 0.05` dead-zone at 90), `min` / `max`
+//! jump to the range bounds, `rotate` is the continuous-speed input, and
+//! `stop` centers a continuous servo (90 = no rotation). The generated sketch
+//! uses the Arduino `Servo` library: it `#include <Servo.h>`, declares a
+//! `Servo` object, `attach`es it in `setup()`, writes the center position, and
+//! binds each wired port — `value`/`rotate` as level writes, `min`/`max`/`stop`
+//! as pulses.
 
 use crate::codegen::emit::{NodeEmission, NodeToken};
-use crate::config::servo::ServoConfig;
+use crate::codegen::wire::{bind_pulses, extra_sources_note, NodeInputs};
+use crate::config::servo::{ServoConfig, ServoType};
 use crate::flow::FlowNode;
 
-/// Emit C++ for a Servo Node. `driver` is the C++ integer angle expression to
-/// write each loop, or `None` for an unconnected Servo which holds its center.
+/// The continuous-servo write for a `-1..=1` speed expression `v`: 90 inside
+/// the dead-zone, else `(v + 1) * 90` clamped to `0..=180` — a transcription
+/// of the runtime's `rotate`.
+fn rotate_expr(v: &str) -> String {
+    format!("((fabs({v}) < 0.05) ? 90 : (int)constrain(({v} + 1.0) * 90.0, 0.0, 180.0))")
+}
+
+/// Emit C++ for a Servo Node. An unwired Servo holds its center.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let config: ServoConfig = serde_json::from_value(node.data.clone()).unwrap_or_default();
     let pin = config.pin;
     let token = node.id_token();
@@ -23,6 +33,7 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
     let pin_var = format!("servo_{token}_pin");
     let (min, max) = (config.range.min, config.range.max);
     let center = (min + max) / 2;
+    let continuous = config.r#type == ServoType::Continuous;
 
     let mut e = NodeEmission {
         includes: vec!["#include <Servo.h>".to_string()],
@@ -38,16 +49,60 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
         ..NodeEmission::default()
     };
 
-    if let Some(expr) = driver {
-        e.loop_body
-            .push(format!("{obj}.write(constrain((int)({expr}), {min}, {max}));"));
+    // value: position (standard) or speed (continuous), a level write.
+    let value_sources = inputs.on("value");
+    if let Some(note) = extra_sources_note("value", value_sources) {
+        e.declarations.push(note);
     }
+    if let Some(source) = value_sources.first() {
+        let v = source.value.as_double_or("90.0");
+        let write = if continuous {
+            rotate_expr(&v)
+        } else {
+            format!("(int)constrain({v}, (double){min}, (double){max})")
+        };
+        e.loop_body.push(format!("{obj}.write({write});"));
+    }
+
+    // rotate: the explicit continuous-speed input (the runtime rejects it for
+    // standard servos, so a wired rotate on a standard servo is noted instead).
+    let rotate_sources = inputs.on("rotate");
+    if let Some(note) = extra_sources_note("rotate", rotate_sources) {
+        e.declarations.push(note);
+    }
+    if let Some(source) = rotate_sources.first() {
+        if continuous {
+            let v = source.value.as_double();
+            e.loop_body.push(format!("{obj}.write({});", rotate_expr(&v)));
+        } else {
+            e.declarations.push(
+                "// note: 'rotate' only works with continuous servos — edge ignored".to_string(),
+            );
+        }
+    }
+
+    // min / max / stop: pulse jumps. stop centers a continuous servo (90).
+    for (port, target) in [
+        ("min", min.to_string()),
+        ("max", max.to_string()),
+        ("stop", "90".to_string()),
+    ] {
+        let binding = bind_pulses(&format!("servo_{token}_{port}"), inputs.on(port));
+        e.declarations.extend(binding.declarations.iter().cloned());
+        e.loop_body.extend(binding.loop_lines.iter().cloned());
+        if let Some(any) = binding.any_fired() {
+            e.loop_body
+                .push(format!("if ({any}) {{ {obj}.write({target}); }}"));
+        }
+    }
+
     e
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::{CppExpr, SourceExpr};
     use crate::flow::Position;
     use serde_json::json;
 
@@ -60,10 +115,16 @@ mod tests {
         }
     }
 
+    fn on(port: &str, expr: CppExpr) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add(port, SourceExpr::level(expr));
+        inputs
+    }
+
     /// Scenario: A Servo Node pulls in its supporting library.
     #[test]
     fn servo_includes_library_and_declares_object() {
-        let e = emit(&servo("srv-1", json!({ "pin": 9 })), None);
+        let e = emit(&servo("srv-1", json!({ "pin": 9 })), &NodeInputs::default());
         assert!(e.includes.iter().any(|i| i.contains("Servo.h")), "missing Servo.h include");
         assert!(e.declarations.iter().any(|d| d.contains("Servo servo_srv_1")), "missing Servo object");
     }
@@ -71,20 +132,62 @@ mod tests {
     /// Scenario: A Servo Node pulls in its supporting library — attaches to pin.
     #[test]
     fn servo_attaches_to_its_pin() {
-        let e = emit(&servo("srv-1", json!({ "pin": 9 })), None);
+        let e = emit(&servo("srv-1", json!({ "pin": 9 })), &NodeInputs::default());
         assert!(e.declarations.iter().any(|d| d.contains("= 9;")));
         assert!(e.setup.iter().any(|s| s.contains(".attach(")), "missing attach call");
     }
 
     #[test]
     fn servo_centers_within_range() {
-        let e = emit(&servo("srv-1", json!({ "pin": 9, "range": { "min": 0, "max": 180 } })), None);
+        let e = emit(
+            &servo("srv-1", json!({ "pin": 9, "range": { "min": 0, "max": 180 } })),
+            &NodeInputs::default(),
+        );
         assert!(e.setup.iter().any(|s| s.contains(".write(90)")), "should center to 90");
+    }
+
+    #[test]
+    fn value_port_writes_clamped_position() {
+        let e = emit(
+            &servo("srv-1", json!({ "range": { "min": 10, "max": 170 } })),
+            &on("value", CppExpr::number("v")),
+        );
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("constrain(") && body.contains("10") && body.contains("170"), "{body}");
+    }
+
+    #[test]
+    fn continuous_servo_maps_speed_with_dead_zone() {
+        let e = emit(
+            &servo("srv-1", json!({ "type": "continuous" })),
+            &on("value", CppExpr::number("speed")),
+        );
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("fabs(") && body.contains("? 90 :"), "dead-zone at 90: {body}");
+        assert!(body.contains("+ 1.0) * 90.0"), "speed mapping: {body}");
+    }
+
+    #[test]
+    fn min_max_ports_jump_to_range_bounds() {
+        let mut inputs = NodeInputs::default();
+        inputs.add("min", SourceExpr::level(CppExpr::boolean("a")));
+        inputs.add("max", SourceExpr::level(CppExpr::boolean("b")));
+        let e = emit(&servo("srv-1", json!({ "range": { "min": 20, "max": 160 } })), &inputs);
+        let body = e.loop_body.join("\n");
+        assert!(body.contains(".write(20)"), "min jump: {body}");
+        assert!(body.contains(".write(160)"), "max jump: {body}");
+    }
+
+    #[test]
+    fn rotate_on_standard_servo_is_noted_not_emitted() {
+        let e = emit(&servo("srv-1", json!({})), &on("rotate", CppExpr::number("v")));
+        assert!(e.loop_body.is_empty(), "standard servo rejects rotate");
+        assert!(e.declarations.iter().any(|d| d.contains("continuous")));
     }
 
     #[test]
     fn servo_emits_deterministically() {
         let n = servo("srv-1", json!({ "pin": 9 }));
-        assert_eq!(emit(&n, None), emit(&n, None));
+        assert_eq!(emit(&n, &NodeInputs::default()), emit(&n, &NodeInputs::default()));
     }
 }

--- a/crates/microflow-core/src/codegen/output/stepper.rs
+++ b/crates/microflow-core/src/codegen/output/stepper.rs
@@ -1,23 +1,24 @@
 //! Stepper emitter — mirrors `runtime/output/stepper.rs`.
 //!
 //! The live Stepper drives a stepper motor through Firmata's `AccelStepper`
-//! protocol — configuring the interface (step/direction driver or 4-wire), max
-//! speed and acceleration, then moving to absolute/relative positions. The
-//! generated sketch uses the Arduino `AccelStepper` library directly: it
-//! `#include <AccelStepper.h>`, declares the motor with the matching interface
-//! and pins, sets max speed + acceleration in `setup()`, and — when wired from
-//! an upstream value — targets that position and calls `run()` every loop. `run()`
-//! steps at most once per call and returns immediately, so motion is fully
-//! non-blocking and other Nodes keep ticking.
+//! protocol; its ports are `value` (a *relative* move of that many steps, one
+//! move per received sample, zero-step samples skipped), `to` (an absolute
+//! target), `stop`, `zero` (reset the current position to 0), and `enable`
+//! (energize/de-energize the outputs, truthy ⇢ enabled). The generated sketch
+//! uses the Arduino `AccelStepper` library directly with the matching port
+//! semantics: `value` issues `move(steps)` on each new sample, `to` targets
+//! `moveTo(position)`, and `run()` is called every loop — it steps at most
+//! once per call and returns immediately, so motion is fully non-blocking and
+//! other Nodes keep ticking.
 
 use crate::codegen::emit::{cpp_double, NodeEmission, NodeToken};
+use crate::codegen::wire::{bind_pulses, extra_sources_note, NodeInputs};
 use crate::config::stepper::StepperConfig;
 use crate::flow::FlowNode;
 
-/// Emit C++ for a Stepper Node. `driver` is an optional target-position
-/// expression (absolute step count); `None` leaves the motor parked at zero.
+/// Emit C++ for a Stepper Node. Unwired, the motor parks at zero.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let token = node.id_token();
     let obj = format!("stepper_{token}");
     let config: StepperConfig = serde_json::from_value(node.data.clone()).unwrap_or_default();
@@ -40,10 +41,66 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
         ..NodeEmission::default()
     };
 
-    if let Some(expr) = driver {
-        // Non-blocking: moveTo sets the target, run() steps at most once per call.
-        e.loop_body.push(format!("{obj}.moveTo((long)({expr}));"));
+    // value: one relative move per new sample; zero steps are skipped.
+    let value_sources = inputs.on("value");
+    if let Some(note) = extra_sources_note("value", value_sources) {
+        e.declarations.push(note);
     }
+    if let Some(source) = value_sources.first() {
+        let binding = bind_pulses(&format!("stepper_{token}_value"), &value_sources[..1]);
+        e.declarations.extend(binding.declarations.iter().cloned());
+        e.loop_body.extend(binding.loop_lines.iter().cloned());
+        let fired = &binding.fired[0];
+        let steps = format!("stepper_{token}_steps");
+        e.loop_body.push(format!("if ({fired}) {{"));
+        e.loop_body
+            .push(format!("  long {steps} = (long)({});", source.value.as_double()));
+        e.loop_body
+            .push(format!("  if ({steps} != 0) {{ {obj}.move({steps}); }}"));
+        e.loop_body.push("}".to_string());
+    }
+
+    // to: an absolute target; a level write is idempotent, like repeated CMD_TO.
+    let to_sources = inputs.on("to");
+    if let Some(note) = extra_sources_note("to", to_sources) {
+        e.declarations.push(note);
+    }
+    if let Some(source) = to_sources.first() {
+        e.loop_body
+            .push(format!("{obj}.moveTo((long)({}));", source.value.as_double()));
+    }
+
+    // stop / zero: pulses.
+    let binding = bind_pulses(&format!("stepper_{token}_stop"), inputs.on("stop"));
+    e.declarations.extend(binding.declarations.iter().cloned());
+    e.loop_body.extend(binding.loop_lines.iter().cloned());
+    if let Some(any) = binding.any_fired() {
+        e.loop_body.push(format!("if ({any}) {{ {obj}.stop(); }}"));
+    }
+    let binding = bind_pulses(&format!("stepper_{token}_zero"), inputs.on("zero"));
+    e.declarations.extend(binding.declarations.iter().cloned());
+    e.loop_body.extend(binding.loop_lines.iter().cloned());
+    if let Some(any) = binding.any_fired() {
+        e.loop_body
+            .push(format!("if ({any}) {{ {obj}.setCurrentPosition(0); }}"));
+    }
+
+    // enable: energize per new sample's truthiness (runtime: n > 0).
+    let enable_sources = inputs.on("enable");
+    if let Some(note) = extra_sources_note("enable", enable_sources) {
+        e.declarations.push(note);
+    }
+    if let Some(source) = enable_sources.first() {
+        let binding = bind_pulses(&format!("stepper_{token}_enable"), &enable_sources[..1]);
+        e.declarations.extend(binding.declarations.iter().cloned());
+        e.loop_body.extend(binding.loop_lines.iter().cloned());
+        let fired = &binding.fired[0];
+        e.loop_body.push(format!(
+            "if ({fired}) {{ if ({}) {{ {obj}.enableOutputs(); }} else {{ {obj}.disableOutputs(); }} }}",
+            source.value.as_bool()
+        ));
+    }
+
     // The motor must keep stepping toward its target every loop, even when
     // unconnected (no-op until a target is set), so always emit run().
     e.loop_body.push(format!("{obj}.run();"));
@@ -53,6 +110,7 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::{CppExpr, SourceExpr};
     use crate::flow::Position;
     use serde_json::json;
 
@@ -65,37 +123,65 @@ mod tests {
         }
     }
 
+    fn on(port: &str, expr: CppExpr) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add(port, SourceExpr::level(expr));
+        inputs
+    }
+
     #[test]
     fn stepper_includes_library_and_declares_motor() {
-        let e = emit(&stepper("st-1", json!({})), None);
+        let e = emit(&stepper("st-1", json!({})), &NodeInputs::default());
         assert!(e.includes.iter().any(|i| i.contains("AccelStepper.h")));
         assert!(e.declarations.iter().any(|d| d.contains("AccelStepper stepper_st_1(AccelStepper::DRIVER, 2, 3)")));
     }
 
     #[test]
     fn stepper_sets_speed_and_acceleration() {
-        let e = emit(&stepper("st-1", json!({ "speed": 800, "acceleration": 200 })), None);
+        let e = emit(&stepper("st-1", json!({ "speed": 800, "acceleration": 200 })), &NodeInputs::default());
         assert!(e.setup.iter().any(|s| s.contains("setMaxSpeed(800")));
         assert!(e.setup.iter().any(|s| s.contains("setAcceleration(200")));
     }
 
     #[test]
-    fn stepper_targets_value_and_runs_non_blocking() {
-        let e = emit(&stepper("st-1", json!({})), Some("sensor_x_value"));
-        assert!(e.loop_body.iter().any(|l| l.contains("moveTo") && l.contains("sensor_x_value")));
+    fn value_port_issues_relative_moves_per_sample() {
+        let e = emit(&stepper("st-1", json!({})), &on("value", CppExpr::number("steps_src")));
+        let body = e.loop_body.join("\n");
+        assert!(body.contains(".move(stepper_st_1_steps)"), "relative move: {body}");
+        assert!(body.contains("!= 0"), "zero-step samples skipped: {body}");
+        assert!(body.contains("!="), "change-pulsed: {body}");
+    }
+
+    #[test]
+    fn to_port_targets_absolute_position() {
+        let e = emit(&stepper("st-1", json!({})), &on("to", CppExpr::number("target")));
+        assert!(e.loop_body.iter().any(|l| l.contains(".moveTo((long)(((double)(target))))")));
+    }
+
+    #[test]
+    fn stop_zero_and_enable_ports_are_bound() {
+        let mut inputs = NodeInputs::default();
+        inputs.add("stop", SourceExpr::level(CppExpr::boolean("halt")));
+        inputs.add("zero", SourceExpr::level(CppExpr::boolean("z")));
+        inputs.add("enable", SourceExpr::level(CppExpr::boolean("en")));
+        let e = emit(&stepper("st-1", json!({})), &inputs);
+        let body = e.loop_body.join("\n");
+        assert!(body.contains(".stop()"), "{body}");
+        assert!(body.contains(".setCurrentPosition(0)"), "{body}");
+        assert!(body.contains(".enableOutputs()") && body.contains(".disableOutputs()"), "{body}");
+    }
+
+    #[test]
+    fn stepper_runs_non_blocking_even_when_unconnected() {
+        let e = emit(&stepper("st-1", json!({})), &NodeInputs::default());
         assert!(e.loop_body.iter().any(|l| l.contains(".run()")));
         assert!(!e.loop_body.iter().any(|l| l.contains("delay(")), "stepper must not block");
     }
 
     #[test]
-    fn stepper_runs_even_when_unconnected() {
-        let e = emit(&stepper("st-1", json!({})), None);
-        assert!(e.loop_body.iter().any(|l| l.contains(".run()")));
-    }
-
-    #[test]
     fn stepper_emits_deterministically() {
         let n = stepper("st-1", json!({ "speed": 1000 }));
-        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+        let inputs = on("value", CppExpr::number("v"));
+        assert_eq!(emit(&n, &inputs), emit(&n, &inputs));
     }
 }

--- a/crates/microflow-core/src/codegen/parity.rs
+++ b/crates/microflow-core/src/codegen/parity.rs
@@ -2,20 +2,22 @@
 //!
 //! The live runtime (`runtime/`) and the codegen emitters (`codegen/`) are two
 //! implementations of the same Node semantics. The config single-source work
-//! (see `crate::config`) makes them share a Node's fields + defaults, but the
-//! *behavior* is still written twice — and codegen's single-driver value model
-//! deliberately cannot reproduce some multi-input runtime behaviors.
+//! (see `crate::config`) makes them share a Node's fields + defaults, and the
+//! handle-aware wiring model (`codegen/wire.rs`) gives codegen the same
+//! port/emit routing the runtime router uses — but the *behavior* is still
+//! written twice.
 //!
-//! These tests pin every operation variant (and Counter's ports) to an explicit,
-//! EXHAUSTIVE classification: a newly added operation or port won't compile until
-//! it is categorized here, forcing a conscious "emit it, or record the
-//! single-driver limitation" decision. They are the CI replacement for the prose
+//! These tests pin every operation variant (and Counter's ports) to an
+//! explicit, EXHAUSTIVE classification: a newly added operation or port won't
+//! compile until it is categorized here, forcing a conscious "emit it, or
+//! record the limitation" decision. They are the CI replacement for the prose
 //! docstrings that previously kept the two sides in sync by hand — the kind of
-//! hand-sync that let the Smooth attenuation invert silently (commit `e1e1eb9`)
-//! and that leaves Calculate's folds / Counter's extra ports unemittable today.
+//! hand-sync that let the Smooth attenuation invert silently (commit
+//! `e1e1eb9`).
 
 #[cfg(test)]
 mod tests {
+    use crate::codegen::wire::{CppExpr, NodeInputs, SourceExpr};
     use crate::flow::{FlowNode, Position};
     use serde_json::json;
 
@@ -28,31 +30,36 @@ mod tests {
         }
     }
 
-    /// How a codegen emitter treats one operation variant under the single-driver
-    /// model: it either emits operation-specific C++, or collapses to the
-    /// single-input form (the runtime's fold/aggregate reduced to one input).
-    enum Emit {
-        /// Emits C++ containing this distinctive token.
-        Distinct(&'static str),
-        /// Single-input passthrough (no operation-specific C++).
-        Passthrough,
+    /// Two numeric sources wired into one port — the shape that exercises a
+    /// fold's multi-input path.
+    fn two_inputs(port: &str) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add(port, SourceExpr::level(CppExpr::number("a")));
+        inputs.add(port, SourceExpr::level(CppExpr::number("b")));
+        inputs
     }
 
     // ---- Calculate: 11 arithmetic functions ------------------------------
 
-    /// EXHAUSTIVE over `CalculateFunction`. Add a variant → this won't compile
-    /// until you classify it. `ceil`/`floor`/`round` are unary math the Sketch
-    /// applies to one input; the eight folds reduce to their single input
-    /// (documented in `codegen/transformation/calculate.rs`).
-    fn calculate_kind(f: crate::config::calculate::CalculateFunction) -> Emit {
+    /// EXHAUSTIVE over `CalculateFunction`: the C++ token each variant's fold
+    /// must contain when two inputs are wired. Add a variant → this won't
+    /// compile until you name its emitted token.
+    fn calculate_token(f: crate::config::calculate::CalculateFunction) -> &'static str {
         use crate::config::calculate::CalculateFunction::{
             Add, Ceil, Divide, Floor, Max, Min, Modulo, Multiply, Pow, Round, Subtract,
         };
         match f {
-            Ceil => Emit::Distinct("ceil"),
-            Floor => Emit::Distinct("floor"),
-            Round => Emit::Distinct("round"),
-            Add | Subtract | Multiply | Divide | Modulo | Max | Min | Pow => Emit::Passthrough,
+            Add => " + ",
+            Subtract => " - ",
+            Multiply => " * ",
+            Divide => ") / ",
+            Modulo => "fmod(",
+            Max => "fmax(",
+            Min => "fmin(",
+            Pow => "pow(",
+            Ceil => "ceil(",
+            Floor => "floor(",
+            Round => "round(",
         }
     }
 
@@ -77,35 +84,31 @@ mod tests {
         for (wire, variant) in all {
             let e = crate::codegen::transformation::calculate::emit(
                 &node("Calculate", json!({ "function": wire })),
-                Some("drv"),
+                &two_inputs("value"),
             );
             let body = e.loop_body.join("\n");
-            match calculate_kind(variant) {
-                Emit::Distinct(tok) => {
-                    assert!(body.contains(tok), "Calculate `{wire}` must emit `{tok}`, got: {body}");
-                }
-                Emit::Passthrough => {
-                    for unary in ["ceil", "floor", "round"] {
-                        assert!(
-                            !body.contains(unary),
-                            "Calculate `{wire}` must pass its single input through, but emitted `{unary}`: {body}"
-                        );
-                    }
-                    assert!(body.contains("drv"), "Calculate `{wire}` must reference the driver: {body}");
-                }
-            }
+            let token = calculate_token(variant);
+            assert!(
+                body.contains(token),
+                "Calculate `{wire}` must emit its fold (`{token}`), got: {body}"
+            );
+            assert!(body.contains("(a)"), "Calculate `{wire}` must read its inputs: {body}");
         }
     }
 
     // ---- Gate: 6 boolean gates -------------------------------------------
 
-    /// EXHAUSTIVE over `GateType`. Inverting gates negate the single input;
-    /// pass-through gates forward it (`and`/`or`/`xor` all equal the lone input).
-    fn gate_kind(g: crate::config::gate::GateType) -> Emit {
+    /// EXHAUSTIVE over `GateType`: the truthy-count comparison each gate emits
+    /// over two wired inputs, transcribing the runtime's `passes_gate`.
+    fn gate_comparison(g: crate::config::gate::GateType) -> &'static str {
         use crate::config::gate::GateType::{And, Nand, Nor, Or, Xnor, Xor};
         match g {
-            Nand | Nor | Xnor => Emit::Distinct("!((bool)"),
-            And | Or | Xor => Emit::Passthrough,
+            And => "== 2",
+            Nand => "!= 2",
+            Or => "> 0",
+            Nor => "== 0",
+            Xor => "== 1",
+            Xnor => "!= 1",
         }
     }
 
@@ -123,52 +126,55 @@ mod tests {
         for (wire, variant) in all {
             let e = crate::codegen::transformation::gate::emit(
                 &node("Gate", json!({ "gate": wire })),
-                Some("drv"),
+                &two_inputs("value"),
             );
             let body = e.loop_body.join("\n");
-            match gate_kind(variant) {
-                Emit::Distinct(tok) => {
-                    assert!(body.contains(tok), "Gate `{wire}` must invert (`{tok}`), got: {body}");
-                }
-                Emit::Passthrough => assert!(
-                    body.contains("(bool)(drv)") && !body.contains("!((bool)"),
-                    "Gate `{wire}` must pass its single input through, got: {body}"
-                ),
-            }
+            assert!(
+                body.contains("true_count"),
+                "Gate `{wire}` must count truthy inputs, got: {body}"
+            );
+            let cmp = gate_comparison(variant);
+            assert!(
+                body.contains(cmp),
+                "Gate `{wire}` must compare the count (`{cmp}`), got: {body}"
+            );
         }
     }
 
-    // ---- Counter: 4 ports, single-driver model emits only `increment` ----
+    // ---- Counter: 4 ports, all bound by the handle-aware wiring ----------
 
-    /// Runtime `Counter` accepts four ports; the codegen single-driver model can
-    /// only pulse one. The other three are intentionally UNREACHABLE on-device
-    /// (generated C++ has no multi-port input binding). Gated on `runtime`
-    /// because `Component::ports()` lives there. A new/renamed port hits the
-    /// `other =>` arm and fails until classified.
+    /// Runtime `Counter` accepts four ports; the handle-aware wiring model
+    /// emits all of them. Gated on `runtime` because `Component::ports()`
+    /// lives there. A new/renamed port hits the `other =>` arm and fails
+    /// until classified.
     #[cfg(feature = "runtime")]
     #[test]
     fn counter_ports_classified_for_codegen() {
         use crate::runtime::{control::counter::Counter, Component};
 
-        let mut emittable = vec![];
-        for &port in Counter::ports() {
-            match port {
-                "increment" => emittable.push(port), // the driver pulse (rising edge)
-                "decrement" | "reset" | "set" => {}  // unreachable: single-driver model
-                other => panic!(
-                    "Counter port `{other}` is unclassified for codegen parity — emit it in \
-                     codegen/control/counter.rs, or record it as a single-driver limitation \
-                     in codegen/parity.rs."
-                ),
-            }
-        }
-        assert_eq!(emittable, ["increment"], "Counter's only codegen-emittable port is `increment`");
+        // (port, the C++ action its binding must emit).
+        let expected_action = |port: &str| match port {
+            "increment" => "+= 1.0",
+            "decrement" => "-= 1.0",
+            "reset" => "= 0.0",
+            "set" => "counter_p_count = ",
+            other => panic!(
+                "Counter port `{other}` is unclassified for codegen parity — bind it in \
+                 codegen/control/counter.rs and name its emitted action here."
+            ),
+        };
 
-        // And the emitter actually produces that increment.
-        let e = crate::codegen::control::counter::emit(&node("Counter", json!({})), Some("drv"));
-        assert!(
-            e.loop_body.join("\n").contains("+= 1.0"),
-            "Counter codegen must emit the rising-edge increment"
-        );
+        for &port in Counter::ports() {
+            let mut inputs = NodeInputs::default();
+            let expr = if port == "set" { CppExpr::number("v") } else { CppExpr::boolean("v") };
+            inputs.add(port, SourceExpr::level(expr));
+            let e = crate::codegen::control::counter::emit(&node("Counter", json!({})), &inputs);
+            let body = e.loop_body.join("\n");
+            let action = expected_action(port);
+            assert!(
+                body.contains(action),
+                "Counter port `{port}` must emit `{action}`, got: {body}"
+            );
+        }
     }
 }

--- a/crates/microflow-core/src/codegen/transformation/calculate.rs
+++ b/crates/microflow-core/src/codegen/transformation/calculate.rs
@@ -1,19 +1,22 @@
 //! Calculate emitter — mirrors `runtime/transformation/calculate.rs`.
 //!
-//! The live Calculate Node aggregates its inputs and applies an arithmetic
-//! function (`add`, `subtract`, `multiply`, `divide`, `modulo`, `max`, `min`,
-//! `pow`, `ceil`, `floor`, `round`), storing the result as its `Number` value.
+//! The live Calculate Node aggregates *all* inputs wired into its `value` port
+//! (the router delivers a snapshot `Array` because Calculate
+//! `aggregates_inputs`) and folds them with the configured arithmetic function,
+//! storing the result as its `Number` value. Non-numeric inputs (`String`
+//! sources) carry no number and are filtered out, exactly as
+//! `ComponentValue::as_number` returns `None` for them.
 //!
-//! The generated value-passing model feeds a single driver expression into each
-//! transformation Node (the wired source with the smallest id). With a single
-//! input the runtime's fold semantics reduce to: `subtract`/`divide`/`modulo`
-//! return `inputs[0]` unchanged (the fold body is skipped), `add`/`max`/`min`
-//! return the value itself, `multiply` returns the value, `pow` returns the
-//! value (fewer than two inputs), and `ceil`/`floor`/`round` apply their unary
-//! math. We emit the matching single-input C++ so the Sketch reproduces what
-//! the Flow Author observes when one signal drives the Node.
+//! The generated C++ reproduces the same folds over the wired source
+//! expressions: `add` sums, `subtract`/`divide`/`modulo` fold left from the
+//! first input (skipping zero divisors, like the runtime), `multiply` takes the
+//! product, `max`/`min` nest `fmax`/`fmin`, `pow` raises the first input to the
+//! second, and `ceil`/`floor`/`round` apply their unary math to the first
+//! input. With no numeric input wired the value stays at its `0.0` initial
+//! state (the runtime returns early on an empty input set).
 
 use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::codegen::wire::{CppType, NodeInputs};
 use crate::config::calculate::{CalculateConfig, CalculateFunction};
 use crate::flow::FlowNode;
 
@@ -23,27 +26,48 @@ pub fn value_var(node: &FlowNode) -> String {
     format!("calculate_{}_value", node.id_token())
 }
 
-/// Build the C++ expression for the configured function applied to a single
-/// input value `v` (the driver expression). Mirrors the runtime's single-input
-/// fold semantics.
-fn function_expr(function: CalculateFunction, v: &str) -> String {
+/// Build the C++ fold expression for the configured function over the numeric
+/// input expressions, mirroring the runtime's `check` fold semantics.
+fn fold_expr(function: CalculateFunction, inputs: &[String]) -> String {
+    let first = &inputs[0];
     match function {
-        // Unary math functions.
-        CalculateFunction::Ceil => format!("ceil({v})"),
-        CalculateFunction::Floor => format!("floor({v})"),
-        CalculateFunction::Round => format!("round({v})"),
-        // Multi-input folds collapse to the first input when only one is wired.
-        // `add`/`subtract`/`multiply`/`divide`/`modulo`/`max`/`min`/`pow` all
-        // yield the input value itself for a single input.
-        _ => format!("({v})"),
+        CalculateFunction::Add => format!("({})", inputs.join(" + ")),
+        CalculateFunction::Subtract => format!("({})", inputs.join(" - ")),
+        CalculateFunction::Multiply => format!("({})", inputs.join(" * ")),
+        // The runtime skips zero divisors (`acc` unchanged); the nested ternary
+        // reproduces that guard per divisor.
+        CalculateFunction::Divide => inputs[1..].iter().fold(first.clone(), |acc, v| {
+            format!("(({v} == 0.0) ? ({acc}) : (({acc}) / {v}))")
+        }),
+        CalculateFunction::Modulo => inputs[1..].iter().fold(first.clone(), |acc, v| {
+            format!("(({v} == 0.0) ? ({acc}) : fmod({acc}, {v}))")
+        }),
+        CalculateFunction::Max => nest("fmax", inputs),
+        CalculateFunction::Min => nest("fmin", inputs),
+        CalculateFunction::Pow => {
+            if inputs.len() >= 2 {
+                format!("pow({first}, {})", inputs[1])
+            } else {
+                format!("({first})")
+            }
+        }
+        // Unary math applies to the first input, like the runtime's inputs[0].
+        CalculateFunction::Ceil => format!("ceil({first})"),
+        CalculateFunction::Floor => format!("floor({first})"),
+        CalculateFunction::Round => format!("round({first})"),
     }
 }
 
-/// Emit C++ for a Calculate Node. `driver` is the C++ numeric expression that
-/// feeds the Node, or `None` when nothing is wired in (the runtime leaves the
-/// value at its `0.0` initial state).
+/// Nest a two-argument fold (`fmax`/`fmin`) over all inputs.
+fn nest(f: &str, inputs: &[String]) -> String {
+    inputs[1..]
+        .iter()
+        .fold(inputs[0].clone(), |acc, v| format!("{f}({acc}, {v})"))
+}
+
+/// Emit C++ for a Calculate Node over everything wired into its `value` port.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let var = value_var(node);
     let config: CalculateConfig = serde_json::from_value(node.data.clone()).unwrap_or_default();
 
@@ -52,8 +76,17 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
         ..NodeEmission::default()
     };
 
-    if let Some(expr) = driver {
-        let computed = function_expr(config.function, &format!("(double)({expr})"));
+    // String sources carry no number and are dropped, like the runtime's
+    // `filter_map(as_number)`.
+    let numeric: Vec<String> = inputs
+        .on("value")
+        .iter()
+        .filter(|s| s.value.ty != CppType::Str)
+        .map(|s| s.value.as_double())
+        .collect();
+
+    if !numeric.is_empty() {
+        let computed = fold_expr(config.function, &numeric);
         e.loop_body.push(format!("{var} = {computed};"));
     }
     e
@@ -62,6 +95,7 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::{CppExpr, SourceExpr};
     use crate::flow::Position;
     use serde_json::json;
 
@@ -74,39 +108,119 @@ mod tests {
         }
     }
 
+    fn wired(exprs: &[CppExpr]) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        for e in exprs {
+            inputs.add("value", SourceExpr::level(e.clone()));
+        }
+        inputs
+    }
+
     #[test]
     fn declares_output_variable() {
-        let e = emit(&calc("c-1", json!({ "function": "add" })), None);
+        let e = emit(&calc("c-1", json!({ "function": "add" })), &NodeInputs::default());
         assert!(e.declarations.iter().any(|d| d.contains("calculate_c_1_value")));
     }
 
     #[test]
-    fn add_passes_single_input_through() {
-        let e = emit(&calc("c-1", json!({ "function": "add" })), Some("sensor_s_1_value"));
-        assert!(e.loop_body.iter().any(|l| l.contains("sensor_s_1_value")));
-        assert!(!e.loop_body.iter().any(|l| l.contains("ceil")));
+    fn add_sums_all_wired_inputs() {
+        let e = emit(
+            &calc("c-1", json!({ "function": "add" })),
+            &wired(&[CppExpr::number("a"), CppExpr::number("b")]),
+        );
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("((double)(a)) + ((double)(b))"), "got: {body}");
     }
 
     #[test]
-    fn ceil_floor_round_emit_unary_math() {
+    fn subtract_folds_left_from_first_input() {
+        let e = emit(
+            &calc("c-1", json!({ "function": "subtract" })),
+            &wired(&[CppExpr::number("a"), CppExpr::number("b"), CppExpr::number("c")]),
+        );
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("- ((double)(b))") && body.contains("- ((double)(c))"), "got: {body}");
+    }
+
+    #[test]
+    fn divide_guards_zero_divisors_like_the_runtime() {
+        let e = emit(
+            &calc("c-1", json!({ "function": "divide" })),
+            &wired(&[CppExpr::number("a"), CppExpr::number("b")]),
+        );
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("== 0.0) ?"), "zero divisor keeps the accumulator: {body}");
+        assert!(body.contains("/ ((double)(b))"), "got: {body}");
+    }
+
+    #[test]
+    fn modulo_uses_fmod_with_zero_guard() {
+        let e = emit(
+            &calc("c-1", json!({ "function": "modulo" })),
+            &wired(&[CppExpr::number("a"), CppExpr::number("b")]),
+        );
+        assert!(e.loop_body.iter().any(|l| l.contains("fmod")));
+    }
+
+    #[test]
+    fn max_min_nest_fmax_fmin() {
+        let inputs = wired(&[CppExpr::number("a"), CppExpr::number("b"), CppExpr::number("c")]);
+        let max = emit(&calc("c-1", json!({ "function": "max" })), &inputs);
+        assert!(max.loop_body.iter().any(|l| l.contains("fmax(fmax(")));
+        let min = emit(&calc("c-1", json!({ "function": "min" })), &inputs);
+        assert!(min.loop_body.iter().any(|l| l.contains("fmin(fmin(")));
+    }
+
+    #[test]
+    fn pow_uses_first_two_inputs_or_passes_single_through() {
+        let two = emit(
+            &calc("c-1", json!({ "function": "pow" })),
+            &wired(&[CppExpr::number("a"), CppExpr::number("b")]),
+        );
+        assert!(two.loop_body.iter().any(|l| l.contains("pow(")));
+        let one = emit(&calc("c-1", json!({ "function": "pow" })), &wired(&[CppExpr::number("a")]));
+        assert!(!one.loop_body.iter().any(|l| l.contains("pow(")), "single input passes through");
+    }
+
+    #[test]
+    fn ceil_floor_round_emit_unary_math_on_first_input() {
         for func in ["ceil", "floor", "round"] {
-            let e = emit(&calc("c-1", json!({ "function": func })), Some("x"));
-            assert!(
-                e.loop_body.iter().any(|l| l.contains(func)),
-                "expected {func} call"
+            let e = emit(
+                &calc("c-1", json!({ "function": func })),
+                &wired(&[CppExpr::number("x"), CppExpr::number("y")]),
             );
+            let body = e.loop_body.join("\n");
+            assert!(body.contains(func), "expected {func} call");
+            assert!(!body.contains("(y)"), "unary math ignores extra inputs: {body}");
         }
     }
 
     #[test]
-    fn no_driver_emits_no_loop_body() {
-        let e = emit(&calc("c-1", json!({ "function": "add" })), None);
+    fn string_sources_are_filtered_out_like_the_runtime() {
+        let mut inputs = NodeInputs::default();
+        inputs.add("value", SourceExpr::level(CppExpr::text("msg")));
+        let e = emit(&calc("c-1", json!({ "function": "add" })), &inputs);
+        assert!(e.loop_body.is_empty(), "a string-only input set never computes");
+    }
+
+    #[test]
+    fn bool_sources_coerce_to_numbers() {
+        let mut inputs = NodeInputs::default();
+        inputs.add("value", SourceExpr::level(CppExpr::boolean("flag")));
+        let e = emit(&calc("c-1", json!({ "function": "add" })), &inputs);
+        assert!(e.loop_body.iter().any(|l| l.contains("(flag) ? 1.0 : 0.0")));
+    }
+
+    #[test]
+    fn no_input_emits_no_loop_body() {
+        let e = emit(&calc("c-1", json!({ "function": "add" })), &NodeInputs::default());
         assert!(e.loop_body.is_empty());
     }
 
     #[test]
     fn emits_deterministically() {
         let n = calc("c-1", json!({ "function": "multiply" }));
-        assert_eq!(emit(&n, Some("x")), emit(&n, Some("x")));
+        let inputs = wired(&[CppExpr::number("x"), CppExpr::number("y")]);
+        assert_eq!(emit(&n, &inputs), emit(&n, &inputs));
     }
 }

--- a/crates/microflow-core/src/codegen/transformation/compare.rs
+++ b/crates/microflow-core/src/codegen/transformation/compare.rs
@@ -1,19 +1,22 @@
 //! Compare emitter — mirrors `runtime/transformation/compare.rs`.
 //!
-//! The live Compare Node validates its input against a configured `validator`
-//! and `subValidator`, storing a `Bool` result:
+//! The live Compare Node validates the value arriving on its `value` port
+//! against a configured `validator` and `subValidator`, storing a `Bool`
+//! result:
 //! - `boolean` — truthiness of the input.
 //! - `number` — `greater than` / `less than` / (default) equals `number`.
 //! - `oddeven` — `odd` / (default) even, on the rounded input.
 //! - `range` — `outside` the `[min, max]` bounds / (default) strictly inside.
-//! - `text` — string predicates; not expressible against the numeric/boolean
-//!   driver expressions of the generated value model, so it emits the runtime's
-//!   `false` default for an empty match.
+//! - `text` — string predicates; not expressible against the on-device value
+//!   model, so it emits the runtime's `false` default for an empty match.
 //!
 //! The generated Sketch stores the boolean outcome in a `bool` variable that
 //! downstream Nodes read, reproducing the live comparison for the wired input.
+//! Compare does not aggregate: with several sources wired the generated code
+//! follows the first (deterministic) one and notes the rest.
 
 use crate::codegen::emit::{cpp_double, NodeEmission, NodeToken};
+use crate::codegen::wire::{extra_sources_note, CppExpr, NodeInputs};
 use crate::config::compare::{CompareConfig, CompareValidator};
 use crate::flow::FlowNode;
 
@@ -24,21 +27,22 @@ pub fn state_var(node: &FlowNode) -> String {
 }
 
 /// Build the C++ boolean expression for the configured comparison applied to
-/// the driver expression `v`.
-fn compare_expr(config: &CompareConfig, v: &str) -> String {
+/// the wired source expression, using its typed coercions.
+fn compare_expr(config: &CompareConfig, source: &CppExpr) -> String {
     let sub = config.sub_validator.as_str();
+    let v = source.as_double();
     match config.validator {
         CompareValidator::Number => {
             let n = cpp_double(config.number);
             match sub {
-                "greater than" => format!("((double)({v}) > {n})"),
-                "less than" => format!("((double)({v}) < {n})"),
-                _ => format!("((double)({v}) == {n})"),
+                "greater than" => format!("({v} > {n})"),
+                "less than" => format!("({v} < {n})"),
+                _ => format!("({v} == {n})"),
             }
         }
         CompareValidator::OddEven => {
             // Round to nearest integer first, matching `as i64` after `round()`.
-            let rounded = format!("((long)round((double)({v})))");
+            let rounded = format!("((long)round({v}))");
             match sub {
                 "odd" => format!("(({rounded} % 2) != 0)"),
                 _ => format!("(({rounded} % 2) == 0)"),
@@ -48,20 +52,20 @@ fn compare_expr(config: &CompareConfig, v: &str) -> String {
             let min = cpp_double(config.range.min);
             let max = cpp_double(config.range.max);
             match sub {
-                "outside" => format!("((double)({v}) < {min} || (double)({v}) > {max})"),
-                _ => format!("((double)({v}) > {min} && (double)({v}) < {max})"),
+                "outside" => format!("({v} < {min} || {v} > {max})"),
+                _ => format!("({v} > {min} && {v} < {max})"),
             }
         }
         CompareValidator::Text => "false".to_string(),
         // `boolean` (default): truthiness of the input.
-        CompareValidator::Boolean => format!("((bool)({v}))"),
+        CompareValidator::Boolean => source.as_bool(),
     }
 }
 
-/// Emit C++ for a Compare Node. `driver` is the wired input expression, or
-/// `None` when nothing is connected (the runtime leaves the result at `false`).
+/// Emit C++ for a Compare Node from its `value` port. With nothing connected
+/// the result stays `false` (the runtime never checks without a signal).
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let var = state_var(node);
     let config: CompareConfig = serde_json::from_value(node.data.clone()).unwrap_or_default();
 
@@ -70,8 +74,12 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
         ..NodeEmission::default()
     };
 
-    if let Some(expr) = driver {
-        let computed = compare_expr(&config, expr);
+    let sources = inputs.on("value");
+    if let Some(note) = extra_sources_note("value", sources) {
+        e.declarations.push(note);
+    }
+    if let Some(source) = sources.first() {
+        let computed = compare_expr(&config, &source.value);
         e.loop_body.push(format!("{var} = {computed};"));
     }
     e
@@ -80,6 +88,7 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::SourceExpr;
     use crate::flow::Position;
     use serde_json::json;
 
@@ -92,17 +101,26 @@ mod tests {
         }
     }
 
+    fn value_input(expr: CppExpr) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add("value", SourceExpr::level(expr));
+        inputs
+    }
+
     #[test]
     fn boolean_validator_uses_truthiness() {
-        let e = emit(&cmp("c-1", json!({ "validator": "boolean" })), Some("x"));
-        assert!(e.loop_body.iter().any(|l| l.contains("(bool)")));
+        let e = emit(
+            &cmp("c-1", json!({ "validator": "boolean" })),
+            &value_input(CppExpr::number("x")),
+        );
+        assert!(e.loop_body.iter().any(|l| l.contains("(x) != 0.0")));
     }
 
     #[test]
     fn number_greater_than_emits_comparison() {
         let e = emit(
             &cmp("c-1", json!({ "validator": "number", "subValidator": "greater than", "number": 5.0 })),
-            Some("v"),
+            &value_input(CppExpr::number("v")),
         );
         assert!(e.loop_body.iter().any(|l| l.contains("> 5.0")));
     }
@@ -111,21 +129,27 @@ mod tests {
     fn number_less_than_and_equals() {
         let lt = emit(
             &cmp("c-1", json!({ "validator": "number", "subValidator": "less than", "number": 2.0 })),
-            Some("v"),
+            &value_input(CppExpr::number("v")),
         );
         assert!(lt.loop_body.iter().any(|l| l.contains("< 2.0")));
         let eq = emit(
             &cmp("c-1", json!({ "validator": "number", "subValidator": "equal", "number": 3.0 })),
-            Some("v"),
+            &value_input(CppExpr::number("v")),
         );
         assert!(eq.loop_body.iter().any(|l| l.contains("== 3.0")));
     }
 
     #[test]
     fn oddeven_emits_modulo() {
-        let odd = emit(&cmp("c-1", json!({ "validator": "oddeven", "subValidator": "odd" })), Some("v"));
+        let odd = emit(
+            &cmp("c-1", json!({ "validator": "oddeven", "subValidator": "odd" })),
+            &value_input(CppExpr::number("v")),
+        );
         assert!(odd.loop_body.iter().any(|l| l.contains("% 2) != 0")));
-        let even = emit(&cmp("c-1", json!({ "validator": "oddeven", "subValidator": "even" })), Some("v"));
+        let even = emit(
+            &cmp("c-1", json!({ "validator": "oddeven", "subValidator": "even" })),
+            &value_input(CppExpr::number("v")),
+        );
         assert!(even.loop_body.iter().any(|l| l.contains("% 2) == 0")));
     }
 
@@ -133,19 +157,38 @@ mod tests {
     fn range_inside_and_outside() {
         let inside = emit(
             &cmp("c-1", json!({ "validator": "range", "range": { "min": 1.0, "max": 9.0 } })),
-            Some("v"),
+            &value_input(CppExpr::number("v")),
         );
         assert!(inside.loop_body.iter().any(|l| l.contains("> 1.0") && l.contains("< 9.0")));
         let outside = emit(
             &cmp("c-1", json!({ "validator": "range", "subValidator": "outside", "range": { "min": 1.0, "max": 9.0 } })),
-            Some("v"),
+            &value_input(CppExpr::number("v")),
         );
         assert!(outside.loop_body.iter().any(|l| l.contains("||")));
     }
 
     #[test]
-    fn no_driver_leaves_false() {
-        let e = emit(&cmp("c-1", json!({ "validator": "boolean" })), None);
+    fn bool_source_coerces_to_number_for_numeric_validators() {
+        let e = emit(
+            &cmp("c-1", json!({ "validator": "number", "number": 1.0 })),
+            &value_input(CppExpr::boolean("flag")),
+        );
+        assert!(e.loop_body.iter().any(|l| l.contains("(flag) ? 1.0 : 0.0")));
+    }
+
+    #[test]
+    fn extra_sources_are_noted_and_ignored() {
+        let mut inputs = NodeInputs::default();
+        inputs.add("value", SourceExpr::level(CppExpr::number("a")));
+        inputs.add("value", SourceExpr::level(CppExpr::number("b")));
+        let e = emit(&cmp("c-1", json!({ "validator": "boolean" })), &inputs);
+        assert!(e.declarations.iter().any(|d| d.contains("// note:")));
+        assert!(!e.loop_body.iter().any(|l| l.contains("(b)")), "only the first source drives");
+    }
+
+    #[test]
+    fn no_input_leaves_false() {
+        let e = emit(&cmp("c-1", json!({ "validator": "boolean" })), &NodeInputs::default());
         assert!(e.loop_body.is_empty());
         assert!(e.declarations.iter().any(|d| d.contains("= false;")));
     }
@@ -153,6 +196,7 @@ mod tests {
     #[test]
     fn emits_deterministically() {
         let n = cmp("c-1", json!({ "validator": "number", "number": 1.0 }));
-        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+        let inputs = value_input(CppExpr::number("v"));
+        assert_eq!(emit(&n, &inputs), emit(&n, &inputs));
     }
 }

--- a/crates/microflow-core/src/codegen/transformation/function.rs
+++ b/crates/microflow-core/src/codegen/transformation/function.rs
@@ -38,6 +38,7 @@
 //! identical input always yields identical output.
 
 use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::codegen::wire::{extra_sources_note, NodeInputs};
 use crate::flow::FlowNode;
 
 /// The C++ `double` variable holding this Function Node's latest result.
@@ -46,16 +47,17 @@ pub fn value_var(node: &FlowNode) -> String {
     format!("function_{}_value", node.id_token())
 }
 
-/// Emit C++ for a Function Node. `driver` is the C++ numeric expression that
-/// feeds the Node's `input`, or `None` when nothing is wired in (the runtime
-/// leaves the value at its `0.0` initial state).
+/// Emit C++ for a Function Node from its `trigger` port. The first wired
+/// source feeds the Node's `input` (extra sources are noted); with nothing
+/// wired in, the translated expression evaluates with `input = 0`, mirroring
+/// the runtime.
 ///
 /// On success the Node's value variable is assigned the translated expression
 /// in `loop()`. When the source falls outside the supported subset, a
 /// clearly-marked `// unsupported` comment is emitted instead and no assignment
 /// is produced — the value stays at `0.0`.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let var = value_var(node);
     let token = node.id_token();
     let mut e = NodeEmission {
@@ -69,9 +71,15 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
         .and_then(serde_json::Value::as_str)
         .unwrap_or("");
 
+    let sources = inputs.on("trigger");
+    if let Some(note) = extra_sources_note("trigger", sources) {
+        e.declarations.push(note);
+    }
     // The `input` C++ expression downstream code reads. With nothing wired in,
     // the runtime evaluates the JS with `input = 0`, so we mirror that.
-    let input_expr = driver.map_or_else(|| "0.0".to_string(), |d| format!("(double)({d})"));
+    let input_expr = sources
+        .first()
+        .map_or_else(|| "0.0".to_string(), |s| s.value.as_double());
 
     match translate(code, &input_expr) {
         Ok(cpp) => {
@@ -466,6 +474,14 @@ mod tests {
         }
     }
 
+    /// A single numeric source wired into the Function's `trigger` port.
+    fn trig(expr: &str) -> NodeInputs {
+        use crate::codegen::wire::{CppExpr, SourceExpr};
+        let mut inputs = NodeInputs::default();
+        inputs.add("trigger", SourceExpr::level(CppExpr::number(expr)));
+        inputs
+    }
+
     fn loop_line(e: &NodeEmission) -> String {
         e.loop_body.join("\n")
     }
@@ -476,7 +492,7 @@ mod tests {
 
     #[test]
     fn declares_output_variable() {
-        let e = emit(&func("fn-1", "return input;"), None);
+        let e = emit(&func("fn-1", "return input;"), &NodeInputs::default());
         assert!(e
             .declarations
             .iter()
@@ -493,7 +509,7 @@ mod tests {
 
     #[test]
     fn return_input_reads_driver() {
-        let e = emit(&func("fn-1", "return input;"), Some("sensor_s_value"));
+        let e = emit(&func("fn-1", "return input;"), &trig("sensor_s_value"));
         let body = loop_line(&e);
         assert!(body.contains("function_fn_1_value"));
         assert!(
@@ -505,7 +521,7 @@ mod tests {
 
     #[test]
     fn arithmetic_is_translated() {
-        let e = emit(&func("fn-1", "return input * 2 + 1;"), Some("x"));
+        let e = emit(&func("fn-1", "return input * 2 + 1;"), &trig("x"));
         let body = loop_line(&e);
         assert!(body.contains('*') && body.contains('+'), "got: {body}");
         assert!(!is_unsupported(&e));
@@ -514,7 +530,7 @@ mod tests {
     #[test]
     fn bindings_chain_into_return() {
         let code = "const a = input * 2;\nconst b = a + 3;\nreturn b;";
-        let e = emit(&func("fn-1", code), Some("x"));
+        let e = emit(&func("fn-1", code), &trig("x"));
         let body = loop_line(&e);
         // `b` resolves to `a + 3` which resolves to `input * 2`.
         assert!(body.contains('*'), "binding a inlined: {body}");
@@ -526,14 +542,14 @@ mod tests {
     fn default_code_passthrough_is_supported() {
         // The Node's default body: assigns input and returns it.
         let code = "const value = input;\nreturn value;";
-        let e = emit(&func("fn-1", code), Some("driver"));
+        let e = emit(&func("fn-1", code), &trig("driver"));
         assert!(loop_line(&e).contains("driver"));
         assert!(!is_unsupported(&e));
     }
 
     #[test]
     fn comparison_and_ternary_are_translated() {
-        let e = emit(&func("fn-1", "return input > 10 ? 1 : 0;"), Some("x"));
+        let e = emit(&func("fn-1", "return input > 10 ? 1 : 0;"), &trig("x"));
         let body = loop_line(&e);
         assert!(
             body.contains('>') && body.contains('?') && body.contains(':'),
@@ -544,13 +560,13 @@ mod tests {
 
     #[test]
     fn logical_operators_are_translated() {
-        let e = emit(&func("fn-1", "return input > 0 && input < 100;"), Some("x"));
+        let e = emit(&func("fn-1", "return input > 0 && input < 100;"), &trig("x"));
         assert!(loop_line(&e).contains("&&"));
     }
 
     #[test]
     fn strict_equality_collapses_to_cpp_equality() {
-        let e = emit(&func("fn-1", "return input === 5 ? 1 : 0;"), Some("x"));
+        let e = emit(&func("fn-1", "return input === 5 ? 1 : 0;"), &trig("x"));
         let body = loop_line(&e);
         assert!(body.contains("=="), "got: {body}");
         assert!(!body.contains("==="), "=== must collapse to ==, got: {body}");
@@ -558,13 +574,13 @@ mod tests {
 
     #[test]
     fn math_helpers_are_translated() {
-        let e = emit(&func("fn-1", "return Math.max(input, 0);"), Some("x"));
+        let e = emit(&func("fn-1", "return Math.max(input, 0);"), &trig("x"));
         assert!(loop_line(&e).contains("max("), "Math.max → max");
     }
 
     #[test]
     fn unary_negation_is_translated() {
-        let e = emit(&func("fn-1", "return -input;"), Some("x"));
+        let e = emit(&func("fn-1", "return -input;"), &trig("x"));
         assert!(loop_line(&e).contains('-'));
     }
 
@@ -573,7 +589,7 @@ mod tests {
     #[test]
     fn loop_construct_is_marked_unsupported() {
         let code = "let s = 0;\nfor (let i = 0; i < 10; i++) { s = s + i; }\nreturn s;";
-        let e = emit(&func("fn-1", code), Some("x"));
+        let e = emit(&func("fn-1", code), &trig("x"));
         assert!(
             e.declarations
                 .iter()
@@ -587,35 +603,35 @@ mod tests {
 
     #[test]
     fn string_literal_is_marked_unsupported() {
-        let e = emit(&func("fn-1", "return \"hello\";"), Some("x"));
+        let e = emit(&func("fn-1", "return \"hello\";"), &trig("x"));
         assert!(is_unsupported(&e));
         assert!(e.loop_body.is_empty());
     }
 
     #[test]
     fn template_slot_is_marked_unsupported() {
-        let e = emit(&func("fn-1", "return input + {{gain}};"), Some("x"));
+        let e = emit(&func("fn-1", "return input + {{gain}};"), &trig("x"));
         assert!(is_unsupported(&e));
         assert!(e.loop_body.is_empty());
     }
 
     #[test]
     fn unknown_call_is_marked_unsupported() {
-        let e = emit(&func("fn-1", "return parseInt(input);"), Some("x"));
+        let e = emit(&func("fn-1", "return parseInt(input);"), &trig("x"));
         assert!(is_unsupported(&e));
         assert!(e.loop_body.is_empty());
     }
 
     #[test]
     fn missing_return_is_marked_unsupported() {
-        let e = emit(&func("fn-1", "const a = input;"), Some("x"));
+        let e = emit(&func("fn-1", "const a = input;"), &trig("x"));
         assert!(is_unsupported(&e));
         assert!(e.loop_body.is_empty());
     }
 
     #[test]
     fn unknown_identifier_is_marked_unsupported() {
-        let e = emit(&func("fn-1", "return undeclared + 1;"), Some("x"));
+        let e = emit(&func("fn-1", "return undeclared + 1;"), &trig("x"));
         assert!(is_unsupported(&e));
         assert!(e.loop_body.is_empty());
     }
@@ -623,7 +639,7 @@ mod tests {
     #[test]
     fn no_driver_uses_zero_input() {
         // With nothing wired in the runtime evaluates with input = 0.
-        let e = emit(&func("fn-1", "return input + 1;"), None);
+        let e = emit(&func("fn-1", "return input + 1;"), &NodeInputs::default());
         let body = loop_line(&e);
         assert!(body.contains("0.0"), "input defaults to 0.0, got: {body}");
         assert!(!is_unsupported(&e));
@@ -632,12 +648,12 @@ mod tests {
     #[test]
     fn emits_deterministically() {
         let n = func("fn-1", "return input * 2 + 1;");
-        assert_eq!(emit(&n, Some("x")), emit(&n, Some("x")));
+        assert_eq!(emit(&n, &trig("x")), emit(&n, &trig("x")));
     }
 
     #[test]
     fn unsupported_is_deterministic() {
         let n = func("fn-1", "for (;;) {}\nreturn 1;");
-        assert_eq!(emit(&n, Some("x")), emit(&n, Some("x")));
+        assert_eq!(emit(&n, &trig("x")), emit(&n, &trig("x")));
     }
 }

--- a/crates/microflow-core/src/codegen/transformation/gate.rs
+++ b/crates/microflow-core/src/codegen/transformation/gate.rs
@@ -114,10 +114,10 @@ mod tests {
     #[test]
     fn xor_xnor_compare_against_one() {
         let inputs = wired(&[CppExpr::boolean("a"), CppExpr::boolean("b"), CppExpr::boolean("c")]);
-        let xor = emit(&gate("g-1", json!({ "gate": "xor" })), &inputs);
-        assert!(xor.loop_body.iter().any(|l| l.contains("== 1")));
-        let xnor = emit(&gate("g-1", json!({ "gate": "xnor" })), &inputs);
-        assert!(xnor.loop_body.iter().any(|l| l.contains("!= 1")));
+        let one_hot = emit(&gate("g-1", json!({ "gate": "xor" })), &inputs);
+        assert!(one_hot.loop_body.iter().any(|l| l.contains("== 1")));
+        let not_one_hot = emit(&gate("g-1", json!({ "gate": "xnor" })), &inputs);
+        assert!(not_one_hot.loop_body.iter().any(|l| l.contains("!= 1")));
     }
 
     #[test]

--- a/crates/microflow-core/src/codegen/transformation/gate.rs
+++ b/crates/microflow-core/src/codegen/transformation/gate.rs
@@ -1,16 +1,17 @@
 //! Gate emitter — mirrors `runtime/transformation/gate.rs`.
 //!
-//! The live Gate Node counts the truthy inputs and applies a boolean gate
-//! (`and`, `nand`, `or`, `xor`, `nor`, `xnor`) over `true_count` vs `total`.
+//! The live Gate Node receives a snapshot of *all* inputs wired into its
+//! `value` port (it `aggregates_inputs`), counts the truthy ones, and applies
+//! the configured boolean gate over `true_count` vs `total`:
+//! `and` ⇢ `true_count == total`, `nand` ⇢ `!=  total`, `or` ⇢ `> 0`,
+//! `nor` ⇢ `== 0`, `xor` ⇢ `== 1`, `xnor` ⇢ `!= 1`.
 //!
-//! The generated value model feeds a single boolean driver into the Node
-//! (`total == 1`), so the gates collapse to: `and`/`or`/`xor` pass the input
-//! through (`true_count == total`, `> 0`, and `== 1` all equal the single
-//! input), while `nand`/`nor`/`xnor` invert it. We emit the matching
-//! single-input pass-through / inverting logic into a `bool` variable that
-//! downstream Nodes read, reproducing the live gate for the wired signal.
+//! The generated C++ reproduces exactly that: a truthy count over every wired
+//! source expression compared per the gate, stored into a `bool` variable that
+//! downstream Nodes read.
 
 use crate::codegen::emit::{NodeEmission, NodeToken};
+use crate::codegen::wire::NodeInputs;
 use crate::config::gate::{GateConfig, GateType};
 use crate::flow::FlowNode;
 
@@ -20,22 +21,25 @@ pub fn state_var(node: &FlowNode) -> String {
     format!("gate_{}_result", node.id_token())
 }
 
-/// Build the single-input C++ boolean expression for the configured gate over
-/// the driver expression `v`.
-fn gate_expr(gate: GateType, v: &str) -> String {
+/// The comparison of the truthy count `tc` against `total` for the configured
+/// gate — a direct transcription of the runtime's `passes_gate`.
+fn gate_comparison(gate: GateType, tc: &str, total: usize) -> String {
     match gate {
-        // Inverting gates for a single input.
-        GateType::Nand | GateType::Nor | GateType::Xnor => format!("(!((bool)({v})))"),
-        // Pass-through gates for a single input (and / or / xor).
-        _ => format!("((bool)({v}))"),
+        GateType::And => format!("({tc} == {total})"),
+        GateType::Nand => format!("({tc} != {total})"),
+        GateType::Or => format!("({tc} > 0)"),
+        GateType::Nor => format!("({tc} == 0)"),
+        GateType::Xor => format!("({tc} == 1)"),
+        GateType::Xnor => format!("({tc} != 1)"),
     }
 }
 
-/// Emit C++ for a Gate Node. `driver` is the wired boolean input, or `None`
-/// when nothing is connected (the runtime leaves the result at `false` because
-/// `check` is skipped for an empty input set).
+/// Emit C++ for a Gate Node over everything wired into its `value` port. With
+/// nothing connected the result stays `false` (the runtime skips `check` for
+/// an empty input set).
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
+    let token = node.id_token();
     let var = state_var(node);
     let config: GateConfig = serde_json::from_value(node.data.clone()).unwrap_or_default();
 
@@ -44,16 +48,29 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
         ..NodeEmission::default()
     };
 
-    if let Some(expr) = driver {
-        let computed = gate_expr(config.gate, expr);
-        e.loop_body.push(format!("{var} = {computed};"));
+    let sources = inputs.on("value");
+    if sources.is_empty() {
+        return e;
     }
+
+    let count_terms: Vec<String> = sources
+        .iter()
+        .map(|s| format!("({} ? 1 : 0)", s.value.as_bool()))
+        .collect();
+    let tc = format!("gate_{token}_true_count");
+    e.loop_body
+        .push(format!("int {tc} = {};", count_terms.join(" + ")));
+    e.loop_body.push(format!(
+        "{var} = {};",
+        gate_comparison(config.gate, &tc, sources.len())
+    ));
     e
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::{CppExpr, SourceExpr};
     use crate::flow::Position;
     use serde_json::json;
 
@@ -66,31 +83,64 @@ mod tests {
         }
     }
 
-    #[test]
-    fn and_or_xor_pass_through() {
-        for g in ["and", "or", "xor"] {
-            let e = emit(&gate("g-1", json!({ "gate": g })), Some("x"));
-            assert!(
-                e.loop_body.iter().any(|l| l.contains("(bool)(x)") && !l.contains("!(")),
-                "gate {g} should pass through"
-            );
+    fn wired(exprs: &[CppExpr]) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        for e in exprs {
+            inputs.add("value", SourceExpr::level(e.clone()));
         }
+        inputs
     }
 
     #[test]
-    fn nand_nor_xnor_invert() {
-        for g in ["nand", "nor", "xnor"] {
-            let e = emit(&gate("g-1", json!({ "gate": g })), Some("x"));
-            assert!(
-                e.loop_body.iter().any(|l| l.contains("!((bool)(x))")),
-                "gate {g} should invert"
-            );
-        }
+    fn and_requires_every_input_truthy() {
+        let e = emit(
+            &gate("g-1", json!({ "gate": "and" })),
+            &wired(&[CppExpr::boolean("a"), CppExpr::boolean("b")]),
+        );
+        let body = e.loop_body.join("\n");
+        assert!(body.contains("((a) ? 1 : 0) + ((b) ? 1 : 0)"), "got: {body}");
+        assert!(body.contains("== 2"), "and compares count to total: {body}");
     }
 
     #[test]
-    fn no_driver_leaves_false() {
-        let e = emit(&gate("g-1", json!({ "gate": "and" })), None);
+    fn or_nor_compare_against_zero() {
+        let inputs = wired(&[CppExpr::boolean("a"), CppExpr::boolean("b")]);
+        let or = emit(&gate("g-1", json!({ "gate": "or" })), &inputs);
+        assert!(or.loop_body.iter().any(|l| l.contains("> 0")));
+        let nor = emit(&gate("g-1", json!({ "gate": "nor" })), &inputs);
+        assert!(nor.loop_body.iter().any(|l| l.contains("== 0")));
+    }
+
+    #[test]
+    fn xor_xnor_compare_against_one() {
+        let inputs = wired(&[CppExpr::boolean("a"), CppExpr::boolean("b"), CppExpr::boolean("c")]);
+        let xor = emit(&gate("g-1", json!({ "gate": "xor" })), &inputs);
+        assert!(xor.loop_body.iter().any(|l| l.contains("== 1")));
+        let xnor = emit(&gate("g-1", json!({ "gate": "xnor" })), &inputs);
+        assert!(xnor.loop_body.iter().any(|l| l.contains("!= 1")));
+    }
+
+    #[test]
+    fn nand_inverts_the_all_truthy_test() {
+        let e = emit(
+            &gate("g-1", json!({ "gate": "nand" })),
+            &wired(&[CppExpr::boolean("x")]),
+        );
+        assert!(e.loop_body.iter().any(|l| l.contains("!= 1")), "single-input nand is a NOT");
+    }
+
+    #[test]
+    fn numeric_sources_use_truthiness() {
+        let e = emit(
+            &gate("g-1", json!({ "gate": "and" })),
+            &wired(&[CppExpr::number("sensor_v")]),
+        );
+        assert!(e.loop_body.iter().any(|l| l.contains("(sensor_v) != 0.0")));
+    }
+
+    #[test]
+    fn no_input_leaves_false() {
+        let e = emit(&gate("g-1", json!({ "gate": "and" })), &NodeInputs::default());
         assert!(e.loop_body.is_empty());
         assert!(e.declarations.iter().any(|d| d.contains("= false;")));
     }
@@ -98,6 +148,7 @@ mod tests {
     #[test]
     fn emits_deterministically() {
         let n = gate("g-1", json!({ "gate": "nand" }));
-        assert_eq!(emit(&n, Some("x")), emit(&n, Some("x")));
+        let inputs = wired(&[CppExpr::boolean("x")]);
+        assert_eq!(emit(&n, &inputs), emit(&n, &inputs));
     }
 }

--- a/crates/microflow-core/src/codegen/transformation/range_map.rs
+++ b/crates/microflow-core/src/codegen/transformation/range_map.rs
@@ -16,6 +16,7 @@
 //! We emit the same arithmetic into a `double` variable downstream Nodes read.
 
 use crate::codegen::emit::{cpp_double, NodeEmission, NodeToken};
+use crate::codegen::wire::{extra_sources_note, NodeInputs};
 use crate::config::range_map::RangeMapConfig;
 use crate::flow::FlowNode;
 
@@ -25,10 +26,13 @@ pub fn value_var(node: &FlowNode) -> String {
     format!("range_map_{}_value", node.id_token())
 }
 
-/// Emit C++ for a `RangeMap` Node. `driver` is the wired numeric input, or
-/// `None` when nothing is connected (the runtime leaves the value at `0.0`).
+/// Emit C++ for a `RangeMap` Node from its `value` port. With nothing
+/// connected the value stays at `0.0` (the runtime never maps without a
+/// signal). `RangeMap` does not aggregate: extra sources are noted and the
+/// first drives the map. String sources are parsed like the runtime's
+/// `String(s) => s.parse().unwrap_or(0.0)` arm.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let var = value_var(node);
     // Mirror `Range` defaults: from 0..1023, to 0..1023.
     let config: RangeMapConfig = serde_json::from_value(node.data.clone()).unwrap_or_default();
@@ -47,9 +51,14 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
         ..NodeEmission::default()
     };
 
-    if let Some(expr) = driver {
+    let sources = inputs.on("value");
+    if let Some(note) = extra_sources_note("value", sources) {
+        e.declarations.push(note);
+    }
+    if let Some(source) = sources.first() {
+        let input = source.value.as_double_parsing();
         let mapped = format!(
-            "(((double)({expr}) - {in_min}) * ({out_max} - {out_min}) / ({in_max} - {in_min}) + {out_min})"
+            "(({input} - {in_min}) * ({out_max} - {out_min}) / ({in_max} - {in_min}) + {out_min})"
         );
         e.loop_body
             .push(format!("{var} = round(({mapped}) * {factor}) / {factor};"));
@@ -60,6 +69,7 @@ pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::{CppExpr, SourceExpr};
     use crate::flow::Position;
     use serde_json::json;
 
@@ -72,9 +82,15 @@ mod tests {
         }
     }
 
+    fn value_input(expr: CppExpr) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add("value", SourceExpr::level(expr));
+        inputs
+    }
+
     #[test]
     fn declares_output_variable() {
-        let e = emit(&rm("r-1", json!({})), None);
+        let e = emit(&rm("r-1", json!({})), &NodeInputs::default());
         assert!(e.declarations.iter().any(|d| d.contains("range_map_r_1_value")));
     }
 
@@ -82,7 +98,7 @@ mod tests {
     fn emits_linear_remap_math() {
         let e = emit(
             &rm("r-1", json!({ "from": { "min": 0.0, "max": 1023.0 }, "to": { "min": 0.0, "max": 255.0 } })),
-            Some("sensor_s_1_value"),
+            &value_input(CppExpr::number("sensor_s_1_value")),
         );
         let body = e.loop_body.join("\n");
         assert!(body.contains("sensor_s_1_value"));
@@ -95,7 +111,7 @@ mod tests {
     fn small_output_span_uses_decimal_precision() {
         let e = emit(
             &rm("r-1", json!({ "from": { "min": 0.0, "max": 100.0 }, "to": { "min": 0.0, "max": 5.0 } })),
-            Some("v"),
+            &value_input(CppExpr::number("v")),
         );
         assert!(e.loop_body.iter().any(|l| l.contains("* 10.0") && l.contains("/ 10.0")));
     }
@@ -104,20 +120,36 @@ mod tests {
     fn large_output_span_uses_whole_numbers() {
         let e = emit(
             &rm("r-1", json!({ "from": { "min": 0.0, "max": 100.0 }, "to": { "min": 0.0, "max": 255.0 } })),
-            Some("v"),
+            &value_input(CppExpr::number("v")),
         );
         assert!(e.loop_body.iter().any(|l| l.contains("* 1.0") && l.contains("/ 1.0")));
     }
 
     #[test]
-    fn no_driver_emits_no_loop_body() {
-        let e = emit(&rm("r-1", json!({})), None);
+    fn string_sources_parse_like_the_runtime() {
+        let e = emit(&rm("r-1", json!({})), &value_input(CppExpr::text("msg")));
+        assert!(e.loop_body.iter().any(|l| l.contains(".toFloat()")));
+    }
+
+    #[test]
+    fn extra_sources_are_noted() {
+        let mut inputs = NodeInputs::default();
+        inputs.add("value", SourceExpr::level(CppExpr::number("a")));
+        inputs.add("value", SourceExpr::level(CppExpr::number("b")));
+        let e = emit(&rm("r-1", json!({})), &inputs);
+        assert!(e.declarations.iter().any(|d| d.contains("// note:")));
+    }
+
+    #[test]
+    fn no_input_emits_no_loop_body() {
+        let e = emit(&rm("r-1", json!({})), &NodeInputs::default());
         assert!(e.loop_body.is_empty());
     }
 
     #[test]
     fn emits_deterministically() {
         let n = rm("r-1", json!({ "to": { "min": 0.0, "max": 255.0 } }));
-        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+        let inputs = value_input(CppExpr::number("v"));
+        assert_eq!(emit(&n, &inputs), emit(&n, &inputs));
     }
 }

--- a/crates/microflow-core/src/codegen/transformation/smooth.rs
+++ b/crates/microflow-core/src/codegen/transformation/smooth.rs
@@ -17,6 +17,7 @@
 //! `double` is read by downstream Nodes.
 
 use crate::codegen::emit::{cpp_double, NodeEmission, NodeToken};
+use crate::codegen::wire::{extra_sources_note, NodeInputs};
 use crate::config::smooth::{SmoothConfig, SmoothType};
 use crate::flow::FlowNode;
 
@@ -26,21 +27,30 @@ pub fn value_var(node: &FlowNode) -> String {
     format!("smooth_{}_value", node.id_token())
 }
 
-/// Emit C++ for a Smooth Node. `driver` is the wired numeric input, or `None`
-/// when nothing is connected (the runtime leaves the value at `0.0`).
+/// Emit C++ for a Smooth Node from its `value` port. With nothing connected
+/// the value stays at `0.0` (the runtime never smooths without a signal).
+/// Smooth does not aggregate: extra sources are noted and the first drives.
 ///
 /// Deserializes the shared [`SmoothConfig`] from `node.data`, so the fields and
 /// defaults are exactly the ones the live runtime uses — no re-typed literals.
 #[must_use]
-pub fn emit(node: &FlowNode, driver: Option<&str>) -> NodeEmission {
+pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     let token = node.id_token();
     let var = value_var(node);
     let config: SmoothConfig = serde_json::from_value(node.data.clone()).unwrap_or_default();
 
-    match config.smooth_type {
-        SmoothType::MovingAverage => moving_average(&token, &var, config.window_size, driver),
-        SmoothType::Smooth => exponential(&var, config.attenuation, driver),
+    let sources = inputs.on("value");
+    let driver = sources.first().map(|s| s.value.as_double());
+    let mut e = match config.smooth_type {
+        SmoothType::MovingAverage => {
+            moving_average(&token, &var, config.window_size, driver.as_deref())
+        }
+        SmoothType::Smooth => exponential(&var, config.attenuation, driver.as_deref()),
+    };
+    if let Some(note) = extra_sources_note("value", sources) {
+        e.declarations.push(note);
     }
+    e
 }
 
 /// Exponential smoothing: a single persistent running value.
@@ -58,8 +68,8 @@ fn exponential(var: &str, attenuation: f64, driver: Option<&str>) -> NodeEmissio
         let seeded = format!("{var}_seeded");
         e.declarations.push(format!("bool {seeded} = false;"));
         e.loop_body.push(format!(
-            "if (!{seeded}) {{ {var} = (double)({expr}); {seeded} = true; }} \
-             else {{ {var} = (1.0 - {attenuation}) * (double)({expr}) + {attenuation} * {var}; }}"
+            "if (!{seeded}) {{ {var} = {expr}; {seeded} = true; }} \
+             else {{ {var} = (1.0 - {attenuation}) * {expr} + {attenuation} * {var}; }}"
         ));
     }
     e
@@ -85,7 +95,7 @@ fn moving_average(token: &str, var: &str, window_size: usize, driver: Option<&st
     };
 
     if let Some(expr) = driver {
-        e.loop_body.push(format!("{buf}[{idx}] = (double)({expr});"));
+        e.loop_body.push(format!("{buf}[{idx}] = {expr};"));
         e.loop_body.push(format!("{idx} = ({idx} + 1) % {window};"));
         e.loop_body
             .push(format!("if ({count} < {window}) {{ {count}++; }}"));
@@ -101,6 +111,7 @@ fn moving_average(token: &str, var: &str, window_size: usize, driver: Option<&st
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codegen::wire::{CppExpr, SourceExpr};
     use crate::flow::Position;
     use serde_json::json;
 
@@ -113,9 +124,18 @@ mod tests {
         }
     }
 
+    fn value_input(expr: CppExpr) -> NodeInputs {
+        let mut inputs = NodeInputs::default();
+        inputs.add("value", SourceExpr::level(expr));
+        inputs
+    }
+
     #[test]
     fn exponential_persists_running_value() {
-        let e = emit(&smooth("s-1", json!({ "type": "smooth", "attenuation": 0.9 })), Some("v"));
+        let e = emit(
+            &smooth("s-1", json!({ "type": "smooth", "attenuation": 0.9 })),
+            &value_input(CppExpr::number("v")),
+        );
         // Decl is a single persistent double; loop updates it from itself.
         assert!(e.declarations.iter().any(|d| d.contains("smooth_s_1_value")));
         assert!(e.loop_body.iter().any(|l| l.contains("0.9") && l.contains("smooth_s_1_value")));
@@ -125,7 +145,7 @@ mod tests {
     fn moving_average_uses_ring_buffer() {
         let e = emit(
             &smooth("s-1", json!({ "type": "movingAverage", "windowSize": 5 })),
-            Some("v"),
+            &value_input(CppExpr::number("v")),
         );
         assert!(e.declarations.iter().any(|d| d.contains("smooth_s_1_window[5]")));
         assert!(e.loop_body.iter().any(|l| l.contains("% 5")));
@@ -136,20 +156,20 @@ mod tests {
     fn moving_average_guards_zero_window() {
         let e = emit(
             &smooth("s-1", json!({ "type": "movingAverage", "windowSize": 0 })),
-            Some("v"),
+            &value_input(CppExpr::number("v")),
         );
         assert!(e.declarations.iter().any(|d| d.contains("smooth_s_1_window[1]")));
     }
 
     #[test]
     fn default_type_is_exponential() {
-        let e = emit(&smooth("s-1", json!({})), Some("v"));
+        let e = emit(&smooth("s-1", json!({})), &value_input(CppExpr::number("v")));
         assert!(e.loop_body.iter().any(|l| l.contains("0.995")));
     }
 
     #[test]
-    fn no_driver_emits_no_loop_body() {
-        let e = emit(&smooth("s-1", json!({})), None);
+    fn no_input_emits_no_loop_body() {
+        let e = emit(&smooth("s-1", json!({})), &NodeInputs::default());
         assert!(e.loop_body.is_empty());
         assert!(e.declarations.iter().any(|d| d.contains("= 0.0;")));
     }
@@ -157,6 +177,7 @@ mod tests {
     #[test]
     fn emits_deterministically() {
         let n = smooth("s-1", json!({ "type": "movingAverage", "windowSize": 3 }));
-        assert_eq!(emit(&n, Some("v")), emit(&n, Some("v")));
+        let inputs = value_input(CppExpr::number("v"));
+        assert_eq!(emit(&n, &inputs), emit(&n, &inputs));
     }
 }

--- a/crates/microflow-core/src/codegen/validate.rs
+++ b/crates/microflow-core/src/codegen/validate.rs
@@ -32,7 +32,7 @@
 //! clock, no IO, deterministic ordering (Nodes in `id` order).
 
 use crate::codegen::board::{BoardCapability, BoardTarget};
-use crate::codegen::emit::pin_or_default;
+use crate::codegen::emit::{pin_or_default, NodeToken};
 use crate::flow::{FlowNode, FlowUpdate};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -97,6 +97,42 @@ pub fn validate(flow: &FlowUpdate, target: &BoardTarget) -> Vec<ValidationProble
     // indices yet still demand more *distinct* analog inputs than the board has.
     // The per-Node pass above cannot see this; this pass does.
     problems.extend(analog_oversubscription_problems(&by_id, target));
+
+    // Identifier collisions: emission derives every C++ symbol from the Node
+    // id's sanitized token, so two ids that sanitize identically would emit
+    // duplicate globals — an uncompilable Sketch. Refuse before emission.
+    problems.extend(token_collision_problems(&by_id));
+    problems
+}
+
+/// Flag every Node whose sanitized identifier token (`led-1` → `led_1`)
+/// collides with another Node's. Emission namespaces all C++ symbols by that
+/// token, so a collision means duplicate global definitions.
+fn token_collision_problems(by_id: &BTreeMap<&str, &FlowNode>) -> Vec<ValidationProblem> {
+    let mut by_token: BTreeMap<String, Vec<&FlowNode>> = BTreeMap::new();
+    for node in by_id.values() {
+        by_token.entry(node.id_token()).or_default().push(node);
+    }
+
+    let mut problems = Vec::new();
+    for (token, nodes) in by_token {
+        if nodes.len() < 2 {
+            continue;
+        }
+        let ids: Vec<&str> = nodes.iter().map(|n| n.id.as_str()).collect();
+        for node in nodes {
+            let kind = node.node_type.as_deref().unwrap_or("unknown");
+            problems.push(problem(
+                node,
+                kind,
+                format!(
+                    "Node {} ({kind}) shares the generated identifier '{token}' with {} — rename the node ids so they differ by more than punctuation",
+                    node.id,
+                    ids.iter().filter(|id| **id != node.id).copied().collect::<Vec<_>>().join(", "),
+                ),
+            ));
+        }
+    }
     problems
 }
 
@@ -440,6 +476,33 @@ mod tests {
         assert_eq!(problems.len(), 2);
         assert_eq!(problems[0].node_id, "a-mqtt");
         assert_eq!(problems[1].node_id, "z-mqtt");
+    }
+
+    /// Two Node ids that sanitize to the same C++ token are refused — the
+    /// emitted globals would collide and the Sketch would not compile.
+    #[test]
+    fn colliding_identifier_tokens_are_flagged() {
+        let uno = target_by_id("uno").unwrap();
+        let f = flow(vec![
+            node("led-1", "Led", json!({ "pin": 13 })),
+            node("led_1", "Led", json!({ "pin": 12 })),
+        ]);
+        let problems = validate(&f, &uno);
+        assert_eq!(problems.len(), 2, "both colliding Nodes are flagged");
+        for p in &problems {
+            assert!(p.message.contains("led_1"), "names the shared token: {}", p.message);
+        }
+    }
+
+    /// Distinct tokens raise no collision problem.
+    #[test]
+    fn distinct_identifier_tokens_are_not_flagged() {
+        let uno = target_by_id("uno").unwrap();
+        let f = flow(vec![
+            node("led-1", "Led", json!({ "pin": 13 })),
+            node("led-2", "Led", json!({ "pin": 12 })),
+        ]);
+        assert!(validate(&f, &uno).is_empty());
     }
 
     /// Unknown / typeless Nodes never make a Flow unrunnable.

--- a/crates/microflow-core/src/codegen/wire.rs
+++ b/crates/microflow-core/src/codegen/wire.rs
@@ -1,0 +1,385 @@
+//! Typed, handle-aware wiring model for the Sketch Generation context.
+//!
+//! The live runtime routes an event by `(source, source_handle)` and delivers
+//! it to `(target, target_handle)` (see [`crate::runtime::router`] when the
+//! `runtime` feature is on). Codegen mirrors that contract statically: every
+//! edge is resolved to a [`SourceExpr`] — the C++ expression a source Node
+//! exposes on one *specific* emit handle — and grouped per target *port*
+//! (target handle) into a [`NodeInputs`]. Emitters bind their real ports by
+//! name instead of receiving one anonymous "driver" expression, so an edge
+//! into a Led's `toggle` port generates toggle logic, not a level write.
+//!
+//! Expressions are **typed** ([`CppType`]) and consumed through coercions that
+//! mirror `ComponentValue`'s conversions (`as_bool` / `as_number` / `as_u8`),
+//! so a `String`-valued source wired into a numeric port compiles to the same
+//! fallback the runtime applies instead of producing uncompilable C++.
+//!
+//! Like everything in codegen this module is pure data + pure functions:
+//! deterministic for identical input, no clock, no IO.
+
+use std::collections::BTreeMap;
+
+/// The C++ type a wired expression evaluates to.
+///
+/// `Str` is the Arduino `String` class — it has no implicit conversion to
+/// `bool` or `double`, which is exactly why consumers must go through the
+/// typed coercions below instead of C-style casts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CppType {
+    /// A boolean expression (`bool`).
+    Bool,
+    /// A numeric expression (`double`, or an integral type that widens to it).
+    Double,
+    /// An Arduino `String` expression.
+    Str,
+}
+
+/// A typed C++ expression a source Node exposes on one emit handle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CppExpr {
+    /// The raw C++ expression (a variable name or parenthesizable expression).
+    pub code: String,
+    /// The expression's C++ type, driving the coercions below.
+    pub ty: CppType,
+}
+
+impl CppExpr {
+    /// A boolean-typed expression.
+    pub fn boolean(code: impl Into<String>) -> Self {
+        Self { code: code.into(), ty: CppType::Bool }
+    }
+
+    /// A numeric (double-compatible) expression.
+    pub fn number(code: impl Into<String>) -> Self {
+        Self { code: code.into(), ty: CppType::Double }
+    }
+
+    /// An Arduino-`String`-typed expression.
+    pub fn text(code: impl Into<String>) -> Self {
+        Self { code: code.into(), ty: CppType::Str }
+    }
+
+    /// Coerce to a C++ `bool` expression, mirroring `ComponentValue::as_bool`:
+    /// numbers are truthy when non-zero, strings when non-empty.
+    #[must_use]
+    pub fn as_bool(&self) -> String {
+        let c = &self.code;
+        match self.ty {
+            CppType::Bool => format!("({c})"),
+            CppType::Double => format!("(({c}) != 0.0)"),
+            CppType::Str => format!("(({c}).length() > 0)"),
+        }
+    }
+
+    /// Coerce to a C++ `double` expression, mirroring
+    /// `ComponentValue::as_number(..).unwrap_or(default)`: booleans map to
+    /// `1.0` / `0.0`; strings carry no number, so they yield `default` — the
+    /// same fallback the runtime applies at its dispatch sites.
+    #[must_use]
+    pub fn as_double_or(&self, default: &str) -> String {
+        let c = &self.code;
+        match self.ty {
+            CppType::Bool => format!("(({c}) ? 1.0 : 0.0)"),
+            CppType::Double => format!("((double)({c}))"),
+            CppType::Str => format!("({default})"),
+        }
+    }
+
+    /// [`Self::as_double_or`] with the runtime's usual `0.0` fallback.
+    #[must_use]
+    pub fn as_double(&self) -> String {
+        self.as_double_or("0.0")
+    }
+
+    /// Coerce to a C++ `double` expression like [`Self::as_double`], but
+    /// *parsing* string sources instead of defaulting — for the dispatch sites
+    /// (e.g. `RangeMap::map_value`) that run their own `String → number` parse
+    /// with a `0.0` fallback, which is what Arduino's `toFloat()` returns for
+    /// unparseable text.
+    #[must_use]
+    pub fn as_double_parsing(&self) -> String {
+        let c = &self.code;
+        match self.ty {
+            CppType::Str => format!("((double)(({c}).toFloat()))"),
+            _ => self.as_double(),
+        }
+    }
+
+    /// Coerce to a `uint8_t` expression, mirroring `ComponentValue::as_u8`
+    /// (clamp to `0..=255`); strings yield `default` like `as_u8().unwrap_or`.
+    #[must_use]
+    pub fn as_u8_or(&self, default: u8) -> String {
+        let c = &self.code;
+        match self.ty {
+            CppType::Bool => format!("(uint8_t)(({c}) ? 1 : 0)"),
+            CppType::Double => {
+                format!("(uint8_t)constrain((double)({c}), 0.0, 255.0)")
+            }
+            CppType::Str => format!("(uint8_t){default}"),
+        }
+    }
+
+    /// Coerce to an Arduino `String` expression (for payload formatting).
+    #[must_use]
+    pub fn as_string(&self) -> String {
+        let c = &self.code;
+        match self.ty {
+            CppType::Str => format!("({c})"),
+            CppType::Bool => format!("(({c}) ? String(\"true\") : String(\"false\"))"),
+            CppType::Double => format!("String({c})"),
+        }
+    }
+}
+
+/// How a pulse-consuming port detects that a level source "fired", mirroring
+/// when the runtime twin would have emitted on that handle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Detector {
+    /// Fire on any change of the numeric value — the shape of `value`-style
+    /// handles, which the runtime emits on every stored-value update (a
+    /// Button's `value` fires on press *and* release).
+    Change,
+    /// Fire only on the falsey→truthy transition — the shape of `true` /
+    /// `false`-style handles, which the runtime emits only when the state
+    /// enters that side.
+    RisingEdge,
+}
+
+/// What a source Node exposes on one emit handle: the value expression plus
+/// how its emissions map onto loop iterations — either an explicit *fired*
+/// expression (event-shaped handles like Delay `event`, Interval `event`,
+/// Trigger `bang`: true only on the emitting tick) or a [`Detector`] that
+/// pulse-consuming ports synthesize over the value (see [`bind_pulses`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceExpr {
+    /// The typed value expression downstream code reads.
+    pub value: CppExpr,
+    /// C++ `bool` expression, true only on the tick the source fired.
+    pub fired: Option<String>,
+    /// Synthesized-detector shape when `fired` is absent.
+    pub detector: Detector,
+}
+
+impl SourceExpr {
+    /// A level-valued source whose runtime twin emits on every value change.
+    #[must_use]
+    pub fn level(value: CppExpr) -> Self {
+        Self { value, fired: None, detector: Detector::Change }
+    }
+
+    /// A level-valued source whose runtime twin fires only when the
+    /// expression turns truthy (`true`/`false` state handles).
+    #[must_use]
+    pub fn rising(value: CppExpr) -> Self {
+        Self { value, fired: None, detector: Detector::RisingEdge }
+    }
+
+    /// An event-valued source: `fired` is true exactly on the emission tick.
+    #[must_use]
+    pub fn event(value: CppExpr, fired: impl Into<String>) -> Self {
+        Self { value, fired: Some(fired.into()), detector: Detector::Change }
+    }
+}
+
+/// Every wired input of one target Node, grouped by port (target handle) with
+/// sources in deterministic order (the builder inserts them sorted by edge).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NodeInputs {
+    by_port: BTreeMap<String, Vec<SourceExpr>>,
+}
+
+impl NodeInputs {
+    /// Append a resolved source under `port`, preserving insertion order.
+    pub fn add(&mut self, port: &str, source: SourceExpr) {
+        self.by_port.entry(port.to_string()).or_default().push(source);
+    }
+
+    /// All sources wired into `port`, in deterministic order.
+    #[must_use]
+    pub fn on(&self, port: &str) -> &[SourceExpr] {
+        self.by_port.get(port).map_or(&[], Vec::as_slice)
+    }
+
+    /// The first (deterministically ordered) source on `port`, if any.
+    #[must_use]
+    pub fn first(&self, port: &str) -> Option<&SourceExpr> {
+        self.on(port).first()
+    }
+
+    /// The wired port names, sorted. Emitters use this to surface an explicit
+    /// comment for ports they cannot generate rather than dropping them.
+    pub fn ports(&self) -> impl Iterator<Item = &str> {
+        self.by_port.keys().map(String::as_str)
+    }
+
+    /// True when nothing is wired into the Node.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_port.is_empty()
+    }
+}
+
+/// The C++ fragments a pulse binding contributes: persistent edge-tracking
+/// declarations, per-tick detector lines, and one fired-expression per source.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PulseBinding {
+    /// Module-level declarations (previous-state trackers).
+    pub declarations: Vec<String>,
+    /// Per-tick detector statements; must run before the fired expressions
+    /// are read, once per loop iteration.
+    pub loop_lines: Vec<String>,
+    /// One C++ `bool` expression per source, true only on its firing tick.
+    pub fired: Vec<String>,
+}
+
+impl PulseBinding {
+    /// A single expression that is true when *any* source fired this tick, or
+    /// `None` when the binding has no sources.
+    #[must_use]
+    pub fn any_fired(&self) -> Option<String> {
+        if self.fired.is_empty() {
+            None
+        } else {
+            Some(format!("({})", self.fired.join(" || ")))
+        }
+    }
+}
+
+/// Bind `sources` as pulses: event-shaped sources contribute their own fired
+/// expression; level sources get a synthesized detector over their value —
+/// per the source's [`Detector`], so a `value`-handle source fires on every
+/// change (both button edges, every new sample) while a `true`/`false`-handle
+/// source fires only when its expression turns truthy, exactly when the
+/// runtime twin would have emitted. A constant level never re-fires, so a
+/// sustained level counts once. `prefix` must be unique per (node, port) — it
+/// namespaces the tracker variables.
+#[must_use]
+pub fn bind_pulses(prefix: &str, sources: &[SourceExpr]) -> PulseBinding {
+    let mut binding = PulseBinding::default();
+    for (i, source) in sources.iter().enumerate() {
+        if let Some(fired) = &source.fired {
+            binding.fired.push(fired.clone());
+            continue;
+        }
+        let prev = format!("{prefix}_prev{i}");
+        let now = format!("{prefix}_now{i}");
+        let fired = format!("{prefix}_fired{i}");
+        match source.detector {
+            Detector::RisingEdge => {
+                binding.declarations.push(format!("bool {prev} = false;"));
+                binding.loop_lines.push(format!("bool {now} = {};", source.value.as_bool()));
+                binding
+                    .loop_lines
+                    .push(format!("bool {fired} = {now} && !{prev};"));
+            }
+            Detector::Change => {
+                binding.declarations.push(format!("double {prev} = 0.0;"));
+                binding
+                    .loop_lines
+                    .push(format!("double {now} = {};", source.value.as_double()));
+                binding
+                    .loop_lines
+                    .push(format!("bool {fired} = ({now} != {prev});"));
+            }
+        }
+        binding.loop_lines.push(format!("{prev} = {now};"));
+        binding.fired.push(fired);
+    }
+    binding
+}
+
+/// A visible comment for a single-source port with more than one wired source:
+/// the generated code deterministically follows the first source, and this
+/// note keeps the dropped fan-in from disappearing silently. Returns `None`
+/// when zero or one source is wired.
+#[must_use]
+pub fn extra_sources_note(port: &str, sources: &[SourceExpr]) -> Option<String> {
+    if sources.len() <= 1 {
+        return None;
+    }
+    Some(format!(
+        "// note: {} additional source(s) wired into '{port}' are ignored — generated code follows the first source only",
+        sources.len() - 1
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coercions_match_component_value_semantics() {
+        let b = CppExpr::boolean("flag");
+        let n = CppExpr::number("val");
+        let s = CppExpr::text("txt");
+
+        assert_eq!(b.as_bool(), "(flag)");
+        assert_eq!(n.as_bool(), "((val) != 0.0)");
+        assert_eq!(s.as_bool(), "((txt).length() > 0)");
+
+        assert_eq!(b.as_double(), "((flag) ? 1.0 : 0.0)");
+        assert_eq!(n.as_double(), "((double)(val))");
+        // Strings carry no number: the runtime's unwrap_or default applies.
+        assert_eq!(s.as_double_or("42.0"), "(42.0)");
+
+        // as_u8 clamps like ComponentValue::as_u8.
+        assert!(n.as_u8_or(255).contains("constrain"));
+        assert_eq!(s.as_u8_or(255), "(uint8_t)255");
+    }
+
+    #[test]
+    fn inputs_group_sources_per_port_in_order() {
+        let mut inputs = NodeInputs::default();
+        inputs.add("value", SourceExpr::level(CppExpr::number("a")));
+        inputs.add("value", SourceExpr::level(CppExpr::number("b")));
+        inputs.add("toggle", SourceExpr::level(CppExpr::boolean("c")));
+
+        assert_eq!(inputs.on("value").len(), 2);
+        assert_eq!(inputs.on("value")[0].value.code, "a");
+        assert_eq!(inputs.first("toggle").unwrap().value.code, "c");
+        assert!(inputs.on("unwired").is_empty());
+        assert_eq!(inputs.ports().collect::<Vec<_>>(), ["toggle", "value"]);
+    }
+
+    #[test]
+    fn level_sources_synthesize_a_change_detector() {
+        // A `value`-handle source fires on every change — both button edges,
+        // every new sample — mirroring the runtime's emit-on-update.
+        let sources = [SourceExpr::level(CppExpr::number("sensor_v"))];
+        let b = bind_pulses("counter_c_set", &sources);
+        assert!(b.declarations[0].starts_with("double counter_c_set_prev0"));
+        assert!(b.loop_lines.iter().any(|l| l.contains("!= counter_c_set_prev0")));
+        assert_eq!(b.fired, ["counter_c_set_fired0"]);
+    }
+
+    #[test]
+    fn rising_sources_synthesize_a_rising_edge_detector() {
+        // A `true`/`false`-handle source fires only when its expression turns
+        // truthy — the runtime emits those handles on entry to that side.
+        let sources = [SourceExpr::rising(CppExpr::boolean("btn"))];
+        let b = bind_pulses("led_l1_true", &sources);
+        assert_eq!(b.declarations, ["bool led_l1_true_prev0 = false;"]);
+        assert!(b.loop_lines.iter().any(|l| l.contains("&& !led_l1_true_prev0")));
+        assert_eq!(b.any_fired().unwrap(), "(led_l1_true_fired0)");
+    }
+
+    #[test]
+    fn pulse_binding_reuses_event_sources_fired_expression() {
+        let sources = [SourceExpr::event(CppExpr::number("delay_d_value"), "delay_d_fired")];
+        let b = bind_pulses("x", &sources);
+        assert!(b.declarations.is_empty(), "event sources need no tracker");
+        assert!(b.loop_lines.is_empty());
+        assert_eq!(b.fired, ["delay_d_fired"]);
+    }
+
+    #[test]
+    fn multiple_sources_or_together() {
+        let sources = [
+            SourceExpr::level(CppExpr::boolean("a")),
+            SourceExpr::event(CppExpr::number("b"), "b_fired"),
+        ];
+        let b = bind_pulses("p", &sources);
+        assert_eq!(b.fired.len(), 2);
+        assert_eq!(b.any_fired().unwrap(), "(p_fired0 || b_fired)");
+    }
+}

--- a/crates/microflow-core/src/config/i2c_device.rs
+++ b/crates/microflow-core/src/config/i2c_device.rs
@@ -17,6 +17,96 @@
 //! a flat list), so a device whose init needs timed steps — notably the VL53L0X,
 //! which wants ST's stateful tuning-blob + calibration sequence — is left with an
 //! empty list and documented as needing a dedicated driver.
+//!
+//! ## Config struct
+//! [`I2cDeviceConfig`] and [`OutputFormat`] live here too (ungated) so codegen
+//! can deserialize the SAME struct the runtime builds from, instead of
+//! re-parsing the node JSON field-by-field with its own duplicated defaults —
+//! which drifted (see `codegen/input/i2c_device.rs`).
+
+use serde::{Deserialize, Serialize};
+
+/// How the raw I2C reply bytes are decoded into a value. Shared by the live
+/// runtime (`runtime/input/i2c_device.rs`, folds to a `ComponentValue`) and the
+/// sketch emitter (`codegen/input/i2c_device.rs`, folds to a C++ `long`), so the
+/// byte→number decode agrees whether a flow runs live or is exported.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputFormat {
+    // The `alias`es accept the human labels older flows persisted as the field
+    // value (before the leva options-orientation fix), so a stale `"Raw bytes"`
+    // still decodes to `Raw` instead of erroring the whole config back to default.
+    #[serde(alias = "Raw bytes")]
+    Raw,
+    #[default]
+    #[serde(alias = "Unsigned int")]
+    UnsignedInt,
+    #[serde(alias = "Signed int")]
+    SignedInt,
+}
+
+/// Deserialized configuration for the generic `I2cDevice` node. Ungated (no
+/// `runtime` feature) so both the interpreter and the emitter read one struct.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+// The web sends camelCase keys (e.g. `readLength`); without this the multi-word
+// fields silently fell back to their defaults (read_length stuck at 2 — the UI
+// byte count was ignored). Single-word fields are unaffected.
+#[serde(rename_all = "camelCase")]
+pub struct I2cDeviceConfig {
+    #[serde(default = "default_address")]
+    pub address: u8,
+    #[serde(default)]
+    pub register: u8,
+    #[serde(default = "default_read_length")]
+    pub read_length: u8,
+    /// Board sampling-interval **period in milliseconds** for this device's
+    /// continuous read — NOT a frequency, despite the name older flows persist.
+    /// Reconciled to the MAX across all I2C nodes
+    /// (`Component::sampling_interval_hint`). The web still writes the key `freq`,
+    /// so the wire name is kept via `serde(rename)` for doc compatibility.
+    #[serde(rename = "freq", default = "default_sample_interval_ms")]
+    pub sample_interval_ms: u32,
+    #[serde(default = "default_device")]
+    pub device: String,
+    #[serde(default)]
+    pub output: OutputFormat,
+    /// Stream on the board's sampling interval (`true`, default) vs. read only
+    /// when the `trigger` command handle fires (`false`). When off, no continuous
+    /// read is armed — `i2c_continuous_read` returns `None` — so the bus stays
+    /// quiet until a one-shot `trigger` requests a read.
+    #[serde(default = "default_autoread")]
+    pub autoread: bool,
+}
+
+fn default_address() -> u8 {
+    0x48
+}
+fn default_read_length() -> u8 {
+    2
+}
+fn default_sample_interval_ms() -> u32 {
+    100
+}
+fn default_device() -> String {
+    "custom".to_string()
+}
+fn default_autoread() -> bool {
+    true
+}
+
+impl Default for I2cDeviceConfig {
+    fn default() -> Self {
+        Self {
+            address: default_address(),
+            register: 0,
+            read_length: default_read_length(),
+            sample_interval_ms: default_sample_interval_ms(),
+            device: default_device(),
+            output: OutputFormat::default(),
+            autoread: default_autoread(),
+        }
+    }
+}
 
 /// Normalise a device id to lowercase-alphanumeric. Older flows persisted the
 /// leva *label* ("TCS34725") rather than the preset id ("tcs34725") before the

--- a/crates/microflow-core/src/runtime/board.rs
+++ b/crates/microflow-core/src/runtime/board.rs
@@ -11,9 +11,34 @@ use crate::firmata::FirmataClient;
 use crate::runtime::error::{HardwareError, RuntimeError};
 use crate::runtime::pin_mode;
 
+/// The I2C subset of the board write surface — the six Firmata operations an
+/// I2C device driver needs: bus config, one-shot and continuous reads, writes,
+/// stop-reading, and the sampling interval that clocks continuous reads. Carved
+/// out of [`BoardWriter`] as its supertrait so an I2C driver — and a test fake —
+/// depends on just these six, not the ~14 pin/servo/tone methods it never calls.
+/// Drivers reach it via [`RuntimeContext::i2c`](crate::runtime::RuntimeContext::i2c).
+pub trait I2cBus {
+    fn i2c_config(&mut self, delay: i32) -> Result<(), RuntimeError>;
+    fn i2c_read(&mut self, address: i32, size: i32) -> Result<(), RuntimeError>;
+    fn i2c_read_continuous(
+        &mut self,
+        address: i32,
+        register: i32,
+        size: i32,
+    ) -> Result<(), RuntimeError>;
+    fn i2c_write(&mut self, address: i32, data: &[u8]) -> Result<(), RuntimeError>;
+    fn i2c_stop_reading(&mut self, address: i32) -> Result<(), RuntimeError>;
+    /// The board's global sampling interval (ms): a single Firmata setting that
+    /// clocks every continuous I2C read (and analog report), so it lives with the
+    /// I2C surface that depends on it.
+    fn sampling_interval(&mut self, interval_ms: i32) -> Result<(), RuntimeError>;
+}
+
 /// Typed Firmata write surface used by hardware component nodes. Every method
-/// encodes one (or a few) Firmata message(s); nothing blocks or does I/O.
-pub trait BoardWriter {
+/// encodes one (or a few) Firmata message(s); nothing blocks or does I/O. The
+/// I2C operations live in the [`I2cBus`] supertrait, so an I2C driver can depend
+/// on that narrower surface while everything else takes the full `BoardWriter`.
+pub trait BoardWriter: I2cBus {
     fn set_pin_mode(&mut self, pin: u8, mode: u8) -> Result<(), RuntimeError>;
     fn digital_write(&mut self, pin: u8, value: bool) -> Result<(), RuntimeError>;
     fn analog_write(&mut self, pin: u8, value: u16) -> Result<(), RuntimeError>;
@@ -26,17 +51,6 @@ pub trait BoardWriter {
     fn tone(&mut self, pin: u8, half_period_us: u32, duration_ms: u32) -> Result<(), RuntimeError>;
     fn no_tone(&mut self, pin: u8) -> Result<(), RuntimeError>;
     fn sysex(&mut self, command: u8, data: &[u8]) -> Result<(), RuntimeError>;
-    fn i2c_config(&mut self, delay: i32) -> Result<(), RuntimeError>;
-    fn i2c_read(&mut self, address: i32, size: i32) -> Result<(), RuntimeError>;
-    fn i2c_read_continuous(
-        &mut self,
-        address: i32,
-        register: i32,
-        size: i32,
-    ) -> Result<(), RuntimeError>;
-    fn i2c_write(&mut self, address: i32, data: &[u8]) -> Result<(), RuntimeError>;
-    fn i2c_stop_reading(&mut self, address: i32) -> Result<(), RuntimeError>;
-    fn sampling_interval(&mut self, interval_ms: i32) -> Result<(), RuntimeError>;
 }
 
 /// [`BoardWriter`] that encodes into a byte buffer via a borrowed
@@ -161,7 +175,9 @@ impl BoardWriter for BufferBoardWriter<'_> {
         self.out.extend_from_slice(&self.client.encode_sysex(command, data));
         Ok(())
     }
+}
 
+impl I2cBus for BufferBoardWriter<'_> {
     fn i2c_config(&mut self, delay: i32) -> Result<(), RuntimeError> {
         self.out.extend_from_slice(&self.client.encode_i2c_config(delay));
         Ok(())

--- a/crates/microflow-core/src/runtime/component.rs
+++ b/crates/microflow-core/src/runtime/component.rs
@@ -203,13 +203,11 @@ pub trait HardwareComponent: Component {
         Ok(())
     }
 
-    /// I²C-reply Hardware Callback for a registered `I2cAddress`. `value` is an
-    /// `Array` of byte values.
-    fn on_i2c_reply(
-        &mut self,
-        _value: ComponentValue,
-        _ctx: &mut RuntimeContext,
-    ) -> Result<(), RuntimeError> {
+    /// I²C-reply Hardware Callback for a registered `I2cAddress`. `bytes` are the
+    /// raw reply bytes: the runtime unmarshals the `Array` transport once at the
+    /// dispatch site ([`ComponentValue::as_byte_vec`]) so every driver decodes
+    /// straight from the slice instead of re-unwrapping `ComponentValue` itself.
+    fn on_i2c_reply(&mut self, _bytes: &[u8], _ctx: &mut RuntimeContext) -> Result<(), RuntimeError> {
         Ok(())
     }
 }

--- a/crates/microflow-core/src/runtime/context.rs
+++ b/crates/microflow-core/src/runtime/context.rs
@@ -8,7 +8,7 @@
 //! turn drains, the runtime folds everything into one [`Effects`] the host
 //! executes: write the bytes, dispatch the events to the UI, arm/cancel timers.
 
-use crate::runtime::board::BoardWriter;
+use crate::runtime::board::{BoardWriter, I2cBus};
 use crate::runtime::value::ComponentEvent;
 use serde::Serialize;
 use std::sync::Arc;
@@ -182,6 +182,14 @@ impl<'a> RuntimeContext<'a> {
     /// The sans-IO board writer. Calls encode Firmata bytes into the turn's
     /// outbound buffer; nothing crosses the wire until the host applies `Effects`.
     pub fn board(&mut self) -> &mut dyn BoardWriter {
+        self.board
+    }
+
+    /// The I2C subset of the board writer — a narrower handle than
+    /// [`board`](Self::board) for I2C device drivers, exposing only the six bus
+    /// operations ([`I2cBus`]). Upcast from the same underlying writer, so encoded
+    /// bytes still land in this turn's outbound buffer.
+    pub fn i2c(&mut self) -> &mut dyn I2cBus {
         self.board
     }
 

--- a/crates/microflow-core/src/runtime/input/i2c_device.rs
+++ b/crates/microflow-core/src/runtime/input/i2c_device.rs
@@ -14,78 +14,7 @@ use crate::runtime::{
     Component, ComponentBase, ComponentBuilder, ComponentValue, HardwareComponent,
     I2cContinuousRead, ListenerWiring, RuntimeContext, RuntimeError,
 };
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum OutputFormat {
-    // The `alias`es accept the human labels older flows persisted as the field
-    // value (before the leva options-orientation fix), so a stale `"Raw bytes"`
-    // still decodes to `Raw` instead of erroring the whole config back to default.
-    #[serde(alias = "Raw bytes")]
-    Raw,
-    #[default]
-    #[serde(alias = "Unsigned int")]
-    UnsignedInt,
-    #[serde(alias = "Signed int")]
-    SignedInt,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-// The web sends camelCase keys (e.g. `readLength`); without this the multi-word
-// fields silently fell back to their defaults (read_length stuck at 2 — the UI
-// byte count was ignored). Single-word fields are unaffected.
-#[serde(rename_all = "camelCase")]
-pub struct I2cDeviceConfig {
-    #[serde(default = "default_address")]
-    pub address: u8,
-    #[serde(default)]
-    pub register: u8,
-    #[serde(default = "default_read_length")]
-    pub read_length: u8,
-    #[serde(default = "default_freq")]
-    pub freq: u32,
-    #[serde(default = "default_device")]
-    pub device: String,
-    #[serde(default)]
-    pub output: OutputFormat,
-    /// Stream on the board's sampling interval (`true`, default) vs. read only
-    /// when the `trigger` command handle fires (`false`). When off, no continuous
-    /// read is armed — `i2c_continuous_read` returns `None` — so the bus stays
-    /// quiet until a one-shot `trigger` requests a read.
-    #[serde(default = "default_autoread")]
-    pub autoread: bool,
-}
-
-fn default_address() -> u8 {
-    0x48
-}
-fn default_read_length() -> u8 {
-    2
-}
-fn default_freq() -> u32 {
-    100
-}
-fn default_device() -> String {
-    "custom".to_string()
-}
-fn default_autoread() -> bool {
-    true
-}
-
-impl Default for I2cDeviceConfig {
-    fn default() -> Self {
-        Self {
-            address: default_address(),
-            register: 0,
-            read_length: default_read_length(),
-            freq: default_freq(),
-            device: default_device(),
-            output: OutputFormat::default(),
-            autoread: default_autoread(),
-        }
-    }
-}
+use crate::config::i2c_device::{I2cDeviceConfig, OutputFormat};
 
 pub struct I2cDevice {
     base: ComponentBase,
@@ -100,35 +29,6 @@ impl I2cDevice {
             base: ComponentBase::new(id, ComponentValue::Number(0.0)),
             config,
             initialized: false,
-        }
-    }
-
-    /// Convert raw I2C reply bytes to a `ComponentValue` based on the output format.
-    fn convert_bytes(&self, data: &[u8]) -> ComponentValue {
-        match self.config.output {
-            OutputFormat::Raw => ComponentValue::Array(
-                data.iter().map(|&b| ComponentValue::Number(f64::from(b))).collect(),
-            ),
-            OutputFormat::UnsignedInt => {
-                // Big-endian unsigned integer from up to 4 bytes
-                let mut value: u32 = 0;
-                for &byte in data.iter().take(4) {
-                    value = (value << 8) | u32::from(byte);
-                }
-                ComponentValue::Number(f64::from(value))
-            }
-            OutputFormat::SignedInt => {
-                // Big-endian signed integer (two's complement) from up to 4 bytes
-                let len = data.len().min(4);
-                if len == 0 {
-                    return ComponentValue::Number(0.0);
-                }
-                let mut value: i32 = if data[0] & 0x80 != 0 { -1 } else { 0 };
-                for &byte in data.iter().take(len) {
-                    value = (value << 8) | i32::from(byte);
-                }
-                ComponentValue::Number(f64::from(value))
-            }
         }
     }
 
@@ -159,12 +59,44 @@ impl I2cDevice {
         // hang the bus (see `effective_register`).
         let register = self.effective_register();
         if register != 0 {
-            ctx.board().i2c_write(i32::from(self.config.address), &[register])?;
+            ctx.i2c().i2c_write(i32::from(self.config.address), &[register])?;
         }
         // Request a read
-        ctx.board()
+        ctx.i2c()
             .i2c_read(i32::from(self.config.address), i32::from(self.config.read_length))?;
         Ok(())
+    }
+}
+
+/// Decode raw I2C reply bytes into a `ComponentValue` per the output format.
+/// A pure function (no `self`) so the big-endian unsigned/signed folding is
+/// unit-testable in isolation — the decode the runtime applies live, mirrored
+/// as C++ by `codegen/input/i2c_device.rs`.
+fn convert_bytes(output: OutputFormat, data: &[u8]) -> ComponentValue {
+    match output {
+        OutputFormat::Raw => ComponentValue::Array(
+            data.iter().map(|&b| ComponentValue::Number(f64::from(b))).collect(),
+        ),
+        OutputFormat::UnsignedInt => {
+            // Big-endian unsigned integer from up to 4 bytes
+            let mut value: u32 = 0;
+            for &byte in data.iter().take(4) {
+                value = (value << 8) | u32::from(byte);
+            }
+            ComponentValue::Number(f64::from(value))
+        }
+        OutputFormat::SignedInt => {
+            // Big-endian signed integer (two's complement) from up to 4 bytes
+            let len = data.len().min(4);
+            if len == 0 {
+                return ComponentValue::Number(0.0);
+            }
+            let mut value: i32 = if data[0] & 0x80 != 0 { -1 } else { 0 };
+            for &byte in data.iter().take(len) {
+                value = (value << 8) | i32::from(byte);
+            }
+            ComponentValue::Number(f64::from(value))
+        }
     }
 }
 
@@ -200,7 +132,7 @@ impl Component for I2cDevice {
     /// per-node in `initialize` instead let the last-initialized I2C node win,
     /// out-pacing a slower sensor's conversion (it read before data was ready).
     fn sampling_interval_hint(&self) -> Option<u32> {
-        Some(self.config.freq)
+        Some(self.config.sample_interval_ms)
     }
 
     /// No-hold SHT2x/HTU21 measurements NACK until the conversion completes, so
@@ -262,7 +194,7 @@ impl Component for I2cDevice {
                     }
                     _ => {}
                 }
-                ctx.board().i2c_write(i32::from(self.config.address), &data)?;
+                ctx.i2c().i2c_write(i32::from(self.config.address), &data)?;
                 self.base.emit(ComponentBase::VALUE_HANDLE);
                 Ok(())
             }
@@ -298,7 +230,7 @@ impl HardwareComponent for I2cDevice {
         // SHT2x resolution register) before the first read, so the very first
         // reply already carries live data.
         for &payload in self.device_init_writes() {
-            ctx.board().i2c_write(i32::from(self.config.address), payload)?;
+            ctx.i2c().i2c_write(i32::from(self.config.address), payload)?;
         }
 
         // The board's report-loop period (which clocks continuous I2C reads) is
@@ -317,28 +249,17 @@ impl HardwareComponent for I2cDevice {
         Ok(())
     }
 
-    fn on_i2c_reply(
-        &mut self,
-        value: ComponentValue,
-        _ctx: &mut RuntimeContext,
-    ) -> Result<(), RuntimeError> {
-        // value is an Array of byte values from the I2C-reply Hardware Callback.
-        if let ComponentValue::Array(bytes) = &value {
-            let raw: Vec<u8> = bytes
-                .iter()
-                .filter_map(|v| v.as_number().map(|n| n as u8))
-                .collect();
-
-            let converted = self.convert_bytes(&raw);
-            // `set_value` already emits "value" on change; a second explicit
-            // emit would re-fire on every poll (even when unchanged) now that
-            // the emit layer no longer value-dedupes.
-            self.base.set_value(converted);
-
-            // No re-request here: the board streams these replies on its own
-            // (continuous read armed in `initialize`), so each reply is purely a
-            // value update.
-        }
+    fn on_i2c_reply(&mut self, bytes: &[u8], _ctx: &mut RuntimeContext) -> Result<(), RuntimeError> {
+        // The runtime unmarshals the I2C-reply Hardware Callback to raw bytes
+        // once at the dispatch site (`ComponentValue::as_byte_vec`), so decode
+        // straight from the slice — no per-node re-unwrap.
+        let converted = convert_bytes(self.config.output, bytes);
+        // `set_value` already emits "value" on change; a second explicit emit
+        // would re-fire on every poll (even when unchanged) now that the emit
+        // layer no longer value-dedupes.
+        self.base.set_value(converted);
+        // No re-request here: the board streams these replies on its own
+        // (continuous read armed in `initialize`), so each reply is a value update.
         Ok(())
     }
 }
@@ -509,6 +430,56 @@ mod tests {
         assert_eq!(cfg.address, 0x29);
         assert_eq!(cfg.read_length, 8);
         assert_eq!(cfg.output, OutputFormat::Raw);
-        assert_eq!(cfg.freq, 50);
+        assert_eq!(cfg.sample_interval_ms, 50);
+    }
+
+    // --- convert_bytes: the numeric decode, now a pure fn tested in isolation ---
+
+    #[test]
+    fn convert_bytes_raw_preserves_every_byte() {
+        assert_eq!(
+            convert_bytes(OutputFormat::Raw, &[0x01, 0xFF, 0x00]),
+            ComponentValue::Array(vec![
+                ComponentValue::Number(1.0),
+                ComponentValue::Number(255.0),
+                ComponentValue::Number(0.0),
+            ]),
+        );
+    }
+
+    #[test]
+    fn convert_bytes_unsigned_is_big_endian() {
+        // 0x0102 = 258 across two bytes, MSB first.
+        assert_eq!(
+            convert_bytes(OutputFormat::UnsignedInt, &[0x01, 0x02]),
+            ComponentValue::Number(258.0),
+        );
+        // High bit set stays positive when unsigned.
+        assert_eq!(
+            convert_bytes(OutputFormat::UnsignedInt, &[0xFF, 0xFF]),
+            ComponentValue::Number(65535.0),
+        );
+    }
+
+    #[test]
+    fn convert_bytes_signed_sign_extends_from_msb() {
+        // 0xFFFF as signed 16-bit is -1; the fold sign-extends from the MSB.
+        assert_eq!(convert_bytes(OutputFormat::SignedInt, &[0xFF, 0xFF]), ComponentValue::Number(-1.0));
+        // A clear high byte stays positive.
+        assert_eq!(convert_bytes(OutputFormat::SignedInt, &[0x00, 0x2A]), ComponentValue::Number(42.0));
+    }
+
+    #[test]
+    fn convert_bytes_signed_empty_is_zero() {
+        assert_eq!(convert_bytes(OutputFormat::SignedInt, &[]), ComponentValue::Number(0.0));
+    }
+
+    #[test]
+    fn convert_bytes_folds_at_most_four_bytes() {
+        // Only the first 4 bytes fold in; trailing bytes are ignored (u32 cap).
+        assert_eq!(
+            convert_bytes(OutputFormat::UnsignedInt, &[0x01, 0x02, 0x03, 0x04, 0x05]),
+            ComponentValue::Number(f64::from(0x0102_0304_u32)),
+        );
     }
 }

--- a/crates/microflow-core/src/runtime/input/pn532.rs
+++ b/crates/microflow-core/src/runtime/input/pn532.rs
@@ -111,7 +111,7 @@ impl Pn532 {
     /// Write a command frame, then arm a tick to read its reply after a settle.
     fn send(&mut self, ctx: &mut RuntimeContext, payload: &[u8], next: St) -> Result<(), RuntimeError> {
         let frame = build_frame(payload);
-        ctx.board().i2c_write(self.address(), &frame)?;
+        ctx.i2c().i2c_write(self.address(), &frame)?;
         self.state = next;
         ctx.schedule_wakeup("_tick", SETTLE_MS);
         Ok(())
@@ -120,7 +120,7 @@ impl Pn532 {
     /// Issue a one-shot read of `len` bytes, then arm a watchdog tick: if the
     /// reply is lost, the watchdog fires in `next` and retries.
     fn read(&mut self, ctx: &mut RuntimeContext, len: i32, next: St) -> Result<(), RuntimeError> {
-        ctx.board().i2c_read(self.address(), len)?;
+        ctx.i2c().i2c_read(self.address(), len)?;
         self.state = next;
         ctx.schedule_wakeup("_tick", READ_GAP_MS);
         Ok(())
@@ -282,18 +282,10 @@ impl HardwareComponent for Pn532 {
         Ok(())
     }
 
-    fn on_i2c_reply(
-        &mut self,
-        value: ComponentValue,
-        ctx: &mut RuntimeContext,
-    ) -> Result<(), RuntimeError> {
-        if let ComponentValue::Array(bytes) = &value {
-            let raw: Vec<u8> = bytes
-                .iter()
-                .filter_map(|v| v.as_number().map(|n| n as u8))
-                .collect();
-            self.reply(&raw, ctx)?;
-        }
+    fn on_i2c_reply(&mut self, bytes: &[u8], ctx: &mut RuntimeContext) -> Result<(), RuntimeError> {
+        // The runtime already unmarshaled the reply to raw bytes at the dispatch
+        // site, so feed the frame state machine directly.
+        self.reply(bytes, ctx)?;
         Ok(())
     }
 }
@@ -545,8 +537,7 @@ mod tests {
         }
 
         fn reply(&mut self, node: &mut Pn532, bytes: &[u8]) -> Vec<u8> {
-            let arr = ComponentValue::Array(bytes.iter().map(|&b| ComponentValue::Number(f64::from(b))).collect());
-            self.turn(node, |n, ctx| n.on_i2c_reply(arr, ctx).unwrap())
+            self.turn(node, |n, ctx| n.on_i2c_reply(bytes, ctx).unwrap())
         }
 
         fn emitted_value(&self) -> Option<ComponentValue> {

--- a/crates/microflow-core/src/runtime/mod.rs
+++ b/crates/microflow-core/src/runtime/mod.rs
@@ -41,7 +41,7 @@ pub mod cloud;
 // (so shared configs can use them without the `runtime` feature); re-exported
 // here so existing `crate::runtime::serde_utils` references keep resolving.
 pub use crate::config::serde_utils;
-pub use board::{BoardWriter, BufferBoardWriter};
+pub use board::{BoardWriter, BufferBoardWriter, I2cBus};
 pub use component::{
     Component, ComponentBase, ComponentBuilder, EventSink, HardwareComponent, I2cContinuousRead,
 };
@@ -878,9 +878,15 @@ impl FlowRuntime {
                 reserved_handles::PIN_CHANGE => component
                     .as_hardware_mut()
                     .map_or(Ok(()), |hw| hw.on_pin_change(event.value.clone(), &mut ctx)),
-                reserved_handles::I2C_REPLY => component
-                    .as_hardware_mut()
-                    .map_or(Ok(()), |hw| hw.on_i2c_reply(event.value.clone(), &mut ctx)),
+                reserved_handles::I2C_REPLY => {
+                    // Unmarshal the `Array` transport to raw bytes ONCE here so
+                    // every I2C driver's `on_i2c_reply` receives a slice rather
+                    // than re-unwrapping `ComponentValue` itself (the old clone).
+                    let bytes = event.value.as_byte_vec();
+                    component
+                        .as_hardware_mut()
+                        .map_or(Ok(()), |hw| hw.on_i2c_reply(&bytes, &mut ctx))
+                }
                 other => component.dispatch_internal(&other[1..], event.value.clone(), &mut ctx),
             };
             if let Err(e) = result {

--- a/crates/microflow-core/src/runtime/value.rs
+++ b/crates/microflow-core/src/runtime/value.rs
@@ -90,6 +90,18 @@ impl ComponentValue {
     pub fn as_u8(&self) -> Option<u8> {
         self.as_number().map(|v| v.clamp(0.0, 255.0) as u8)
     }
+
+    /// Bytes of an `Array` of numbers — how the board's `I2C_REPLY` frames are
+    /// carried through the flow. Non-`Array` values and non-numeric elements are
+    /// dropped. Centralizes the `Array → Vec<u8>` unmarshal every I2C driver's
+    /// `on_i2c_reply` used to repeat verbatim.
+    #[must_use]
+    pub fn as_byte_vec(&self) -> Vec<u8> {
+        match self {
+            ComponentValue::Array(items) => items.iter().filter_map(ComponentValue::as_u8).collect(),
+            _ => Vec::new(),
+        }
+    }
 }
 
 /// Event emitted by a component.

--- a/crates/microflow-firmata-wasm/src/lib.rs
+++ b/crates/microflow-firmata-wasm/src/lib.rs
@@ -167,6 +167,18 @@ impl FirmataSession {
         self.client.encode_i2c_read(address, size)
     }
 
+    /// Start a continuous (streaming) I2C read: the board re-writes `register`
+    /// and pushes an `I2C_REPLY` every sampling interval on its own. Pairs with
+    /// [`Self::encode_sampling_interval`] (the stream rate) and
+    /// [`Self::encode_i2c_stop_reading`]. The desktop `BoardWriter` has all six
+    /// I2C encoders; this shim was missing this one and the sampling interval, so
+    /// browser-side streaming was reachable only through the core runtime.
+    #[wasm_bindgen(js_name = encodeI2cReadContinuous)]
+    #[must_use]
+    pub fn encode_i2c_read_continuous(&self, address: i32, register: i32, size: i32) -> Vec<u8> {
+        self.client.encode_i2c_read_continuous(address, register, size)
+    }
+
     #[wasm_bindgen(js_name = encodeI2cWrite)]
     #[must_use]
     pub fn encode_i2c_write(&self, address: i32, data: &[u8]) -> Vec<u8> {
@@ -177,6 +189,15 @@ impl FirmataSession {
     #[must_use]
     pub fn encode_i2c_stop_reading(&self, address: i32) -> Vec<u8> {
         self.client.encode_i2c_stop_reading(address)
+    }
+
+    /// Set the board's global sampling interval (ms) — the report-loop period
+    /// that clocks continuous I2C reads (and analog reporting). A single global
+    /// Firmata setting; the runtime reconciles it to the slowest sensor's rate.
+    #[wasm_bindgen(js_name = encodeSamplingInterval)]
+    #[must_use]
+    pub fn encode_sampling_interval(&self, interval_ms: i32) -> Vec<u8> {
+        self.client.encode_sampling_interval(interval_ms)
     }
 
     #[wasm_bindgen(js_name = encodeSysex)]

--- a/docs/adr/0013-handle-aware-sketch-wiring.md
+++ b/docs/adr/0013-handle-aware-sketch-wiring.md
@@ -1,0 +1,85 @@
+# 0013 — Sketch generation wires by handle, typed, in dataflow order
+
+Status: accepted (2026-07)
+
+## Context
+
+The live runtime routes an event by `(source, source_handle)` and dispatches it
+to `(target, target_handle)` — the Port/Emit contract of
+[ADR-0007](0007-node-wire-interface-emit-contract.md). Sketch generation
+(`crates/microflow-core/src/codegen/`) originally used a *single-driver value
+model*: every target Node received at most one anonymous C++ "driver"
+expression, chosen as the wired source with the smallest id, with both edge
+handles ignored.
+
+That model could not represent the wire contract:
+
+- Multi-port Nodes were unreachable: an edge into a Led's `toggle`, a Relay's
+  `true`/`false` (Relay has no `value` port at all), a Counter's
+  `decrement`/`reset`/`set`, or an Rgb channel generated either wrong code
+  (level write regardless of port) or nothing.
+- Multi-input Nodes collapsed: Calculate's folds and Gate's truthy-count
+  reduced to single-input passthroughs (recorded as a limitation in
+  `codegen/parity.rs`).
+- Expressions were untyped strings: a `String`-valued source (Llm response,
+  Mqtt payload) cast with `(double)(…)` produced C++ that does not compile,
+  breaking the "generated sketches always compile" invariant.
+- `loop()` bodies ran in an id-derived order, so a producer whose id sorted
+  after its consumer introduced a one-tick delay per hop — behavior depended
+  on node ids the author never sees.
+
+## Decision
+
+Codegen resolves every edge through a typed, handle-aware wiring model
+(`codegen/wire.rs`), the static twin of the runtime router:
+
+- **`CppExpr { code, ty: Bool | Double | Str }`** — every source expression is
+  typed; consumers coerce through `as_bool` / `as_double(_or)` / `as_u8_or` /
+  `as_string`, transcribing `ComponentValue`'s conversions (strings carry no
+  number and fall back to the dispatch-site default; `as_u8` clamps 0..=255).
+- **`SourceExpr`** — what a Node exposes on one emit handle:
+  `output_expression(node, handle)` in `codegen/mod.rs` mirrors each
+  component's `emits()` list. Event-shaped handles (Delay/Interval `event`,
+  Trigger `bang`) carry an explicit `fired` flag variable that is true only on
+  the emitting loop iteration; level handles carry a `Detector` — `Change` for
+  `value`-style handles (the runtime emits on every update, both button edges)
+  and `RisingEdge` for `true`/`false` state handles (emitted only on entry).
+- **`NodeInputs`** — per target, every wired source grouped by the edge's real
+  `target_handle`, in deterministic order. Emitters bind their actual ports
+  (`emit(node, &NodeInputs)`): pulse ports consume firings via
+  `bind_pulses` (the shared edge/change-detector primitive that Counter, Delay
+  and the I2C trigger previously hand-rolled), level ports sample coerced
+  values, and aggregating Nodes (Calculate, Gate — the only
+  `aggregates_inputs` components) fold over *all* sources like the runtime
+  snapshot delivery.
+- **Dataflow loop order** — `loop()` fragments are concatenated in topological
+  order (Kahn, smallest-id tie-break; nodes on a cycle append in id order), so
+  a value produced this tick is consumed this tick. Declarations/`setup()`
+  stay in id order.
+- **Nothing drops silently.** An edge codegen cannot honor — missing source
+  node, source handle with no on-device value, an unmodelled port (Figma's
+  typed-variable mutations, Pixel `color`/`set`, I2C `write`), or extra
+  sources on a single-source port — emits a `// note:` comment on the target
+  Node in the sketch. Two node ids that sanitize to the same C++ identifier
+  token are refused by validation (the emitted globals would collide), keeping
+  the never-emit-unrunnable-code gate honest. User-authored strings are
+  escaped into C++ literals (`emit::cpp_string_literal`).
+
+The interpret↔emit parity guards (`codegen/parity.rs`) now pin every
+Calculate/Gate variant to its emitted fold token and every Counter port to its
+emitted action — the "single-driver limitation" classifications are gone.
+
+## Consequences
+
+- Generated behavior matches the runtime router per handle: `button.true →
+  led.toggle` toggles on press; `compare.true → counter.reset` resets on the
+  crossing; `map.to + constant.value → calculate.value` sums both inputs.
+- A String source wired into a numeric port compiles (and reproduces the
+  runtime's fallback) instead of producing invalid C++.
+- Mqtt publish and Llm request emission is pulse-driven — one message/request
+  per source firing — instead of publishing every loop tick.
+- Sketches for flows with unmodelled wiring still generate, with the gap
+  named in the sketch text rather than silently absent.
+- Emitters take `&NodeInputs` instead of `Option<&str>`; new node emitters
+  declare their ports by binding them, and `codegen/parity.rs` +
+  `catalog_parity.rs` fail CI when the two sides drift.


### PR DESCRIPTION
## Summary

Rearchitects Arduino sketch generation ([ADR-0013](docs/adr/0013-handle-aware-sketch-wiring.md)) — replaces the single-driver value model (one anonymous C++ expression per target, both edge handles ignored, smallest-source-id wins) with the static twin of the runtime router:

- **Typed, handle-aware wiring** (`codegen/wire.rs`): every edge resolves through `output_expression(node, source_handle)` into a typed `CppExpr` (`Bool | Double | Str`) with coercions transcribing `ComponentValue` (`as_number`-style defaults, `as_u8` clamp) — a `String` source into a numeric port now compiles to the runtime's fallback instead of invalid C++. Sources are grouped per real `target_handle` into `NodeInputs`.
- **Event semantics**: Delay/Interval `event` + Trigger `bang` expose one-tick `fired` flags; `value`-style handles pulse on every change (both button edges, like the runtime's emit-on-update); `true`/`false` state handles pulse on rising edge only. The shared `bind_pulses` primitive replaces three hand-rolled edge detectors.
- **Port-complete emitters** — `emit(node, &NodeInputs)`: Led `true/false/toggle/value` (value = PWM brightness like the runtime), Relay `true/false/toggle` (it has no `value` port), Rgb per-channel + `alpha` + `off`, Servo `value/rotate/min/max/stop`, Piezo `trigger/stop`, Pixel preset tables + `reset`, Matrix shape tables + `reset/reinitialize`, Stepper relative `value` / absolute `to` / `stop/zero/enable`, Counter all four ports, Calculate n-ary folds and Gate truthy-count over **all** wired sources (runtime snapshot semantics), Mqtt/Llm publish/request once per trigger pulse (previously published every 1 ms loop tick), Figma `set`, Monitor `value`, I2C trigger gating.
- **Dataflow loop order**: `loop()` fragments concatenate in topological order (Kahn, id tie-break; cycles append deterministically) — producers feed consumers within one tick instead of id-dependent per-hop delays.
- **Nothing drops silently**: unmappable edges (missing source node, valueless source handle, unmodelled port) emit `// note:` comments in the sketch; colliding sanitized id tokens (`a-b` vs `a_b` → duplicate C++ globals) are refused by validation; user strings are escaped into C++ literals.
- **Parity guards tightened**: `codegen/parity.rs` now pins every Calculate/Gate variant and Counter port to its emitted C++ — the "single-driver limitation" classifications are gone.

Docs: ADR-0013 + `CONTEXT.md` §Sketch Wiring. New `examples/generate_sketch.rs` prints a representative 11-node sketch (verified `g++ -fsyntax-only` clean against an Arduino stub).

> **Note:** `72c8feb` is the concurrent i2c/pn532 runtime work from a parallel session sharing this worktree, committed separately so the codegen diff stays reviewable — the codegen i2c emitter builds on its shared `I2cDeviceConfig`.

## Test plan

- `cargo test --workspace --lib --tests` — 572 passed
- `cargo test -p microflow-core --all-features` — 507 passed (includes the runtime-gated parity guard)
- `cargo clippy --workspace --all-targets -- -D warnings -W clippy::pedantic` — clean
- `cargo run -p microflow-core --example generate_sketch` → g++ syntax check OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)