### PR TITLE
fix(desktop): surface board error details + enable logging in release builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,7 +2803,7 @@ dependencies = [
 
 [[package]]
 name = "microflow"
-version = "0.9.2"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "dashmap",

--- a/apps/web/src-tauri/src/lib.rs
+++ b/apps/web/src-tauri/src/lib.rs
@@ -160,20 +160,23 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_opener::init())
         .setup(move |app| {
-            if cfg!(debug_assertions) {
-                app.handle().plugin(
-                    tauri_plugin_log::Builder::default()
-                        .level(log::LevelFilter::Info)
-                        // Forward `log::` records (hardware, MQTT, LLM, …) to the
-                        // webview via the `log://log` event so the in-app Microflow
-                        // devtools shows the whole backend's activity, not just flow
-                        // events. `.target` appends — stdout/log-dir stay intact.
-                        .target(tauri_plugin_log::Target::new(
-                            tauri_plugin_log::TargetKind::Webview,
-                        ))
-                        .build(),
-                )?;
-            }
+            // Registered in every build: the default targets (stdout + OS log
+            // dir) are the only place flash/board failures can be diagnosed in
+            // production (Windows: %LOCALAPPDATA%\tech.microflow\logs, macOS:
+            // ~/Library/Logs/tech.microflow).
+            let log_builder = tauri_plugin_log::Builder::default().level(log::LevelFilter::Info);
+            let log_builder = if cfg!(debug_assertions) {
+                // Forward `log::` records (hardware, MQTT, LLM, …) to the
+                // webview via the `log://log` event so the in-app Microflow
+                // devtools shows the whole backend's activity, not just flow
+                // events. `.target` appends — stdout/log-dir stay intact.
+                log_builder.target(tauri_plugin_log::Target::new(
+                    tauri_plugin_log::TargetKind::Webview,
+                ))
+            } else {
+                log_builder
+            };
+            app.handle().plugin(log_builder.build())?;
 
             // Tauri's own Tokio runtime handle — where the MQTT/LLM tasks live,
             // so the actor's cloud-node spawns + wakeup timers share it. Cheap,

--- a/apps/web/src/components/layout/nav-microcontroller.tsx
+++ b/apps/web/src/components/layout/nav-microcontroller.tsx
@@ -9,14 +9,16 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { SidebarGroup, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "../ui/sidebar";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { isDesktop } from "@/lib/platform";
 import { cva } from "class-variance-authority";
-import { useBoardPort, useBoardState } from "@/stores/board";
+import { useBoardError, useBoardPort, useBoardState } from "@/stores/board";
 import { useWebSerialBoard } from "@/hooks/use-web-serial-board";
 import { useMemo } from "react";
 
 export function NavMicrocontroller() {
   const boardState = useBoardState();
+  const boardError = useBoardError();
   const port = useBoardPort();
   const webSerial = useWebSerialBoard();
   const desktop = isDesktop();
@@ -73,18 +75,32 @@ export function NavMicrocontroller() {
     }
   };
 
+  const button = (
+    <SidebarMenuButton
+      disabled={!interactive}
+      onClick={interactive ? onClick : undefined}
+      className={buttonVariants({ state: boardState })}
+    >
+      <Icon />
+      <span>{message}</span>
+    </SidebarMenuButton>
+  );
+
   return (
     <SidebarGroup>
       <SidebarMenu>
-        <SidebarMenuItem title={message}>
-          <SidebarMenuButton
-            disabled={!interactive}
-            onClick={interactive ? onClick : undefined}
-            className={buttonVariants({ state: boardState })}
-          >
-            <Icon />
-            <span>{message}</span>
-          </SidebarMenuButton>
+        <SidebarMenuItem title={boardError ?? message}>
+          {boardError ? (
+            // Trigger lives on a wrapper span: the button is disabled on
+            // desktop, and disabled elements don't emit the hover events the
+            // tooltip needs.
+            <Tooltip>
+              <TooltipTrigger render={<span className="block" />}>{button}</TooltipTrigger>
+              <TooltipContent side="right">{boardError}</TooltipContent>
+            </Tooltip>
+          ) : (
+            button
+          )}
         </SidebarMenuItem>
       </SidebarMenu>
     </SidebarGroup>

--- a/apps/web/src/stores/board.ts
+++ b/apps/web/src/stores/board.ts
@@ -59,6 +59,9 @@ export const useBoardPort = () =>
 
 export const useBoardState = () => useBoardStore(useShallow(({ board }) => board.state));
 
+export const useBoardError = () =>
+  useBoardStore(useShallow(({ board }) => (board.state === "error" ? board.error : null)));
+
 export const useBoard = () => useBoardStore(useShallow(({ board }) => board));
 
 export enum MODES {


### PR DESCRIPTION
## Problem
On Windows (any OS), when flashing fails the sidebar shows only the word **Error** — and release builds write **no log file at all**, because `tauri-plugin-log` was registered only under `debug_assertions`. Flash failures on user machines were undiagnosable.

## Changes
- **Release logging**: `tauri-plugin-log` now registered in every build (default stdout + OS log-dir targets). Logs land at `%LOCALAPPDATA%\tech.microflow\logs` (Windows) / `~/Library/Logs/tech.microflow` (macOS). Webview forwarding stays debug-only.
- **Error detail hover**: sidebar board status now shows the full backend error string (already sent in the `board-state` event, previously dropped) in a tooltip + native `title` fallback. Tooltip trigger lives on a wrapper span because the button is disabled on desktop and disabled elements swallow hover events.
- New `useBoardError` selector in the board store.
- Cargo.lock app-version sync (release bump workflow only touches Cargo.toml/tauri.conf.json).

## Verification
- `bunx tsc --noEmit` clean
- `cargo check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)