### PR TITLE
feat(collab): web share links, microflow:// deep link, email invites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +907,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1196,6 +1222,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -2820,11 +2855,13 @@ dependencies = [
  "serialport",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "thiserror 1.0.69",
  "tokio",
@@ -3339,6 +3376,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -4189,6 +4236,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -5158,6 +5215,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5251,6 +5329,23 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]
@@ -5505,6 +5600,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -6572,6 +6676,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -8,3 +8,8 @@ POLAR_DONATION_PRODUCT_ID=
 CORS_ORIGINS=http://localhost:3001
 NODE_ENV=development
 GITHUB_SPONSORS_TOKEN=
+RESEND_API_KEY=your-resend-api-key
+EMAIL_FROM=Microflow <noreply@microflow.tech>
+# Public web app origin, used for links in outgoing emails (share invites).
+# Falls back to the first CORS origin if unset.
+WEB_URL=http://localhost:3001

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,4 +1,7 @@
 VITE_SERVER_URL=http://localhost:3000
+# Public web app origin. Used for share links in the desktop build, where
+# window.location.origin is tauri://localhost. Leave unset for web dev.
+VITE_WEB_URL=http://localhost:3001
 TAURI_PUBLIC_KEY=REPLACE_WITH_YOUR_PUBLIC_KEY
 TAURI_SIGNING_PRIVATE_KEY=REPLACE_WITH_YOUR_PRIVATE_KEY
 TAURI_SIGNING_PRIVATE_KEY_PASSWORD=REPLACE_WITH_YOUR_KEY_PASSWORD

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,6 +35,7 @@
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-router": "^1.167.0",
     "@tauri-apps/api": "^2.10.1",
+    "@tauri-apps/plugin-deep-link": "^2",
     "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-fs": "^2",
     "@tauri-apps/plugin-opener": "^2.5.3",

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-process = "2"
 tauri-plugin-opener = "2"
+tauri-plugin-deep-link = "2"
 serialport = "4"
 tokio = { version = "1", features = ["sync", "rt", "macros", "time", "net"] }
 mqtt-endpoint-tokio = { version = "0.6", default-features = false, features = ["tls", "ws"] }
@@ -50,6 +51,11 @@ ts-rs = "10"
 # (visible under `tauri dev`). Separate pipeline from `tauri-plugin-log`.
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Single-instance (desktop only) forwards deep-link URLs to the running app on
+# Windows/Linux and focuses the existing window instead of opening a new one.
+[target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/apps/web/src-tauri/capabilities/default.json
+++ b/apps/web/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "fs:default",
     "fs:allow-write-text-file",
     "process:default",
-    "opener:default"
+    "opener:default",
+    "deep-link:default"
   ]
 }

--- a/apps/web/src-tauri/src/lib.rs
+++ b/apps/web/src-tauri/src/lib.rs
@@ -153,13 +153,37 @@ pub fn run() {
         figma_subscriptions: Arc::new(TokioMutex::new(Vec::new())),
     };
 
-    tauri::Builder::default()
+    let mut builder = tauri::Builder::default();
+
+    // Single-instance MUST be the first plugin registered. With the `deep-link`
+    // feature it forwards `microflow://` URLs to the already-running instance on
+    // Windows/Linux; we also focus the existing window.
+    #[cfg(desktop)]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            use tauri::Manager;
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.set_focus();
+            }
+        }));
+    }
+
+    builder
+        .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_opener::init())
         .setup(move |app| {
+            // Register the microflow:// scheme at runtime so deep links work in
+            // dev builds on Windows/Linux (macOS uses the bundled Info.plist).
+            #[cfg(any(windows, target_os = "linux"))]
+            {
+                use tauri_plugin_deep_link::DeepLinkExt;
+                let _ = app.deep_link().register_all();
+            }
+
             // Registered in every build: the default targets (stdout + OS log
             // dir) are the only place flash/board failures can be diagnosed in
             // production (Windows: %LOCALAPPDATA%\tech.microflow\logs, macOS:

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -26,6 +26,11 @@
     }
   },
   "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": ["microflow"]
