### PR TITLE
fix(server): allow http://tauri.localhost origin for Windows desktop app

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -25,6 +25,9 @@ const allowedOrigins = [
   ...env.CORS_ORIGINS,
   "tauri://localhost",
   "https://tauri.localhost",
+  // Tauri v2 on Windows serves the app from http://tauri.localhost by default
+  // (app.windows.useHttpsScheme is false), unlike macOS/Linux (tauri://localhost)
+  "http://tauri.localhost",
   ...(env.NODE_ENV === "development" ? ["http://localhost:3001"] : []),
 ];
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -25,6 +25,8 @@ export const auth = betterAuth({
     // Tauri app origins
     "tauri://localhost",
     "https://tauri.localhost",
+    // Tauri v2 on Windows uses http://tauri.localhost (useHttpsScheme defaults to false)
+    "http://tauri.localhost",
     ...(isDev ? ["http://localhost:3001"] : []),
   ],
   advanced: {


### PR DESCRIPTION
## Problem
Windows users of Microflow Studio (all versions, incl. v0.10.0) get **"Something went wrong (failed to fetch)"** on every server call (Edit flow, Show circuit, etc.).

## Root cause
Tauri v2 on Windows serves the webview from origin `http://tauri.localhost` (`app.windows.useHttpsScheme` defaults to `false`), while macOS/Linux use `tauri://localhost`. Both the Hono CORS allowlist and better-auth `trustedOrigins` only contained `tauri://localhost` and `https://tauri.localhost`, so every request from the Windows app was CORS-blocked.

## Fix
Add `http://tauri.localhost` to:
- `apps/server/src/index.ts` (CORS allowlist)
- `packages/auth/src/index.ts` (better-auth `trustedOrigins`)

Server-side only — existing Windows installs start working after server redeploy, no app update required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)