### PR TITLE
fix(range-map): guard the zero-width from range instead of dividing by zero

### DIFF
--- a/crates/microflow-core/src/codegen/transformation/range_map.rs
+++ b/crates/microflow-core/src/codegen/transformation/range_map.rs
@@ -57,9 +57,16 @@ pub fn emit(node: &FlowNode, inputs: &NodeInputs) -> NodeEmission {
     }
     if let Some(source) = sources.first() {
         let input = source.value.as_double_parsing();
-        let mapped = format!(
-            "(({input} - {in_min}) * ({out_max} - {out_min}) / ({in_max} - {in_min}) + {out_min})"
-        );
+        // A zero-width `from` range (min == max) divides by zero in C++
+        // (inf/nan). The range is fixed at codegen time, so collapse it to the
+        // low output bound instead of emitting the division.
+        let mapped = if (config.from.max - config.from.min).abs() < f64::EPSILON {
+            out_min.clone()
+        } else {
+            format!(
+                "(({input} - {in_min}) * ({out_max} - {out_min}) / ({in_max} - {in_min}) + {out_min})"
+            )
+        };
         e.loop_body
             .push(format!("{var} = round(({mapped}) * {factor}) / {factor};"));
     }
@@ -105,6 +112,20 @@ mod tests {
         assert!(body.contains("1023.0"));
         assert!(body.contains("255.0"));
         assert!(body.contains("round("));
+    }
+
+    #[test]
+    fn zero_width_from_range_collapses_to_output_min_without_dividing() {
+        let e = emit(
+            &rm("r-1", json!({ "from": { "min": 5.0, "max": 5.0 }, "to": { "min": 0.0, "max": 255.0 } })),
+            &value_input(CppExpr::number("sensor_s_1_value")),
+        );
+        let body = e.loop_body.join("\n");
+        // A zero-width `from` range maps to the low output bound instead of
+        // dividing by the zero span (which would emit inf/nan C++).
+        assert!(body.contains("0.0"));
+        assert!(!body.contains("sensor_s_1_value"));
+        assert!(!body.contains("(5.0 - 5.0)"));
     }
 
     #[test]

--- a/crates/microflow-core/src/runtime/transformation/range_map.rs
+++ b/crates/microflow-core/src/runtime/transformation/range_map.rs
@@ -40,7 +40,14 @@ impl RangeMap {
         let out_min = self.config.to.min;
         let out_max = self.config.to.max;
 
-        let mapped = ((input_num - in_min) * (out_max - out_min)) / (in_max - in_min) + out_min;
+        // A zero-width `from` range (min == max) would divide by zero and
+        // produce inf/nan, which then propagates to whatever this Node drives.
+        // Collapse the degenerate range to the low output bound instead.
+        let mapped = if (in_max - in_min).abs() < f64::EPSILON {
+            out_min
+        } else {
+            ((input_num - in_min) * (out_max - out_min)) / (in_max - in_min) + out_min
+        };
         let distance = (out_max - out_min).abs();
         let precision = i32::from(distance <= 10.0);
         let factor = 10_f64.powi(precision);


### PR DESCRIPTION
### What
`RangeMap` computes `(input - from.min) * (to.max - to.min) / (from.max - from.min) + to.min` in both the runtime preview and the generated C++. A zero-width `from` range (`min == max`) divides by zero, producing `inf`/`nan` that then propagates to whatever the node drives (a servo angle, LED brightness, pixel value), silently.

### Fix
Collapse the degenerate range to the low output bound (`to.min`) in both places:
- runtime (`range_map.rs`): guard `if in_max == in_min`.
- codegen (`emit`): the `from` range is constant at codegen time, so emit `to.min` directly instead of the division.

Adds a codegen test for the zero-span case (`from` `5..5` maps to `to.min` without emitting the `(5.0 - 5.0)` division).