+      }
+    },
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEM3OEQ5ODI1OTNCMDc4OUUKUldTZWVMQ1RKWmlOeDVrKzlkVlFnWDd4RHgwRCt3VHoranBMcE9zc1lLSFdwMWpaYnRUeGlvQ1oK",
       "endpoints": [

--- a/apps/web/src/components/flow/dialogs/share-flow-dialog.tsx
+++ b/apps/web/src/components/flow/dialogs/share-flow-dialog.tsx
@@ -5,6 +5,8 @@ import { toast } from "sonner";
 
 import { trpc } from "@/lib/trpc";
 import { track } from "@/lib/analytics";
+import { isDesktop } from "@/lib/platform";
+import { env } from "@microflow/env/web";
 import {
   Dialog,
   DialogContent,
@@ -37,13 +39,17 @@ export function ShareFlowDialog({ flowId, flowName, trigger }: Props) {
   const [copiedText, copy] = useCopyToClipboard()
 
   const addCollaboratorMutation = useMutation(trpc.flow.addCollaboratorByEmail.mutationOptions({
-    onSuccess: () => {
+    onSuccess: (data) => {
       queryClient.invalidateQueries({
         queryKey: trpc.flow.get.queryKey({ id: flowId }),
       });
       form.reset();
       track("flow_shared", { via: "collaborator" });
-      toast.success("Collaborator added");
+      toast.success(
+        "invited" in data && data.invited
+          ? "Invitation sent — they'll get access when they sign up"
+          : "Collaborator added",
+      );
     },
     onError: (error) => {
       toast.error(error.message);
@@ -67,9 +73,14 @@ export function ShareFlowDialog({ flowId, flowName, trigger }: Props) {
   const [open, setOpen] = useState(false);
   const queryClient = useQueryClient();
 
+  // Always share the public web link. In the desktop build
+  // window.location.origin is tauri://localhost, so prefer VITE_WEB_URL there.
+  const webOrigin =
+    (isDesktop() ? env.VITE_WEB_URL : undefined) ?? window.location.origin;
+  const shareUrl = `${webOrigin}/flow/${flowId}`;
+
   const handleCopyLink = async () => {
-    const url = `${window.location.origin}/${flowId}/flow`;
-    const copied = await copy(url);
+    const copied = await copy(shareUrl);
     if (copied) {
       track("flow_shared", { via: "link" });
       toast.success("Link copied to clipboard");
@@ -107,7 +118,7 @@ export function ShareFlowDialog({ flowId, flowName, trigger }: Props) {
 
         <div className="space-y-4">
           <InputGroup>
-            <InputGroupInput value={`${window.location.origin}/${flowId}/flow`} readOnly />
+            <InputGroupInput value={shareUrl} readOnly />
             <InputGroupAddon align="inline-end" onClick={handleCopyLink}>
               {copiedText ? <Check /> : <Copy />}
             </InputGroupAddon>

--- a/apps/web/src/components/flow/panels/dock-panel.tsx
+++ b/apps/web/src/components/flow/panels/dock-panel.tsx
@@ -117,9 +117,11 @@ export function DockPanel() {
       <DockIcon onClick={exportFlow}>
         <HardDriveUploadIcon />
       </DockIcon>
-      <DockIcon onClick={handleSettings}>
-        <SettingsIcon />
-      </DockIcon>
+      {activeFlowId !== "local" && (
+        <DockIcon onClick={handleSettings}>
+          <SettingsIcon />
+        </DockIcon>
+      )}
     </Dock>
   );
 }

--- a/apps/web/src/hooks/use-deep-link.ts
+++ b/apps/web/src/hooks/use-deep-link.ts
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { isDesktop } from "@/lib/platform";
+
+/**
+ * Handles `microflow://flow/<flowId>` deep links (from shared web links opened
+ * in the desktop app). Reads the cold-start URL and listens for runtime ones,
+ * then routes to the flow. The `/flow/$flowId` route handles auth/redirect.
+ * No-op in the browser.
+ */
+export function useDeepLink() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isDesktop()) return;
+
+    const openFlow = (urls: string[] | null) => {
+      for (const raw of urls ?? []) {
+        try {
+          const url = new URL(raw);
+          if (url.hostname !== "flow") continue;
+          const flowId = url.pathname.replace(/^\/+/, "");
+          if (!flowId) continue;
+          navigate({ to: "/flow/$flowId", params: { flowId } });
+          return;
+        } catch {
+          // ignore malformed deep-link URLs
+        }
+      }
+    };
+
+    let unlisten: (() => void) | undefined;
+    // Dynamic import: the plugin only exists in the desktop bundle.
+    import("@tauri-apps/plugin-deep-link")
+      .then(async ({ getCurrent, onOpenUrl }) => {
+        openFlow(await getCurrent());
+        unlisten = await onOpenUrl(openFlow);
+      })
+      .catch(() => {});
+
+    return () => unlisten?.();
+  }, [navigate]);
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -22,6 +22,7 @@ import { useBoardEvents } from "@/stores/board";
 import { useMqttSync } from "@/hooks/use-mqtt-sync";
 import { useLlmSync } from "@/hooks/use-llm-sync";
 import { useUpdater } from "@/hooks/use-updater";
+import { useDeepLink } from "@/hooks/use-deep-link";
 import { useFigmaUniqueId, useFigmaStore } from "@/stores/figma";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
@@ -109,6 +110,7 @@ function Board() {
   useLlmSync();
   useUpdater();
   useBackendLogs();
+  useDeepLink();
 
   // Keep the figma store's uniqueId in sync with the auth session
   const uniqueId = useFigmaUniqueId();

--- a/apps/web/src/routes/flow/$flowId.tsx
+++ b/apps/web/src/routes/flow/$flowId.tsx
@@ -22,6 +22,7 @@ import { env } from "@microflow/env/web";
 import { ErrorState } from "@/components/states/error-state";
 import { LoadingState } from "@/components/states/loading-state";
 import { isDesktop } from "@/lib/platform";
+import { toast } from "sonner";
 import type { Node } from "@xyflow/react";
 
 /**
@@ -134,6 +135,24 @@ function CloudFlowLayout() {
       useCircuitStore.getState().reset();
     };
   }, [flowId, setActiveFlowId]);
+
+  // On the web, offer to open the flow in the desktop app. Once per flow per
+  // session so it doesn't nag. The desktop build never hits this branch.
+  useEffect(() => {
+    if (isDesktop()) return;
+    const key = `open-in-app:${flowId}`;
+    if (sessionStorage.getItem(key)) return;
+    sessionStorage.setItem(key, "1");
+    toast("Open this flow in Microflow Studio?", {
+      duration: 10000,
+      action: {
+        label: "Open app",
+        onClick: () => {
+          window.location.href = `microflow://flow/${flowId}`;
+        },
+      },
+    });
+  }, [flowId]);
 
   const { data: profile } = useQuery({
     ...trpc.profile.get.queryOptions(),

--- a/bun.lock
+++ b/bun.lock
@@ -124,6 +124,7 @@
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-router": "^1.167.0",
         "@tauri-apps/api": "^2.10.1",
+        "@tauri-apps/plugin-deep-link": "^2",
         "@tauri-apps/plugin-dialog": "^2",
         "@tauri-apps/plugin-fs": "^2",
         "@tauri-apps/plugin-opener": "^2.5.3",
@@ -218,6 +219,7 @@
         "@polar-sh/sdk": "^0.46.4",
         "better-auth": "catalog:",
         "dotenv": "catalog:",
+        "drizzle-orm": "catalog:",
         "resend": "^6.9.4",
         "zod": "catalog:",
       },
@@ -1128,6 +1130,8 @@
     "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.10.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw=="],
 
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.10.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg=="],
+
+    "@tauri-apps/plugin-deep-link": ["@tauri-apps/plugin-deep-link@2.4.9", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA=="],
 
     "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.6.0", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg=="],
 

--- a/packages/api/src/routers/flow.ts
+++ b/packages/api/src/routers/flow.ts
@@ -1,11 +1,13 @@
 import { z } from "zod";
 import { eq, and, like, ne, inArray } from "drizzle-orm";
 import { db } from "@microflow/db";
-import { flow, flowCollaborator } from "@microflow/db/schema/flow";
+import { flow, flowCollaborator, flowInvite } from "@microflow/db/schema/flow";
 import { user } from "@microflow/db/schema/auth";
 import { userSettings } from "@microflow/db/schema/user-settings";
 import { protectedProcedure, router } from "../index";
 import { FlowDocument } from "@microflow/collab/server";
+import { sendEmail } from "@microflow/auth/email";
+import { env } from "@microflow/env/server";
 
 // ============================================================================
 // Constants
@@ -448,8 +450,38 @@ export const flowRouter = router({
         where: eq(user.email, input.email),
       });
 
+      const webUrl = env.WEB_URL ?? env.CORS_ORIGINS[0];
+      const inviter = ctx.session.user.name || ctx.session.user.email;
+
+      // No account yet: record a pending invite (accepted on sign-up by the
+      // better-auth user.create hook) and email them a sign-up link.
       if (!targetUser) {
-        throw new Error("User not found");
+        await db
+          .insert(flowInvite)
+          .values({
+            id: uid(),
+            flowId: input.flowId,
+            email: input.email,
+            role: input.role,
+            invitedBy: ctx.session.user.id,
+          })
+          .onConflictDoUpdate({
+            target: [flowInvite.flowId, flowInvite.email],
+            set: { role: input.role, invitedBy: ctx.session.user.id },
+          });
+
+        const signupUrl = `${webUrl}/login?redirect=${encodeURIComponent(`/flow/${input.flowId}`)}`;
+        try {
+          await sendEmail({
+            to: input.email,
+            subject: `${inviter} invited you to a flow on Microflow`,
+            html: `<p>${inviter} invited you to collaborate on "${flowRecord.name}" as a <strong>${input.role}</strong>.</p><p><a href="${signupUrl}">Sign up to open it</a> — you'll get access automatically.</p>`,
+          });
+        } catch (error) {
+          console.error("[flow.addCollaboratorByEmail] invite email failed:", error);
+        }
+
+        return { success: true, invited: true };
       }
 
       if (targetUser.id === ctx.session.user.id) {
@@ -475,6 +507,19 @@ export const flowRouter = router({
         userId: targetUser.id,
         role: input.role,
       });
+
+      // Notify the new collaborator. Don't fail the mutation if email fails —
+      // the access grant already succeeded.
+      const flowUrl = `${webUrl}/flow/${input.flowId}`;
+      try {
+        await sendEmail({
+          to: targetUser.email,
+          subject: `${inviter} shared a flow with you on Microflow`,
+          html: `<p>${inviter} added you as a <strong>${input.role}</strong> on "${flowRecord.name}".</p><p><a href="${flowUrl}">Open the flow</a></p>`,
+        });
+      } catch (error) {
+        console.error("[flow.addCollaboratorByEmail] email failed:", error);
+      }
 
       return { success: true, userId: targetUser.id };
     }),

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -17,6 +17,7 @@
     "@polar-sh/sdk": "^0.46.4",
     "better-auth": "catalog:",
     "dotenv": "catalog:",
+    "drizzle-orm": "catalog:",
     "resend": "^6.9.4",
     "zod": "catalog:"
   },

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -1,0 +1,23 @@
+import { env } from "@microflow/env/server";
+import { Resend } from "resend";
+
+const resend = new Resend(env.RESEND_API_KEY);
+
+/**
+ * Send a transactional email via Resend, using the configured EMAIL_FROM.
+ * Throws on failure so callers can surface the error.
+ */
+export async function sendEmail(opts: {
+  to: string;
+  subject: string;
+  html: string;
+}) {
+  const { error } = await resend.emails.send({
+    from: env.EMAIL_FROM,
+    ...opts,
+  });
+  if (error) {
+    console.error("[email] Failed to send:", error);
+    throw new Error("Failed to send email");
+  }
+}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,6 +1,8 @@
 import { db } from "@microflow/db";
 import * as schema from "@microflow/db/schema/auth";
+import { flowInvite, flowCollaborator } from "@microflow/db/schema/flow";
 import { env } from "@microflow/env/server";
+import { eq } from "drizzle-orm";
 import { polar, checkout, portal } from "@polar-sh/better-auth";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
@@ -29,6 +31,29 @@ export const auth = betterAuth({
     "http://tauri.localhost",
     ...(isDev ? ["http://localhost:3001"] : []),
   ],
+  databaseHooks: {
+    user: {
+      create: {
+        // When an invited email finally signs up, convert any pending flow
+        // invites into real collaborator rows so they get access on first login.
+        after: async (user) => {
+          const invites = await db.query.flowInvite.findMany({
+            where: eq(flowInvite.email, user.email),
+          });
+          if (invites.length === 0) return;
+          for (const invite of invites) {
+            await db.insert(flowCollaborator).values({
+              id: crypto.randomUUID(),
+              flowId: invite.flowId,
+              userId: user.id,
+              role: invite.role,
+            });
+          }
+          await db.delete(flowInvite).where(eq(flowInvite.email, user.email));
+        },
+      },
+    },
+  },
   advanced: {
     defaultCookieAttributes: {
       // Use 'lax' in dev for Tauri compatibility, 'none' in production

--- a/packages/db/src/migrations/0004_dark_taskmaster.sql
+++ b/packages/db/src/migrations/0004_dark_taskmaster.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "flow_invite" (
+	"id" text PRIMARY KEY NOT NULL,
+	"flow_id" text NOT NULL,
+	"email" text NOT NULL,
+	"role" text DEFAULT 'viewer' NOT NULL,
+	"invited_by" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "flow_invite" ADD CONSTRAINT "flow_invite_flow_id_flow_id_fk" FOREIGN KEY ("flow_id") REFERENCES "public"."flow"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "flow_invite" ADD CONSTRAINT "flow_invite_invited_by_user_id_fk" FOREIGN KEY ("invited_by") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "flow_invite_flowId_email_idx" ON "flow_invite" USING btree ("flow_id","email");--> statement-breakpoint
+CREATE INDEX "flow_invite_email_idx" ON "flow_invite" USING btree ("email");

--- a/packages/db/src/migrations/meta/0004_snapshot.json
+++ b/packages/db/src/migrations/meta/0004_snapshot.json
@@ -1,0 +1,755 @@
+{
+  "id": "9d26a5f6-5ebd-464a-add0-a793d00f4d0f",
+  "prevId": "f2343ee9-5230-4796-a19a-45717bb43a66",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flow": {
+      "name": "flow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#4338ca'"
+        },
+        "ydoc": {
+          "name": "ydoc",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "flow_ownerId_idx": {
+          "name": "flow_ownerId_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flow_owner_id_user_id_fk": {
+          "name": "flow_owner_id_user_id_fk",
+          "tableFrom": "flow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flow_collaborator": {
+      "name": "flow_collaborator",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "flow_collaborator_flowId_idx": {
+          "name": "flow_collaborator_flowId_idx",
+          "columns": [
+            {
+              "expression": "flow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flow_collaborator_userId_idx": {
+          "name": "flow_collaborator_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flow_collaborator_flow_id_flow_id_fk": {
+          "name": "flow_collaborator_flow_id_flow_id_fk",
+          "tableFrom": "flow_collaborator",
+          "tableTo": "flow",
+          "columnsFrom": [
+            "flow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "flow_collaborator_user_id_user_id_fk": {
+          "name": "flow_collaborator_user_id_user_id_fk",
+          "tableFrom": "flow_collaborator",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flow_invite": {
+      "name": "flow_invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "flow_invite_flowId_email_idx": {
+          "name": "flow_invite_flowId_email_idx",
+          "columns": [
+            {
+              "expression": "flow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flow_invite_email_idx": {
+          "name": "flow_invite_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flow_invite_flow_id_flow_id_fk": {
+          "name": "flow_invite_flow_id_flow_id_fk",
+          "tableFrom": "flow_invite",
+          "tableTo": "flow",
+          "columnsFrom": [
+            "flow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "flow_invite_invited_by_user_id_fk": {
+          "name": "flow_invite_invited_by_user_id_fk",
+          "tableFrom": "flow_invite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collab_color": {
+          "name": "collab_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#4338ca'"
+        },
+        "collab_icon": {
+          "name": "collab_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Cat'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1768680725951,
       "tag": "0003_icy_gateway",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1784294196928,
+      "tag": "0004_dark_taskmaster",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/flow.ts
+++ b/packages/db/src/schema/flow.ts
@@ -4,6 +4,7 @@ import {
   text,
   timestamp,
   index,
+  uniqueIndex,
   customType,
 } from "drizzle-orm/pg-core";
 import { user } from "./auth";
@@ -62,6 +63,33 @@ export const flowCollaborator = pgTable(
   (table) => [
     index("flow_collaborator_flowId_idx").on(table.flowId),
     index("flow_collaborator_userId_idx").on(table.userId),
+  ]
+);
+
+/**
+ * Pending share invitation for an email that has no Microflow account yet.
+ * Converted into a `flowCollaborator` when that email signs up (see the
+ * better-auth `user.create.after` hook in @microflow/auth).
+ */
+export const flowInvite = pgTable(
+  "flow_invite",
+  {
+    id: text("id").primaryKey(),
+    flowId: text("flow_id")
+      .notNull()
+      .references(() => flow.id, { onDelete: "cascade" }),
+    email: text("email").notNull(),
+    role: text("role", { enum: ["viewer", "editor"] })
+      .notNull()
+      .default("viewer"),
+    invitedBy: text("invited_by")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("flow_invite_flowId_email_idx").on(table.flowId, table.email),
+    index("flow_invite_email_idx").on(table.email),
   ]
 );
 

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -17,6 +17,9 @@ export const env = createEnv({
     NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
     RESEND_API_KEY: z.string().min(1),
     EMAIL_FROM: z.string().min(1),
+    // Public web app origin, used to build links in outgoing emails
+    // (e.g. flow share links). Optional; falls back to the first CORS origin.
+    WEB_URL: z.url().optional(),
   },
   runtimeEnv: process.env,
   emptyStringAsUndefined: true,

--- a/packages/env/src/web.ts
+++ b/packages/env/src/web.ts
@@ -5,6 +5,10 @@ export const env = createEnv({
   clientPrefix: "VITE_",
   client: {
     VITE_SERVER_URL: z.url(),
+    // Public web app origin, used for share links from the desktop build
+    // (where window.location.origin is tauri://localhost). Optional; falls
+    // back to window.location.origin in the browser.
+    VITE_WEB_URL: z.url().optional(),
   },
   runtimeEnv: (import.meta as any).env,
   emptyStringAsUndefined: true,


### PR DESCRIPTION
## Summary
Overhauls the collaboration / collaborators flow.

- **Local flow**: hide the settings gear (no cloud settings apply to a device-local flow).
- **Share link**: now builds the public web URL + the real `/flow/:id` route (was the reversed `/:id/flow` on `tauri://localhost`). New optional `VITE_WEB_URL`.
- **`microflow://` deep link**: `tauri-plugin-deep-link` + `tauri-plugin-single-instance` register the scheme. Opening a shared web link shows an "Open in Microflow Studio" prompt that routes the desktop app straight to the flow (auth handled by the existing route guard).
- **Email on share** (Resend): existing users are notified with a link; unknown emails get a pending `flow_invite` + a sign-up link, and are auto-granted access on account creation via a better-auth `user.create` hook. New optional `WEB_URL` (server).

## Migration
`packages/db/src/migrations/0004_dark_taskmaster.sql` adds the `flow_invite` table — run `bun run db:migrate` (or `db:push`) after merge.

## New env (both optional; `.env.example`s updated)
- `VITE_WEB_URL` — public web origin for share links from the desktop build.
- `WEB_URL` — public web origin for links in outgoing emails.

## Verification
- `tsc` clean: web, api, auth
- `cargo check` + `cargo clippy -D warnings -W clippy::pedantic` clean
- Deep-link URL parsing asserted; migration SQL inspected

Not exercised at runtime here (needs Postgres + a built desktop app + Resend): real email send, real `microflow://` open, and invite-accept-on-signup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)